### PR TITLE
Always the latest macOS version for the docs Gh workflow

### DIFF
--- a/.github/workflows/build-docc-pages.yml
+++ b/.github/workflows/build-docc-pages.yml
@@ -21,7 +21,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3


### PR DESCRIPTION
Obviously not the most important thing but let's just see if this fixes it

<img width="1312" alt="image" src="https://github.com/user-attachments/assets/d3ed5de8-50d3-4919-ac16-d5c232b8dcaa" />
