### PR TITLE
Preparation for Swift 6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.10
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/YubiKit/YubiKit/APDU.swift
+++ b/YubiKit/YubiKit/APDU.swift
@@ -15,9 +15,9 @@
 import Foundation
 
 /// Data model for encapsulating an APDU command, as defined by the ISO/IEC 7816-4 standard.
-public struct APDU: CustomStringConvertible {
+public struct APDU: Sendable, CustomStringConvertible {
 
-    public enum ApduType {
+    public enum ApduType: Sendable {
         case short
         case extended
     }

--- a/YubiKit/YubiKit/OATH/OATHSession+Extensions.swift
+++ b/YubiKit/YubiKit/OATH/OATHSession+Extensions.swift
@@ -15,8 +15,8 @@
 import Foundation
 import CommonCrypto
 
-private var hotpCode: UInt8 = 0x10
-private var totpCode: UInt8 = 0x20
+private let hotpCode: UInt8 = 0x10
+private let totpCode: UInt8 = 0x20
 
 extension OATHSession {
     
@@ -24,7 +24,7 @@ extension OATHSession {
         case missingScheme, missingName, missingSecret, parseType, parseAlgorithm
     }
     
-    public enum CredentialType: CustomStringConvertible {
+    public enum CredentialType: CustomStringConvertible, Sendable {
         
         case HOTP(counter: UInt32 = 0)
         case TOTP(period: TimeInterval = 30)
@@ -74,14 +74,14 @@ extension OATHSession {
         }
     }
     
-    public enum HashAlgorithm: UInt8 {
+    public enum HashAlgorithm: UInt8, Sendable {
         case SHA1   = 0x01
         case SHA256 = 0x02
         case SHA512 = 0x03
     }
     
     /// A reference to an OATH Credential stored on a YubiKey.
-    public struct Credential: Identifiable, CustomStringConvertible {
+    public struct Credential: Sendable, Identifiable, CustomStringConvertible {
 
         /// Device ID of the YubiKey.
         public let deviceId: String
@@ -170,8 +170,8 @@ extension OATHSession {
     }
 
     /// A one-time OATH code, calculated from a ``Credential`` stored in a YubiKey.
-    public struct Code: Identifiable, CustomStringConvertible {
-        
+    public struct Code: Identifiable, CustomStringConvertible, Sendable {
+
         public var description: String {
             let dateFormatter = DateFormatter()
             dateFormatter.dateFormat = "HH:mm:ss"

--- a/YubiKit/YubiKit/Response.swift
+++ b/YubiKit/YubiKit/Response.swift
@@ -41,8 +41,8 @@ public struct Response: CustomStringConvertible {
     }
 }
 
-public struct ResponseStatus: Equatable {
-    public enum StatusCode: UInt16, CustomStringConvertible {
+public struct ResponseStatus: Equatable, Sendable {
+    public enum StatusCode: UInt16, CustomStringConvertible, Sendable {
         case ok = 0x9000
         case noInputData = 0x6285
         case verifyFailNoRetry = 0x63C0

--- a/YubiKit/YubiKit/SCP/PublicKeyValues.swift
+++ b/YubiKit/YubiKit/SCP/PublicKeyValues.swift
@@ -20,7 +20,7 @@ struct PublicKeyValues {
         case invalidKeyRepresentation(String?)
         case unsupportedKeyType
 
-        static var invalidKeyRepresentation = Error.invalidKeyRepresentation(nil)
+        static let invalidKeyRepresentation = Error.invalidKeyRepresentation(nil)
     }
 
     let curve: ECKeyCurve

--- a/YubiKit/YubiKit/SCP/SCP03KeyParams.swift
+++ b/YubiKit/YubiKit/SCP/SCP03KeyParams.swift
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 public struct SCP03KeyParams: SCPKeyParams {
-    public var keyRef: SCPKeyRef
-    public var staticKeys: StaticKeys
-    
+    public let keyRef: SCPKeyRef
+    public let staticKeys: StaticKeys
+
     public init(keyRef: SCPKeyRef, staticKeys: StaticKeys) throws(SCPError) {
         if 0xFF & keyRef.kid > 3 {
             throw .illegalArgument("Invalid KID for SCP03")

--- a/YubiKit/YubiKit/SCP/SCPKeyParams.swift
+++ b/YubiKit/YubiKit/SCP/SCPKeyParams.swift
@@ -12,6 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public protocol SCPKeyParams {
+public protocol SCPKeyParams: Sendable {
     var keyRef: SCPKeyRef { get }
 }

--- a/YubiKit/YubiKit/SCP/SCPKeyRef.swift
+++ b/YubiKit/YubiKit/SCP/SCPKeyRef.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-public struct SCPKeyRef: Equatable, Hashable {
+public struct SCPKeyRef: Equatable, Hashable, Sendable {
 
     public typealias Kid = UInt8
 

--- a/YubiKit/YubiKit/SCP/SCPProcessor.swift
+++ b/YubiKit/YubiKit/SCP/SCPProcessor.swift
@@ -18,7 +18,7 @@ fileprivate let insInitializeUpdate: UInt8 = 0x50
 
 typealias SCPKid  = SCPKeyRef.Kid
 
-internal class SCPProcessor: HasSCPLogger {
+internal actor SCPProcessor: HasSCPLogger {
 
     internal var state: SCPState
 

--- a/YubiKit/YubiKit/SCP/SecurityDomainSession.swift
+++ b/YubiKit/YubiKit/SCP/SecurityDomainSession.swift
@@ -403,7 +403,7 @@ public final actor SecurityDomainSession: Session, HasSecurityDomainLogger {
         for key in [keys.enc, keys.mac, dek] {
             let kcv = try defaultKcvIv.cbcEncrypt(key: key).prefix(3)
 
-            let currentDek = processor.state.sessionKeys.dek!
+            let currentDek = await processor.state.sessionKeys.dek!
 
             let encryptedKey = try key.cbcEncrypt(key: currentDek)
             data.append(TKBERTLVRecord(tag: 0x88, value: encryptedKey).data)
@@ -498,7 +498,7 @@ public final actor SecurityDomainSession: Session, HasSecurityDomainLogger {
             precondition(rawSecret.count == 32)
         } catch { throw .wrapped(error) }
 
-        let currentDek = processor.state.sessionKeys.dek!
+        let currentDek = await processor.state.sessionKeys.dek!
         let encryptedSecret = try rawSecret.cbcEncrypt(key: currentDek)
         precondition(encryptedSecret.count == 32)
 

--- a/YubiKit/YubiKit/SCP/StaticKeys.swift
+++ b/YubiKit/YubiKit/SCP/StaticKeys.swift
@@ -15,7 +15,7 @@
 import Foundation
 import CryptoKit
 
-public struct StaticKeys {
+public struct StaticKeys: Sendable {
     
     private static let defaultKey: Data = Data([0x40, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47,
                                                 0x48, 0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x4e, 0x4f])

--- a/YubiKit/YubiKit/Version.swift
+++ b/YubiKit/YubiKit/Version.swift
@@ -15,7 +15,7 @@
 import Foundation
 
 /// The firmware version of the YubiKey.
-public struct Version: Comparable, CustomStringConvertible {
+public struct Version: Sendable, Comparable, CustomStringConvertible {
     
     public let major: UInt8
     public let minor: UInt8


### PR DESCRIPTION
### Motivation
A few loose changes in preparation to Swift 6. Also the bump the Swift version of the package to `5.10`, the last Swift 5 version.


### Changes
- Mostly value types marked as `Sendable`
- vars that never mutated being marked as `let`
-  Making `SCPProcessor` an actor

