### PR TITLE
Ignore swiftpm's .build folder and Package.resolved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,15 @@
-xcuserdata/
+# macOS
 .DS_Store
+
+# Xcode
+xcuserdata/
+
+# SwiftPM
 /.swiftpm
+.build/
+Package.resolved
+
+# Backup & temp files
 *~
 \#*\#
 .\#*


### PR DESCRIPTION
Let's get rid of that pesky `Package.resolved` please. Otherwise I have to kill Xcode each time I'm want to do a `git add .`