### PR TITLE
Fix DocC deploy workflow

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,6 +1,7 @@
 name: Build and Test
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: ["main"]
 

--- a/.github/workflows/docc_deploy.yml
+++ b/.github/workflows/docc_deploy.yml
@@ -41,10 +41,10 @@ jobs:
           HTML
 
       - name: Deploy to GitHub Pages
-        uses: rossjrw/pr-preview-action@v1
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          source-dir: ${{ env.DOCS_PATH }}
-          preview-branch: ${{ env.PAGES_BRANCH }}
-          umbrella-dir: .
+          folder: ${{ env.DOCS_PATH }}
+          branch: ${{ env.PAGES_BRANCH }}
+          clean-exclude: pr-*
+          force: false
           token: ${{ secrets.GITHUB_TOKEN }}
-          action: deploy

--- a/.github/workflows/docc_deploy.yml
+++ b/.github/workflows/docc_deploy.yml
@@ -1,6 +1,7 @@
 name: Deploy DocC
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
 

--- a/.github/workflows/docc_preview.yml
+++ b/.github/workflows/docc_preview.yml
@@ -1,6 +1,7 @@
 name: DocC Preview per Pull Request
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [main]
     types: [opened, reopened, synchronize, closed]


### PR DESCRIPTION
I had misunderstood a few things about `rossjrw/pr-preview-action`. It mirrors the deploy action `JamesIves/github-pages-deploy-action` but for previews. So the correct way it to use `JamesIves/github-pages-deploy-action` for the real deploy.

Both https://yubico.github.io/yubikit-swift and https://yubico.github.io/yubikit-swift/pr-26 work now.

I also added manual trigger to the workflows so we can do it from the GH UI: https://github.com/Yubico/yubikit-swift/pull/26/commits/545be72c0c2813c853b8d29f5b3f3676ad6f0f96 (only works once it hits the default branch - `main`)