### PR TITLE
Refactored LightningConnection with better concurrency guarantees

### DIFF
--- a/YubiKit/YubiKit/LightningConnection.swift
+++ b/YubiKit/YubiKit/LightningConnection.swift
@@ -15,79 +15,314 @@
 #if os(iOS)
 
 import Foundation
-import ExternalAccessory
+@preconcurrency import ExternalAccessory
 import OSLog
 
 /// A connection to the YubiKey utilizing the Lightning port and External Accessory framework.
 @available(iOS 16.0, *)
-public final actor LightningConnection: Connection {
-
-    private static let manager = LightningConnectionManager()
-
-    private let commandProcessingTime = 0.002
-    private var accessoryConnection: AccessoryConnection?
-    private var closingContinuations = [CheckedContinuation<Error?, Never>]()
-    private var closingHandler: (() -> Void)?
-
-    private init() {}
-
-    fileprivate init(connection: AccessoryConnection, closingHandler handler: @escaping () -> Void) {
-        self.accessoryConnection = connection
-        self.closingHandler = handler
-        Logger.lightning.debug("\(String(describing: self).lastComponent), \(#function)")
-    }
+public struct LightningConnection: Connection, Sendable {
+    let accessoryConnectionID: Int
 
     // Starts lightning and wait for a connection
     public static func connection() async throws -> Connection {
-        Logger.lightning.debug("\(String(describing: self).lastComponent), \(#function)")
-        return try await manager.connection()
+        trace(message: "requesting new connection")
+        return try await LightningConnectionManager.shared.connect()
     }
 
     public func close(error: Error?) async {
-        Logger.lightning.debug("\(String(describing: self).lastComponent), \(#function)")
-        closingHandler?()
-        closingContinuations.forEach { continuation in
-            continuation.resume(returning: error)
-        }
-        closingContinuations.removeAll()
-        accessoryConnection = nil
-    }
-
-    fileprivate func closedByManager(error: Error?) {
-        Logger.lightning.debug("\(String(describing: self).lastComponent), \(#function)")
-        closingContinuations.forEach { continuation in
-            continuation.resume(returning: error)
-        }
-        closingContinuations.removeAll()
-        accessoryConnection = nil
+        trace(message: "closing connection")
+        await LightningConnectionManager.shared.close(for: self, error: error)
     }
 
     public func connectionDidClose() async -> Error? {
-        if accessoryConnection == nil {
-            return nil
+        trace(message: "awaiting dismissal")
+        let error = await LightningConnectionManager.shared.didClose(for: self)
+        if let error {
+            trace(message: "dismissed, error: \(String(describing: error))")
+        } else {
+            trace(message: "dismissed")
         }
-        return await withCheckedContinuation { continuation in
-            closingContinuations.append(continuation)
-        }
+        return error
     }
 
     public func send(data: Data) async throws -> Data {
-        guard let accessoryConnection, let outputStream = accessoryConnection.session.outputStream,
-            let inputStream = accessoryConnection.session.inputStream
+        trace(message: "\(data.count) bytes")
+        let response = try await LightningConnectionManager.shared.transmit(request: data, for: self)
+        trace(message: "received \(response.count) bytes")
+        return response
+    }
+}
+
+// MARK: - Internal helpers / extensions
+
+// Downcast helper
+extension Connection {
+    public var lightningConnection: LightningConnection? {
+        self as? LightningConnection
+    }
+}
+
+extension LightningConnection: HasLightningLogger {}
+extension LightningConnectionManager: HasLightningLogger {}
+extension EAAccessoryWrapper: HasLightningLogger {}
+
+// MARK: - Private helpers / extensions
+
+private actor LightningConnectionManager {
+
+    static let shared = LightningConnectionManager()
+
+    private var connectionTask: Task<LightningConnection, Error>?
+    private var pendingConnectionPromise: Promise<LightningConnection>?
+    private var connectionState: (connectionID: ConnectionID, didCloseConnection: (Promise<Error?>))?
+
+    private init() {}
+
+    func connect() async throws -> LightningConnection {
+        // If a connection task is already running, await its result
+        if let connectionTask {
+            trace(message: "awaiting existing connection task")
+            _ = try await connectionTask.value
+            // we cancel this task because only one of multiple
+            // concurrent connections can succed
+            throw ConnectionError.cancelled
+        }
+
+        // Otherwise, create and store a new connection task.
+        let task = Task { () -> LightningConnection in
+            // When the task finishes (on any path), clear it to allow a new connection.
+            defer { self.connectionTask = nil }
+
+            trace(message: "begin new connection task")
+
+            do {
+                // Close previous connection if it exists
+                if let connection = connectionState {
+                    await connection.didCloseConnection.fulfill(nil)
+                    self.connectionState = nil
+                }
+
+                // Create a promise to bridge the callback from EAAccessoryWrapper
+                let connectionPromise: Promise<LightningConnection> = .init()
+                self.pendingConnectionPromise = connectionPromise
+
+                // Connect to YubiKeys that are already plugged in
+                await EAAccessoryWrapper.shared.connectToCurrentDevices()
+
+                // Start monitoring for new accessories
+                await EAAccessoryWrapper.shared.startMonitoring()
+
+                // Await the promise which will be fulfilled by accessoryDidConnect()
+                let result = try await connectionPromise.value()
+                trace(message: "connection established")
+                self.pendingConnectionPromise = nil
+                return result
+            } catch {
+                trace(message: "connection failed: \(error.localizedDescription)")
+                // Cleanup on failure
+                self.pendingConnectionPromise = nil
+                await EAAccessoryWrapper.shared.stopMonitoring()
+                throw error
+            }
+        }
+
+        self.connectionTask = task
+        return try await task.value
+    }
+
+    func transmit(request: Data, for connection: LightningConnection) async throws -> Data {
+        let connectionID = connection.accessoryConnectionID
+        trace(message: "\(request.count) bytes to connection \(connectionID)")
+
+        guard let state = connectionState,
+            state.connectionID == connectionID
+        else {
+            trace(message: "noConnection")
+            throw ConnectionError.noConnection
+        }
+
+        return try await EAAccessoryWrapper.shared.transmit(id: connectionID, data: request)
+    }
+
+    func close(for connection: LightningConnection, error: Error?) async {
+        guard let state = connectionState,
+            state.connectionID == connection.accessoryConnectionID
+        else { return }
+
+        await EAAccessoryWrapper.shared.stopMonitoring()
+        await EAAccessoryWrapper.shared.cleanupConnection(id: state.connectionID)
+        await state.didCloseConnection.fulfill(error)
+        connectionState = nil
+    }
+
+    func didClose(for connection: LightningConnection) async -> Error? {
+        guard let state = connectionState,
+            state.connectionID == connection.accessoryConnectionID
+        else { return nil }
+
+        return try? await state.didCloseConnection.value()
+    }
+
+    // Called by EAAccessoryWrapper when an accessory connects
+    func accessoryDidConnect(connectionID: Int) async {
+        trace(message: "accessory connected with ID \(connectionID)")
+        guard let promise = pendingConnectionPromise else { return }
+
+        connectionState = (connectionID: connectionID, didCloseConnection: Promise<Error?>())
+        let connection = LightningConnection(accessoryConnectionID: connectionID)
+        await promise.fulfill(connection)
+    }
+
+    // Called by EAAccessoryWrapper when an accessory disconnects
+    func accessoryDidDisconnect(connectionID: Int) async {
+        trace(message: "accessory disconnected with ID \(connectionID)")
+
+        // If a connection attempt is in progress, fail it.
+        if let promise = pendingConnectionPromise {
+            await promise.cancel(with: ConnectionError.noConnection)
+            self.pendingConnectionPromise = nil
+        }
+
+        guard let state = connectionState,
+            state.connectionID == connectionID
+        else { return }
+
+        await state.didCloseConnection.fulfill(nil)
+        connectionState = nil
+    }
+}
+
+private actor EAAccessoryWrapper: NSObject, StreamDelegate {
+
+    static let shared = EAAccessoryWrapper()
+    private override init() {}
+
+    private let manager = EAAccessoryManager.shared()
+    private var sessions: [ConnectionID: EASession] = [:]
+    private var connectObserver: NSObjectProtocol?
+    private var disconnectObserver: NSObjectProtocol?
+
+    func setupConnection(id: ConnectionID, session: EASession) async {
+        trace(message: "opening session for ID \(id)")
+        session.open()
+        // Give streams time to stabilize
+        try? await Task.sleep(for: .milliseconds(100))
+        session.outputStream?.delegate = self
+        session.inputStream?.delegate = self
+
+        sessions[id] = session
+    }
+
+    func cleanupConnection(id: ConnectionID) {
+        trace(message: "closing session for ID \(id)")
+        guard let session = sessions[id] else { return }
+
+        session.close()
+        session.outputStream?.delegate = nil
+        session.inputStream?.delegate = nil
+
+        sessions[id] = nil
+    }
+
+    func getConnectedYubiKeys() -> [EAAccessory] {
+        manager.connectedAccessories.filter { $0.isYubiKey }
+    }
+
+    func connectToCurrentDevices() async {
+        // Check for already-connected YubiKeys
+        let connectedYubiKeys = getConnectedYubiKeys()
+        if let connectedKey = connectedYubiKeys.first {
+
+            let connectionID = connectedKey.connectionID
+
+            // Check if we already have a session for this accessory
+            if let _ = sessions[connectionID] {
+                // Reuse existing session
+                await LightningConnectionManager.shared.accessoryDidConnect(connectionID: connectionID)
+            } else if let session = EASession(accessory: connectedKey, forProtocol: "com.yubico.ylp") {
+                // Create new session for this accessory
+                await setupConnection(id: connectionID, session: session)
+                await LightningConnectionManager.shared.accessoryDidConnect(connectionID: connectionID)
+            }
+        }
+    }
+
+    func startMonitoring() {
+        trace(message: "begin monitoring")
+        // Prevent duplicate observers
+        guard connectObserver == nil && disconnectObserver == nil else { return }
+
+        connectObserver = NotificationCenter.default.addObserver(
+            forName: .EAAccessoryDidConnect,
+            object: manager,
+            queue: nil
+        ) { notification in
+            guard let accessory = notification.userInfo?[EAAccessoryKey] as? EAAccessory,
+                accessory.isYubiKey,
+                let session = EASession(accessory: accessory, forProtocol: "com.yubico.ylp")
+            else { return }
+
+            let connectionID = accessory.connectionID
+
+            Task {
+                await EAAccessoryWrapper.shared.setupConnection(id: connectionID, session: session)
+                await LightningConnectionManager.shared.accessoryDidConnect(connectionID: connectionID)
+            }
+        }
+
+        disconnectObserver = NotificationCenter.default.addObserver(
+            forName: .EAAccessoryDidDisconnect,
+            object: manager,
+            queue: nil
+        ) { notification in
+            guard let accessory = notification.userInfo?[EAAccessoryKey] as? EAAccessory,
+                accessory.isYubiKey
+            else { return }
+
+            let connectionID = accessory.connectionID
+
+            Task {
+                await EAAccessoryWrapper.shared.cleanupConnection(id: connectionID)
+                await LightningConnectionManager.shared.accessoryDidDisconnect(connectionID: connectionID)
+            }
+        }
+
+        EAAccessoryManager.shared().registerForLocalNotifications()
+    }
+
+    func stopMonitoring() {
+        trace(message: "stop monitoring")
+        if let observer = connectObserver {
+            NotificationCenter.default.removeObserver(observer)
+            connectObserver = nil
+        }
+        if let observer = disconnectObserver {
+            NotificationCenter.default.removeObserver(observer)
+            disconnectObserver = nil
+        }
+        EAAccessoryManager.shared().unregisterForLocalNotifications()
+    }
+
+    func transmit(id: ConnectionID, data: Data) async throws -> Data {
+        guard let session = sessions[id],
+            let inputStream = session.inputStream,
+            let outputStream = session.outputStream
         else { throw ConnectionError.noConnection }
+
         // Append YLP iAP2 Signal
         try outputStream.writeToYubiKey(data: Data([0x00]) + data)
         while true {
-            try await Task.sleep(for: .seconds(commandProcessingTime))
+            try await Task.sleep(for: .seconds(0.002))
             let result = try inputStream.readFromYubiKey()
-            Logger.lightning.debug(
-                "\(String(describing: self).lastComponent) \(#function): readFromYubiKey: \(result.hexEncodedString)"
+            trace(
+                message:
+                    "got \(result.count) bytes, SW: \(String(format:"%02X%02X", result.bytes[result.count-2], result.bytes[result.count-1]))"
             )
             guard result.count >= 2 else { throw ConnectionError.missingResult }
             let status = ResponseStatus(data: result.subdata(in: result.count - 2..<result.count))
 
             // BUG #62 - Workaround for WTX == 0x01 while status is 0x9000 (success).
-            if (status.status == .ok) || result.bytes[0] != 0x01 {
+            if (status.status == ResponseStatus.StatusCode.ok) || result.bytes[0] != 0x01 {
                 if result.bytes[0] == 0x00 {  // Remove the YLP key protocol header
                     return result.subdata(in: 1..<result.count)
                 } else if result.bytes[0] == 0x01 {  // Remove the YLP key protocol header and the WTX
@@ -98,250 +333,46 @@ public final actor LightningConnection: Connection {
         }
     }
 
-    deinit {
-        Logger.lightning.debug("\(String(describing: self).lastComponent) \(#function)")
+    nonisolated func stream(_ aStream: Stream, handle eventCode: Stream.Event) {
+        trace(message: "stream event: \(String(describing: eventCode))")
     }
 }
 
-fileprivate actor LightningConnectionManager {
-
-    let accessoryWrapper = EAAccessoryWrapper()
-    var currentConnection: LightningConnection?
-
-    var connectionTask: Task<LightningConnection, Error>?
-    func connection() async throws -> LightningConnection {
-        Logger.lightning.debug("\(String(describing: self).lastComponent), \(#function)")
-        let task = Task { [connectionTask] in
-            if let connectionTask {
-                Logger.lightning.debug(
-                    "\(String(describing: self).lastComponent), \(#function): a function call is already awaiting a connection, cancel it before proceeding."
-                )
-                connectionTask.cancel()
-            }
-            return try await self._connection()
-        }
-        connectionTask = task
-        let value = try await withTaskCancellationHandler {
-            try await task.value
-        } onCancel: {
-            task.cancel()
-        }
-        Logger.lightning.debug(
-            "\(String(describing: self).lastComponent), \(#function): returned: \(String(describing: value))"
-        )
-        return value
-    }
-
-    private func _connection() async throws -> LightningConnection {
-        Logger.lightning.debug("\(String(describing: self).lastComponent), \(#function)")
-        if let currentConnection {
-            await currentConnection.close(error: nil)
-            self.currentConnection = nil
-        }
-
-        return try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation { continuation in
-                guard !Task.isCancelled else {
-                    continuation.resume(throwing: CancellationError())
-                    return
-                }
-                accessoryWrapper.connection { result in
-                    switch result {
-                    case .success(let accessoryConnection):
-                        let connection = LightningConnection(
-                            connection: accessoryConnection,
-                            closingHandler: { [weak self] in
-                                self?.accessoryWrapper.stop()
-                            }
-                        )
-                        self.currentConnection = connection
-                        continuation.resume(returning: connection)
-                        self.accessoryWrapper.connectionDidClose { error in
-                            Task {
-                                await connection.closedByManager(error: error)
-                            }
-                        }
-                    case .failure(let error):
-                        continuation.resume(throwing: error)
-                    }
-                }
-            }
-        } onCancel: {
-            accessoryWrapper.stop()
-        }
-    }
-}
-
-private struct AccessoryConnection: Equatable {
-    let accessory: EAAccessory
-    let session: EASession
-
-    func open() {
-        // Streams has to be opened and closed on the main thread to work
-        DispatchQueue.main.sync {
-            guard session.inputStream?.streamStatus != .open,
-                session.outputStream?.streamStatus != .open,
-                session.inputStream?.streamStatus != .opening,
-                session.outputStream?.streamStatus != .opening
-            else {
-                assertionFailure("Tried to open streams that was already open or opening.")
-                return
-            }
-            session.inputStream?.schedule(in: .current, forMode: .common)
-            session.inputStream?.open()
-            session.outputStream?.schedule(in: .current, forMode: .common)
-            session.outputStream?.open()
-        }
-    }
-
-    func close() {
-        DispatchQueue.main.sync {
-            guard session.inputStream?.streamStatus != .closed,
-                session.outputStream?.streamStatus != .closed
-            else {
-                assertionFailure("Tried to close streams that already was closed.")
-                return
-            }
-            session.inputStream?.close()
-            session.outputStream?.close()
-        }
-    }
-}
-
-private class EAAccessoryWrapper: NSObject, StreamDelegate {
-
-    private let manager = EAAccessoryManager.shared()
-    private let queue = DispatchQueue(label: "com.yubico.eaAccessory-connection", qos: .background)
-
-    enum State: Equatable {
-        // no initiatingSession since accessory goes from monitoring straight to connected
-        case ready, scanning
-        case connected(AccessoryConnection)
-    }
-    private var state = State.ready
-
-    private var connectingHandler: ((Result<AccessoryConnection, Error>) -> Void)?
-    private var closingHandler: ((Error?) -> Void)?
-
-    internal func connection(completion handler: @escaping (Result<AccessoryConnection, Error>) -> Void) {
-        Logger.lightning.debug("EAAccessoryWrapper, \(#function)")
-        queue.async {
-            // Signal closure and cancel previous connection handlers
-            // Swap out old handlers to the new ones
-            self.closingHandler?(ConnectionError.closed)
-            self.closingHandler = nil
-            self.connectingHandler?(.failure(ConnectionError.cancelled))
-            self.connectingHandler = handler
-
-            if self.state == .ready {
-                self.start()
-            }
-
-            // Connect to any YubiKeys that's already inserted into the device.
-            guard
-                let accessory = self.manager.connectedAccessories.filter({ accessory in
-                    accessory.isYubiKey
-                }).first,
-                let connection = self.connectToKey(with: accessory)
-            else { return }
-            self.connectingHandler?(.success(connection))
-            self.connectingHandler = nil
-        }
-    }
-
-    func stream(_ aStream: Stream, handle eventCode: Stream.Event) {
-        Logger.lightning.debug(
-            "EAAccessoryWrapper, \(#function): Got stream event: \(String(describing: eventCode)) on stream: \(aStream)"
-        )
-    }
-
-    private func connectToKey(with accessory: EAAccessory) -> AccessoryConnection? {
-        guard accessory.isYubiKey else { return nil }
-        guard let session = EASession(accessory: accessory, forProtocol: "com.yubico.ylp") else { return nil }
-        let connection = AccessoryConnection(accessory: accessory, session: session)
-        Logger.lightning.debug("EAAccessoryWrapper, \(#function), connected to: \(session)")
-        connection.open()
-        connection.session.outputStream!.delegate = self
-        connection.session.inputStream!.delegate = self
-        self.state = .connected(connection)
-        return connection
-    }
-
-    internal func connectionDidClose(completion handler: @escaping (Error?) -> Void) {
-        queue.async {
-            assert(self.closingHandler == nil, "Closing completion already registered.")
-            self.closingHandler = handler
-        }
-    }
-
-    private func start() {
-        self.queue.async {
-            NotificationCenter.default.addObserver(
-                forName: .EAAccessoryDidConnect,
-                object: self.manager,
-                queue: nil
-            ) { [weak self] notification in
-                self?.queue.async {
-                    guard self?.state == .scanning,
-                        self?.connectingHandler != nil,
-                        let accessory = notification.userInfo?[EAAccessoryKey] as? EAAccessory,
-                        let connection = self?.connectToKey(with: accessory)
-                    else { return }
-                    Logger.lightning.debug("EAAccessoryWrapper, connected to: \(accessory)")
-                    self?.state = .connected(connection)
-                    self?.connectingHandler?(.success(connection))
-                    self?.connectingHandler = nil
-                }
-            }
-            NotificationCenter.default.addObserver(
-                forName: .EAAccessoryDidDisconnect,
-                object: self.manager,
-                queue: nil
-            ) { [weak self] notification in
-                self?.queue.async {
-                    guard let accessory = notification.userInfo?[EAAccessoryKey] as? EAAccessory else { return }
-                    guard case let .connected(connection) = self?.state,
-                        connection.accessory.connectionID == accessory.connectionID
-                    else { return }
-                    connection.close()
-                    self?.closingHandler?(nil)
-                    self?.closingHandler = nil
-                    self?.state = .scanning
-                }
-            }
-            EAAccessoryManager.shared().registerForLocalNotifications()
-            // Only transition to .monitoring if previous state was .ready as we might already have transitioned to .connected if a YubiKey was inserted before we started.
-            if self.state == .ready {
-                self.state = .scanning
-            }
-        }
-    }
-
-    internal func stop() {
-        queue.async {
-            switch self.state {
-            case .ready:
-                break
-            case .scanning:
-                // should we call the closingHandler as well?
-                self.connectingHandler?(.failure(ConnectionError.cancelled))
-            case .connected(let connection):
-                connection.close()
-                self.closingHandler?(ConnectionError.closed)
-            }
-            self.connectingHandler = nil
-            self.closingHandler = nil
-            NotificationCenter.default.removeObserver(self, name: .EAAccessoryDidConnect, object: self.manager)
-            NotificationCenter.default.removeObserver(self, name: .EAAccessoryDidDisconnect, object: self.manager)
-            EAAccessoryManager.shared().unregisterForLocalNotifications()
-            self.state = .ready
-        }
-    }
-}
+private typealias ConnectionID = Int
 
 extension EAAccessory {
     fileprivate var isYubiKey: Bool {
-        self.protocolStrings.contains("com.yubico.ylp") && self.manufacturer == "Yubico"
+        protocolStrings.contains("com.yubico.ylp") && manufacturer == "Yubico"
+    }
+}
+
+extension EASession {
+    // NOTE: Apple docs suggest streams should be opened on main thread when using RunLoop scheduling
+    // However, since we're using polling-based I/O (not delegate callbacks), this may not be required
+    fileprivate func open() {
+        guard inputStream?.streamStatus != .open,
+            outputStream?.streamStatus != .open,
+            inputStream?.streamStatus != .opening,
+            outputStream?.streamStatus != .opening
+        else {
+            assertionFailure("Tried to open streams that was already open or opening.")
+            return
+        }
+        inputStream?.schedule(in: .main, forMode: .common)
+        inputStream?.open()
+        outputStream?.schedule(in: .main, forMode: .common)
+        outputStream?.open()
+    }
+
+    fileprivate func close() {
+        guard inputStream?.streamStatus != .closed,
+            outputStream?.streamStatus != .closed
+        else {
+            assertionFailure("Tried to close streams that already was closed.")
+            return
+        }
+        inputStream?.close()
+        outputStream?.close()
     }
 }
 

--- a/YubiKit/YubiKit/Utilities/Logger+Extensions.swift
+++ b/YubiKit/YubiKit/Utilities/Logger+Extensions.swift
@@ -34,6 +34,11 @@ extension HasNFCLogger {
     static var logger: Logger { .nfc }
 }
 
+protocol HasLightningLogger: HasLogger {}
+extension HasLightningLogger {
+    static var logger: Logger { .lightning }
+}
+
 protocol HasSecurityDomainLogger: HasLogger {}
 extension HasSecurityDomainLogger {
     static var logger: Logger { .securityDomain }


### PR DESCRIPTION
### Motivation
In preparation to make the sdk build in Swift 6 it was needed to refactor the LightningConnection.
The new implementation wraps all the calls to CoreNFC in an actor. I verified this compiles without errors or warnings in Swift 6.1.
The end to end tests are all passing for this connection and I tried to keep the same api and throwing error semantics as before.

Similar to what was done in https://github.com/Yubico/yubikit-swift/pull/20 for the SmartCardConnection and in https://github.com/Yubico/yubikit-swift/pull/28 for NFCConnection.