### PR TITLE
Simplified error handling in verifyTemporaryPin()

### DIFF
--- a/YubiKit/YubiKit/PIV/PIVSession.swift
+++ b/YubiKit/YubiKit/PIV/PIVSession.swift
@@ -684,13 +684,7 @@ public final actor PIVSession: Session, InternalSession {
         } catch {
             guard let responseError = error as? ResponseError else { throw error }
             guard responseError.responseStatus.status != .referencedDataNotFound else { throw SessionError.notSupported }
-            let retries = retriesFrom(responseError: responseError)
-            if retries >= 0 {
-                throw SessionError.invalidPin(retries)
-            } else {
-                // Status code returned error, not number of retries
-                throw error
-            }
+            throw error
         }
     }
 }


### PR DESCRIPTION
Throw the original error since it will always be a ResponseStatus.verifyFailNoRetry (0x63c0) if the verification fails.