### PR TITLE
'Connection' wont know about 'Session'

### DIFF
--- a/YubiKit/YubiKit/Connection.swift
+++ b/YubiKit/YubiKit/Connection.swift
@@ -20,7 +20,7 @@ import Foundation
 ///
 /// Protocol implemented in ``LightningConnection``, ``NFCConnection`` and ``SmartCardConnection``.
 
-public protocol Connection: AnyObject {
+public protocol Connection: Sendable {
     
     /// Create a new Connection to the YubiKey.
     ///
@@ -64,18 +64,6 @@ public protocol Connection: AnyObject {
     /// to be handled manually.
     @discardableResult
     func send(data: Data) async throws -> Data
-}
-
-internal protocol InternalConnection {
-    func session() async -> Session?
-    func setSession(_ session: Session?) async
-}
-
-extension InternalConnection {
-    func internalSession() async -> InternalSession? {
-        let internalSession = await session()
-        return internalSession as? InternalSession
-    }
 }
 
 /// Connection Errors.

--- a/YubiKit/YubiKit/LightningConnection.swift
+++ b/YubiKit/YubiKit/LightningConnection.swift
@@ -20,18 +20,9 @@ import OSLog
 
 /// A connection to the YubiKey utilizing the Lightning port and External Accessory framework.
 @available(iOS 16.0, *)
-public final actor LightningConnection: Connection, InternalConnection {
+public final actor LightningConnection: Connection {
 
     private static let manager = LightningConnectionManager()
-
-    private weak var _session: Session?
-    func session() async -> Session? {
-        return _session
-    }
-    func setSession(_ session: Session?) async {
-        Logger.lightning.debug("\(String(describing: self).lastComponent), \(#function): \(String(describing: session))")
-        _session =  session
-    }
 
     private let commandProcessingTime = 0.002;
     private var accessoryConnection: AccessoryConnection?

--- a/YubiKit/YubiKit/Management/ManagementSession.swift
+++ b/YubiKit/YubiKit/Management/ManagementSession.swift
@@ -29,13 +29,6 @@ public enum ManagementSessionError: Error {
     case configTooLarge
 }
 
-extension ManagementSession {
-    @discardableResult
-    func send(apdu: APDU) async throws -> Data {
-        return try await connection.send(apdu: apdu)
-    }
-}
-
 /// An interface to the Management application on the YubiKey.
 ///
 /// Use the Management application to get information and configure a YubiKey.
@@ -161,6 +154,11 @@ public final actor ManagementSession: Session {
     
     deinit {
         Logger.management.debug("\(String(describing: self).lastComponent), \(#function)")
+    }
+
+    @discardableResult
+    private func send(apdu: APDU) async throws -> Data {
+        return try await connection.send(apdu: apdu)
     }
 }
 

--- a/YubiKit/YubiKit/Management/ManagementSession.swift
+++ b/YubiKit/YubiKit/Management/ManagementSession.swift
@@ -32,7 +32,6 @@ public enum ManagementSessionError: Error {
 extension ManagementSession {
     @discardableResult
     func send(apdu: APDU) async throws -> Data {
-        guard let connection else { throw SessionError.noConnection }
         return try await connection.send(apdu: apdu)
     }
 }
@@ -44,8 +43,8 @@ extension ManagementSession {
 /// [Yubico developer website](https://developers.yubico.com/yubikey-manager/Config_Reference.html).
 public final actor ManagementSession: Session {
     
-    var connection: Connection?
-    
+    let connection: Connection
+
     public nonisolated let version: Version
 
     private init(connection: Connection) async throws {
@@ -60,11 +59,6 @@ public final actor ManagementSession: Session {
         // Create a new ManagementSession
         let session = try await ManagementSession(connection: connection)
         return session
-    }
-    
-    public func end() async {
-        Logger.management.debug("\(String(describing: self).lastComponent), \(#function)")
-        connection = nil
     }
     
     nonisolated public func supports(_ feature: SessionFeature) -> Bool {

--- a/YubiKit/YubiKit/Management/ManagementSession.swift
+++ b/YubiKit/YubiKit/Management/ManagementSession.swift
@@ -29,20 +29,22 @@ public enum ManagementSessionError: Error {
     case configTooLarge
 }
 
+extension ManagementSession {
+    @discardableResult
+    func send(apdu: APDU) async throws -> Data {
+        guard let connection else { throw SessionError.noConnection }
+        return try await connection.send(apdu: apdu)
+    }
+}
+
 /// An interface to the Management application on the YubiKey.
 ///
 /// Use the Management application to get information and configure a YubiKey.
 /// Read more about the Management application on the
 /// [Yubico developer website](https://developers.yubico.com/yubikey-manager/Config_Reference.html).
-public final actor ManagementSession: Session, InternalSession {
+public final actor ManagementSession: Session {
     
-    private weak var _connection: Connection?
-    internal func connection() async -> Connection? {
-        return _connection
-    }
-    internal func setConnection(_ connection: Connection?) async {
-        _connection = connection
-    }
+    var connection: Connection?
     
     public nonisolated let version: Version
 
@@ -50,17 +52,11 @@ public final actor ManagementSession: Session, InternalSession {
         let result = try await connection.selectApplication(.management)
         guard let version = Version(withManagementResult: result) else { throw ManagementSessionError.unexpectedData }
         self.version = version
-        self._connection = connection
-        let internalConnection = await self.internalConnection()
-        await internalConnection?.setSession(self)
+        self.connection = connection
     }
     
     public static func session(withConnection connection: Connection) async throws -> ManagementSession {
         Logger.management.debug("\(String(describing: self).lastComponent), \(#function)")
-        // Close active session if there is one
-        let internalConnection = connection as? InternalConnection
-        let currentSession = await internalConnection?.session()
-        await currentSession?.end()
         // Create a new ManagementSession
         let session = try await ManagementSession(connection: connection)
         return session
@@ -68,9 +64,7 @@ public final actor ManagementSession: Session, InternalSession {
     
     public func end() async {
         Logger.management.debug("\(String(describing: self).lastComponent), \(#function)")
-        let internalConnection = await internalConnection()
-        await internalConnection?.setSession(nil)
-        await setConnection(nil)
+        connection = nil
     }
     
     nonisolated public func supports(_ feature: SessionFeature) -> Bool {
@@ -83,14 +77,13 @@ public final actor ManagementSession: Session, InternalSession {
     public func getDeviceInfo() async throws -> DeviceInfo {
         Logger.management.debug("\(String(describing: self).lastComponent), \(#function)")
         guard self.supports(ManagementFeature.deviceInfo) else { throw SessionError.notSupported }
-        guard let connection = _connection else { throw SessionError.noConnection }
         
         var page: UInt8 = 0
         var hasMoreData = true
         var result = [TKTLVTag : Data]()
         while hasMoreData {
             let apdu = APDU(cla: 0, ins: 0x1d, p1: page, p2: 0)
-            let data = try await connection.send(apdu: apdu)
+            let data = try await send(apdu: apdu)
             guard let count = data.bytes.first, count > 0 else { throw ManagementSessionError.missingData }
             guard let tlvs = TKBERTLVRecord.dictionaryOfData(from: data.subdata(in: 1..<data.count)) else { throw ManagementSessionError.unexpectedData }
             Logger.management.debug("\(String(describing: self).lastComponent), \(#function): page: \(page), data: \(data.hexEncodedString)")
@@ -115,10 +108,9 @@ public final actor ManagementSession: Session, InternalSession {
     public func updateDeviceConfig(_ config: DeviceConfig, reboot: Bool, lockCode: Data? = nil, newLockCode: Data? = nil) async throws {
         Logger.management.debug("\(String(describing: self).lastComponent), \(#function)")
         guard self.supports(ManagementFeature.deviceConfig) else { throw SessionError.notSupported }
-        guard let connection = _connection else { throw SessionError.noConnection }
         let data = try config.data(reboot: reboot, lockCode: lockCode, newLockCode: newLockCode)
         let apdu = APDU(cla: 0, ins: 0x1c, p1: 0, p2: 0, command: data)
-        try await connection.send(apdu: apdu)
+        try await send(apdu: apdu)
     }
     
     /// Check whether an application is supported over the specified transport.
@@ -169,9 +161,8 @@ public final actor ManagementSession: Session, InternalSession {
     /// >Note: This functionality requires support for ``ManagementFeature/deviceReset``, available on YubiKey 5.6 or later.
     public func deviceReset() async throws {
         guard self.supports(ManagementFeature.deviceReset) else { throw SessionError.notSupported }
-        guard let connection = _connection else { throw SessionError.noConnection }
         let apdu = APDU(cla: 0, ins: 0x1f, p1: 0, p2: 0)
-        try await connection.send(apdu: apdu)
+        try await send(apdu: apdu)
     }
     
     deinit {

--- a/YubiKit/YubiKit/NFCConnection.swift
+++ b/YubiKit/YubiKit/NFCConnection.swift
@@ -26,17 +26,9 @@ import OSLog
 ///
 /// > Note: NFC is only supported on iPhones from iPhone 6 and forward. It will not work on iPads since there's no NFC chip in these devices.
 @available(iOS 16.0, *)
-public final actor NFCConnection: Connection, InternalConnection {
+public final actor NFCConnection: Connection {
     
     private static let manager = NFCConnectionManager()
-    
-    private weak var _session: Session?
-    func session() async -> Session? {
-        return _session
-    }
-    func setSession(_ session: Session?) async {
-        _session =  session
-    }
     
     private var tagReaderSession: TagReaderSession?
     private var tag: NFCISO7816Tag? { tagReaderSession?.tag }

--- a/YubiKit/YubiKit/OATH/OATHSession.swift
+++ b/YubiKit/YubiKit/OATH/OATHSession.swift
@@ -40,13 +40,6 @@ public enum OATHSessionError: Error {
     case badCalculation
 }
 
-extension OATHSession {
-    @discardableResult
-    func send(apdu: APDU) async throws -> Data {
-        guard let connection else { throw SessionError.noConnection }
-        return try await connection.send(apdu: apdu, insSendRemaining: 0xa5)
-    }
-}
 
 /// An interface to the OATH application on the YubiKey.
 ///
@@ -395,6 +388,12 @@ public final actor OATHSession: Session {
     
     deinit {
         Logger.oath.debug("\(String(describing: self).lastComponent), \(#function)")
+    }
+
+    @discardableResult
+    private func send(apdu: APDU) async throws -> Data {
+        guard let connection else { throw SessionError.noConnection }
+        return try await connection.send(apdu: apdu, insSendRemaining: 0xa5)
     }
 }
 

--- a/YubiKit/YubiKit/OATH/OATHSession.swift
+++ b/YubiKit/YubiKit/OATH/OATHSession.swift
@@ -55,8 +55,8 @@ extension OATHSession {
 /// more about OATH on the [Yubico developer website](https://developers.yubico.com/OATH/).
 public final actor OATHSession: Session {
     
-    var connection: Connection?
-    
+    private(set) var connection: Connection?
+
     private struct SelectResponse {
         let salt: Data
         let challenge: Data?
@@ -96,11 +96,6 @@ public final actor OATHSession: Session {
         // Create a new OATHSession
         let session = try await OATHSession(connection: connection)
         return session
-    }
-    
-    public func end() async {
-        Logger.oath.debug("\(String(describing: self).lastComponent), \(#function)")
-        self.connection = nil
     }
     
     public func reset() async throws {

--- a/YubiKit/YubiKit/PIV/PIVSession.swift
+++ b/YubiKit/YubiKit/PIV/PIVSession.swift
@@ -27,13 +27,6 @@ import Gzip
 /// X.509 certificates and managing access (PIN, PUK, etc). Learn more about the PIV standard in the NIST SP 800-78
 /// [Cryptographic Algorithms and Key Sizes for PIV](https://csrc.nist.gov/publications/detail/sp/800-78/4/final) document.
 
-extension PIVSession {
-    @discardableResult
-    func send(apdu: APDU) async throws -> Data {
-        return try await connection.send(apdu: apdu)
-    }
-}
-
 public final actor PIVSession: Session {
     
     nonisolated public let version: Version
@@ -128,7 +121,7 @@ public final actor PIVSession: Session {
         Logger.piv.debug("\(String(describing: self).lastComponent), \(#function)")
         guard self.supports(PIVSessionFeature.attestation) else { throw SessionError.notSupported }
         let apdu = APDU(cla: 0, ins: insAttest, p1: slot.rawValue, p2: 0)
-        let result = try await send(apdu:  apdu)
+        let result = try await connection.send(apdu: apdu)
         guard let certificate = SecCertificateCreateWithData(nil, result as CFData) else { throw PIVSessionError.dataParseError }
         return certificate
     }
@@ -157,7 +150,7 @@ public final actor PIVSession: Session {
                                          touchPolicy != .`defaultPolicy` ? TKBERTLVRecord(tag: tagTouchpolicy, value: touchPolicy.rawValue.data) : nil].compactMap { $0 }
         let tlvContainer = TKBERTLVRecord(tag: 0xac, records: records)
         let apdu = APDU(cla: 0, ins: insGenerateAsymetric, p1: 0, p2: slot.rawValue, command: tlvContainer.data)
-        let result = try await send(apdu:  apdu)
+        let result = try await connection.send(apdu: apdu)
         guard let records = TKBERTLVRecord.sequenceOfRecords(from: result),
               let record = records.recordWithTag(0x7F49)
         else { throw PIVSessionError.invalidResponse }
@@ -219,7 +212,7 @@ public final actor PIVSession: Session {
             data.append(TKBERTLVRecord(tag: tagTouchpolicy, value: touchPolicy.rawValue.data).data)
         }
         let apdu = APDU(cla: 0, ins: insImportKey, p1: keyType.rawValue, p2: slot.rawValue, command: data, type: .extended)
-        try await send(apdu:  apdu)
+        try await connection.send(apdu: apdu)
         return keyType
     }
     
@@ -234,7 +227,7 @@ public final actor PIVSession: Session {
         guard sourceSlot != PIVSlot.attestation else { throw SessionError.illegalArgument }
         Logger.piv.debug("Move key from \(String(describing: sourceSlot)) to \(String(describing: destinationSlot)), \(#function)")
         let apdu = APDU(cla: 0, ins: insMoveKey, p1: destinationSlot.rawValue, p2: sourceSlot.rawValue)
-        try await send(apdu: apdu)
+        try await connection.send(apdu: apdu)
     }
 
     /// Delete key from slot. This method requires authentication with the management key.
@@ -244,7 +237,7 @@ public final actor PIVSession: Session {
         guard self.supports(PIVSessionFeature.moveDelete) else { throw SessionError.notSupported }
         Logger.piv.debug("Delete key in \(String(describing: slot)), \(#function)")
         let apdu = APDU(cla: 0, ins: insMoveKey, p1: 0xff, p2: slot.rawValue)
-        try await send(apdu:  apdu)
+        try await connection.send(apdu: apdu)
     }
     
     /// Writes an X.509 certificate to a slot on the YubiKey.
@@ -282,7 +275,7 @@ public final actor PIVSession: Session {
         Logger.piv.debug("\(String(describing: self).lastComponent), \(#function)")
         let command = TKBERTLVRecord(tag: tagObjectId, value: slot.objectId).data
         let apdu = APDU(cla: 0, ins: insGetData, p1: 0x3f, p2: 0xff, command: command, type: .extended)
-        let result = try await send(apdu:  apdu)
+        let result = try await connection.send(apdu: apdu)
 
         guard let records = TKBERTLVRecord.sequenceOfRecords(from: result),
               let objectData = records.recordWithTag(tagObjectData)?.value,
@@ -328,7 +321,7 @@ public final actor PIVSession: Session {
         var data = Data([type.rawValue])
         data.append(tlv.data)
         let apdu = APDU(cla: 0, ins: insSetManagementKey, p1: 0xff, p2: requiresTouch ? 0xfe : 0xff, command: data, type: .short)
-        try await send(apdu:  apdu)
+        try await connection.send(apdu: apdu)
     }
     
     /// Authenticate with the Management Key.
@@ -342,7 +335,7 @@ public final actor PIVSession: Session {
         let witness = TKBERTLVRecord(tag: tagAuthWitness, value: Data()).data
         let command = TKBERTLVRecord(tag: tagDynAuth, value: witness).data
         let witnessApdu = APDU(cla: 0, ins: insAuthenticate, p1: keyType.rawValue, p2: UInt8(tagSlotCardManagement), command: command, type: .extended)
-        let witnessResult = try await send(apdu:  witnessApdu)
+        let witnessResult = try await connection.send(apdu:  witnessApdu)
         
         guard let dynAuthRecord = TKBERTLVRecord(from: witnessResult),
               dynAuthRecord.tag == tagDynAuth,
@@ -358,8 +351,8 @@ public final actor PIVSession: Session {
         data.append(challengeRecord.data)
         let authRecord = TKBERTLVRecord(tag: tagDynAuth, value: data)
         let challengeApdu = APDU(cla: 0, ins: insAuthenticate, p1: keyType.rawValue, p2: UInt8(tagSlotCardManagement), command: authRecord.data, type: .extended)
-        let challengeResult = try await send(apdu:  challengeApdu)
-        
+        let challengeResult = try await connection.send(apdu: challengeApdu)
+
         guard let dynAuthRecord = TKBERTLVRecord(from: challengeResult),
               dynAuthRecord.tag == tagDynAuth,
               let encryptedChallengeRecord = TKBERTLVRecord(from: dynAuthRecord.value),
@@ -375,7 +368,7 @@ public final actor PIVSession: Session {
     public func getSlotMetadata(_ slot: PIVSlot) async throws -> PIVSlotMetadata {
         Logger.piv.debug("\(String(describing: self).lastComponent), \(#function)")
         guard self.supports(PIVSessionFeature.metadata) else { throw SessionError.notSupported }
-        let result = try await send(apdu:  APDU(cla: 0, ins: insGetMetadata, p1: 0, p2: slot.rawValue))
+        let result = try await connection.send(apdu: APDU(cla: 0, ins: insGetMetadata, p1: 0, p2: slot.rawValue))
         guard let records = TKBERTLVRecord.sequenceOfRecords(from: result) else { throw PIVSessionError.dataParseError }
         
         guard let rawKeyType = records.recordWithTag(tagMetadataAlgorithm)?.value.bytes[0], let keyType = PIVKeyType(rawValue: rawKeyType),
@@ -396,7 +389,7 @@ public final actor PIVSession: Session {
         Logger.piv.debug("\(String(describing: self).lastComponent), \(#function)")
         guard self.supports(PIVSessionFeature.metadata) else { throw SessionError.notSupported }
         let apdu = APDU(cla: 0, ins: insGetMetadata, p1: 0, p2: p2SlotCardmanagement)
-        let result = try await send(apdu:  apdu)
+        let result = try await connection.send(apdu: apdu)
         guard let records = TKBERTLVRecord.sequenceOfRecords(from: result),
               let isDefault = records.recordWithTag(tagMetadataIsDefault)?.value.bytes[0],
               let rawTouchPolicy = records.recordWithTag(tagMetadataPolicy)?.value.bytes[1],
@@ -419,7 +412,7 @@ public final actor PIVSession: Session {
         try await blockPin()
         try await blockPuk()
         let apdu = APDU(cla: 0, ins: insReset, p1: 0, p2: 0)
-        try await send(apdu:  apdu)
+        try await connection.send(apdu: apdu)
     }
     
     /// Get the serial number of the YubiKey.
@@ -432,7 +425,7 @@ public final actor PIVSession: Session {
         Logger.piv.debug("\(String(describing: self).lastComponent), \(#function)")
         guard self.supports(PIVSessionFeature.serialNumber) else { throw SessionError.notSupported }
         let apdu = APDU(cla: 0, ins: insGetSerial, p1: 0, p2: 0)
-        let result = try await send(apdu:  apdu)
+        let result = try await connection.send(apdu: apdu)
         return CFSwapInt32BigToHost(result.uint32)
     }
     
@@ -447,7 +440,7 @@ public final actor PIVSession: Session {
         guard let pinData = pin.paddedPinData() else { throw PIVSessionError.invalidPin }
         let apdu = APDU(cla: 0, ins: insVerify, p1: 0, p2: 0x80, command: pinData)
         do {
-            try await send(apdu:  apdu)
+            try await connection.send(apdu: apdu)
             currentPinAttempts = maxPinAttempts
             return .success(currentPinAttempts)
         } catch {
@@ -522,7 +515,7 @@ public final actor PIVSession: Session {
         } else {
             let apdu = APDU(cla: 0, ins: insVerify, p1: 0, p2: p2Pin)
             do {
-                try await send(apdu:  apdu)
+                try await connection.send(apdu: apdu)
                 // Already verified, no way to know true count
                 return currentPinAttempts
             } catch {
@@ -549,7 +542,7 @@ public final actor PIVSession: Session {
         guard let pinAttempts = UInt8(exactly: pinAttempts),
               let pukAttempts = UInt8(exactly: pukAttempts) else { throw PIVSessionError.invalidInput }
         let apdu = APDU(cla: 0, ins: insSetPinPukAttempts, p1: pinAttempts, p2: pukAttempts)
-        try await send(apdu:  apdu)
+        try await connection.send(apdu: apdu)
         maxPinAttempts = Int(pinAttempts)
         currentPinAttempts = Int(pinAttempts)
     }
@@ -584,7 +577,7 @@ public final actor PIVSession: Session {
         Logger.piv.debug("\(String(describing: self).lastComponent), \(#function)")
         do {
             let apdu = APDU(cla: 0, ins: insGetMetadata, p1: 0, p2: UInt8(tagSlotOCCAuth))
-            let data = try await send(apdu:  apdu)
+            let data = try await connection.send(apdu: apdu)
             let records = TKBERTLVRecord.sequenceOfRecords(from: data)
             guard let isConfigured = records?.recordWithTag(tagMetadataBioConfigured)?.value.integer,
                   let retries = records?.recordWithTag(tagMetadataRetries)?.value.integer,
@@ -622,7 +615,7 @@ public final actor PIVSession: Session {
                 }
             }
             let apdu = APDU(cla: 0, ins: insVerify, p1: 0, p2: UInt8(tagSlotOCCAuth), command: data)
-            let response = try await send(apdu:  apdu)
+            let response = try await connection.send(apdu: apdu)
             return requestTemporaryPin ? response : nil
         } catch {
             guard let responseError = error as? ResponseError else { throw error }
@@ -652,7 +645,7 @@ public final actor PIVSession: Session {
         do {
             let data = TKBERTLVRecord(tag: 0x01, value: pin).data
             let apdu = APDU(cla: 0, ins: insVerify, p1: 0, p2: UInt8(tagSlotOCCAuth), command: data)
-            try await send(apdu:  apdu)
+            try await connection.send(apdu: apdu)
             return
         } catch {
             guard let responseError = error as? ResponseError else { throw error }
@@ -672,7 +665,7 @@ extension PIVSession {
         recordsData.append(TKBERTLVRecord(tag: exponentiation ? tagExponentiation : tagChallenge, value: message).data)
         let command = TKBERTLVRecord(tag: tagDynAuth, value: recordsData).data
         let apdu = APDU(cla: 0, ins: insAuthenticate, p1: keyType.rawValue, p2: slot.rawValue, command: command, type: .extended)
-        let resultData = try await send(apdu:  apdu)
+        let resultData = try await connection.send(apdu: apdu)
         guard let result = TKBERTLVRecord.init(from: resultData), result.tag == tagDynAuth else { throw PIVSessionError.responseDataNotTLVFormatted }
         guard let data = TKBERTLVRecord(from: result.value), data.tag == tagAuthResponse else { throw PIVSessionError.responseDataNotTLVFormatted }
         return data.value
@@ -683,7 +676,7 @@ extension PIVSession {
         command.append(TKBERTLVRecord(tag: tagObjectId, value: objectId).data)
         command.append(TKBERTLVRecord(tag: tagObjectData, value: data).data)
         let apdu = APDU(cla: 0, ins: insPutData, p1: 0x3f, p2: 0xff, command: command, type: .extended)
-        try await send(apdu:  apdu)
+        try await connection.send(apdu: apdu)
     }
     
     private func changeReference(ins: UInt8, p2: UInt8, valueOne: String, valueTwo: String) async throws -> Int {
@@ -691,7 +684,7 @@ extension PIVSession {
         let data = paddedValueOne + paddedValueTwo
         let apdu = APDU(cla: 0, ins: ins, p1: 0, p2: p2, command: data)
         do {
-            try await send(apdu:  apdu)
+            try await connection.send(apdu: apdu)
             return currentPinAttempts
         } catch {
             guard let responseError = error as? ResponseError else { throw PIVSessionError.invalidResponse }
@@ -727,7 +720,7 @@ extension PIVSession {
     private func getPinPukMetadata(p2: UInt8) async throws -> PIVPinPukMetadata {
         guard self.supports(PIVSessionFeature.metadata) else { throw SessionError.notSupported }
         let apdu = APDU(cla: 0, ins: insGetMetadata, p1: 0, p2: p2)
-        let result = try await send(apdu:  apdu)
+        let result = try await connection.send(apdu: apdu)
         guard let records = TKBERTLVRecord.sequenceOfRecords(from: result),
               let isDefault = records.recordWithTag(tagMetadataIsDefault)?.value.bytes[0],
               let retriesTotal = records.recordWithTag(tagMetadataRetries)?.value.bytes[0],

--- a/YubiKit/YubiKit/Session.swift
+++ b/YubiKit/YubiKit/Session.swift
@@ -20,7 +20,7 @@ import Foundation
 /// of communicating with the different applications on the YubiKey.
 ///
 /// The protocol is implemented by ``OATHSession`` and ``ManagementSession``.
-public protocol Session: AnyObject {
+public protocol Session: Sendable {
     
     /// Returns a new session using the supplied connection.
     static func session(withConnection connection: Connection) async throws -> Self
@@ -31,18 +31,6 @@ public protocol Session: AnyObject {
     /// End the session. This will remove its internal connection and discard any state saved by the session.
     /// The connection to the YubiKey will be kept open.
     func end() async
-}
-
-internal protocol InternalSession {
-    func connection() async -> Connection?
-    func setConnection(_ connection: Connection?) async
-}
-
-extension InternalSession {
-    func internalConnection() async -> InternalConnection? {
-        let connection = await connection()
-        return connection as? InternalConnection
-    }
 }
 
 public protocol SessionFeature {

--- a/YubiKit/YubiKit/Session.swift
+++ b/YubiKit/YubiKit/Session.swift
@@ -27,10 +27,6 @@ public protocol Session: Sendable {
     
     /// Determine wether the Session supports the specific feature.
     func supports(_ feature: SessionFeature) -> Bool
-
-    /// End the session. This will remove its internal connection and discard any state saved by the session.
-    /// The connection to the YubiKey will be kept open.
-    func end() async
 }
 
 public protocol SessionFeature {

--- a/YubiKit/YubiKit/SmartCardConnection.swift
+++ b/YubiKit/YubiKit/SmartCardConnection.swift
@@ -19,22 +19,13 @@ import OSLog
 /// A connection to the YubiKey utilizing the USB-C port and the TKSmartCard implementation from
 /// the CryptoTokenKit framework.
 @available(iOS 16.0, macOS 13.0, *)
-public final actor SmartCardConnection: Connection, InternalConnection {
+public final actor SmartCardConnection: Connection {
     
     private static let manager = SmartCardManager()
     
     public static func connection() async throws -> Connection {
         Logger.smartCard.debug("\(String(describing: self).lastComponent), \(#function)")
         return try await manager.connection()
-    }
-    
-    private weak var _session: Session?
-    func session() async -> Session? {
-        return _session
-    }
-    func setSession(_ session: Session?) async {
-        Logger.smartCard.debug("\(String(describing: self).lastComponent), \(#function): \(String(describing: session))")
-        _session =  session
     }
 
     private var smartCard: TKSmartCard?


### PR DESCRIPTION
### Motivation

The main goal is to make `Connection` conform to `Sendable`. This isn’t the full picture yet, but it’s a step toward enabling SDK callers to use *Swift 6*.

### Consequences

1. We lose the ability for a `Session` to mark itself as dirty and prevent sending commands to the Yubikey once another `Session` takes over the `Connection`. While this was nice to have, dropping it brings us closer to how the Java and Python SDKs behave.
2. The SDK internals are now simpler.