### PR TITLE
Mark all public value types as 'Sendable'

### DIFF
--- a/YubiKit/YubiKit/Connection.swift
+++ b/YubiKit/YubiKit/Connection.swift
@@ -67,7 +67,7 @@ public protocol SmartCardConnection: Sendable {
 }
 
 /// SmartCardConnection Errors.
-public enum ConnectionError: Error {
+public enum ConnectionError: Error, Sendable {
     /// No current connection.
     case noConnection
     /// Unexpected result returned from YubiKey.
@@ -81,7 +81,7 @@ public enum ConnectionError: Error {
 }
 
 /// A ResponseError containing the status code.
-public struct ResponseError: Error {
+public struct ResponseError: Error, Sendable {
     /// Status code of the response.
     public let responseStatus: ResponseStatus
 }

--- a/YubiKit/YubiKit/Keys/Curve25519Keys.swift
+++ b/YubiKit/YubiKit/Keys/Curve25519Keys.swift
@@ -16,7 +16,7 @@ import CryptoKit
 import Foundation
 
 /// Ed25519
-public enum Ed25519 {
+public enum Ed25519: Sendable {
     /// An Ed25519 public key for signature verification
     public struct PublicKey: Sendable, Equatable {
         /// The 32-byte public key data
@@ -80,7 +80,7 @@ public enum Ed25519 {
 }
 
 /// X25519 key agreement algorithm keys
-public enum X25519 {
+public enum X25519: Sendable {
     /// An X25519 public key for key agreement
     public struct PublicKey: Sendable, Equatable {
         /// The 32-byte public key data

--- a/YubiKit/YubiKit/Keys/ECKeys.swift
+++ b/YubiKit/YubiKit/Keys/ECKeys.swift
@@ -17,7 +17,7 @@
 
 import Foundation
 
-public enum EC {
+public enum EC: Sendable {
     /// Supported elliptic curve types (currently P-256 and P-384) using uncompressed point representation.
     public enum Curve: Sendable, Equatable {
         case p384

--- a/YubiKit/YubiKit/Keys/RSAKeys.swift
+++ b/YubiKit/YubiKit/Keys/RSAKeys.swift
@@ -18,7 +18,7 @@
 import CryptoTokenKit
 import Foundation
 
-public enum RSA {
+public enum RSA: Sendable {
 
     /// Supported RSA key sizes (in bits).
     public enum KeySize: Int, Sendable, CaseIterable {

--- a/YubiKit/YubiKit/Management/Capability.swift
+++ b/YubiKit/YubiKit/Management/Capability.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Identifies a feature (typically an application) on a YubiKey which may or may not be supported, and which can be enabled or disabled.
-public enum Capability: UInt {
+public enum Capability: UInt, Sendable {
     /// Identifies the YubiOTP application.
     case OTP = 0x0001
     /// Identifies the U2F (CTAP1) portion of the FIDO application.

--- a/YubiKit/YubiKit/Management/ManagementFeature.swift
+++ b/YubiKit/YubiKit/Management/ManagementFeature.swift
@@ -15,7 +15,7 @@
 import Foundation
 
 /// Management session features.
-public enum ManagementFeature: SessionFeature {
+public enum ManagementFeature: SessionFeature, Sendable {
 
     /// Support for reading the DeviceInfo data from the YubiKey.
     case deviceInfo

--- a/YubiKit/YubiKit/Management/ManagementSession.swift
+++ b/YubiKit/YubiKit/Management/ManagementSession.swift
@@ -16,7 +16,7 @@ import CryptoTokenKit
 import Foundation
 import OSLog
 
-public enum ManagementSessionError: Error {
+public enum ManagementSessionError: Error, Sendable {
     /// Application is not supported on this YubiKey.
     case applicationNotSupported
     /// Unexpected configuration state.

--- a/YubiKit/YubiKit/NFCSmartCardConnection.swift
+++ b/YubiKit/YubiKit/NFCSmartCardConnection.swift
@@ -119,7 +119,7 @@ public struct NFCSmartCardConnection: SmartCardConnection, Sendable {
 }
 
 // NFCSmartCardConnection specific errors
-public enum NFCConnectionError: Error {
+public enum NFCConnectionError: Error, Sendable {
     case failedToPoll
     case unsupported
     case malformedAPDU

--- a/YubiKit/YubiKit/OATH/OATHSession.swift
+++ b/YubiKit/YubiKit/OATH/OATHSession.swift
@@ -28,7 +28,7 @@ private let tagResponse: TKTLVTag = 0x75
 
 let oathDefaultPeriod = 30.0
 
-public enum OATHSessionError: Error {
+public enum OATHSessionError: Error, Sendable {
     case wrongPassword
     case responseDataNotTLVFormatted
     case missingVersionInfo
@@ -454,7 +454,7 @@ public final actor OATHSession: Session {
     }
 }
 
-public struct DeriveAccessKeyError: Error {
+public struct DeriveAccessKeyError: Error, Sendable {
     let cryptorStatus: CCCryptorStatus
 }
 

--- a/YubiKit/YubiKit/OATH/OATHSessionFeature.swift
+++ b/YubiKit/YubiKit/OATH/OATHSessionFeature.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-public enum OATHSessionFeature: SessionFeature {
+public enum OATHSessionFeature: SessionFeature, Sendable {
 
     case rename, touch, sha512
 

--- a/YubiKit/YubiKit/PIV/PIVDataTypes.swift
+++ b/YubiKit/YubiKit/PIV/PIVDataTypes.swift
@@ -15,7 +15,7 @@
 import Foundation
 
 /// Namespace for all PIV related types
-public enum PIV {
+public enum PIV: Sendable {
 
     /// The touch policy of a private key defines whether or not a user presence check (physical touch) is required to use the key.
     public enum TouchPolicy: UInt8, Sendable {

--- a/YubiKit/YubiKit/PIV/PIVSessionFeature.swift
+++ b/YubiKit/YubiKit/PIV/PIVSessionFeature.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-public enum PIVSessionFeature: SessionFeature {
+public enum PIVSessionFeature: SessionFeature, Sendable {
 
     case usagePolicy, aesKey, serialNumber, metadata, attestation, p384, touchCached, rsaGeneration, rsa3072and4096,
         moveDelete, ed25519, x25519

--- a/YubiKit/YubiKit/Response.swift
+++ b/YubiKit/YubiKit/Response.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-public struct Response: CustomStringConvertible {
+public struct Response: CustomStringConvertible, Sendable {
 
     public init(rawData: Data) {
         if rawData.count > 2 {

--- a/YubiKit/YubiKit/SCP/SCP03KeyParams.swift
+++ b/YubiKit/YubiKit/SCP/SCP03KeyParams.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public struct SCP03KeyParams: SCPKeyParams {
+public struct SCP03KeyParams: SCPKeyParams, Sendable {
     public let keyRef: SCPKeyRef
     public let staticKeys: StaticKeys
 

--- a/YubiKit/YubiKit/SCP/SCP11KeyParams.swift
+++ b/YubiKit/YubiKit/SCP/SCP11KeyParams.swift
@@ -14,7 +14,7 @@
 
 import CommonCrypto
 
-public struct SCP11KeyParams: SCPKeyParams {
+public struct SCP11KeyParams: SCPKeyParams, Sendable {
     public let keyRef: SCPKeyRef
     public let pkSdEcka: EC.PublicKey
     public let oceKeyRef: SCPKeyRef?

--- a/YubiKit/YubiKit/SCP/SecurityDomainSession.swift
+++ b/YubiKit/YubiKit/SCP/SecurityDomainSession.swift
@@ -25,7 +25,7 @@ import OSLog
 /// - notSupported: Requested operation isn’t available in the current context.
 /// - encryptionFailed: AES‑CBC encryption failed (CommonCrypto).
 /// - wrapped: Wraps a lower‑level ``Error`` (e.g. CryptoTokenKit).
-public enum SCPError: Error {
+public enum SCPError: Error, Sendable {
     case unexpectedResponse(String?)
     case illegalArgument(String?)
     case notSupported(String?)

--- a/YubiKit/YubiKit/Session.swift
+++ b/YubiKit/YubiKit/Session.swift
@@ -36,7 +36,7 @@ public protocol SessionFeature {
     func isSupported(by version: Version) -> Bool
 }
 
-public enum SessionError: Error {
+public enum SessionError: Error, Sendable {
     case notSupported(_: String?)  // consider renaming to illegalState to match Java sdk
     case activeSession
     case missingApplication

--- a/YubiKit/YubiKit/USBSmartCardConnection.swift
+++ b/YubiKit/YubiKit/USBSmartCardConnection.swift
@@ -81,7 +81,7 @@ extension USBSmartCardConnection: SmartCardConnection {
 }
 
 // USBSmartCardConnection specific errors
-public enum SmartCardConnectionError: Error {
+public enum SmartCardConnectionError: Error, Sendable {
     /// CryptoTokenKit failed to return TKSmartCardSlotManager.default
     case unsupported
     /// CryptoTokenKit returned no slots

--- a/YubiKit/YubiKit/Utilities/Data+Extensions.swift
+++ b/YubiKit/YubiKit/Utilities/Data+Extensions.swift
@@ -15,7 +15,7 @@
 import CommonCrypto
 import Foundation
 
-public enum PIVEncryptionError: Error {
+public enum PIVEncryptionError: Error, Sendable {
     case cryptorError(CCCryptorStatus)
     case missingData
     case unsupportedAlgorithm

--- a/YubiKit/YubiKit/Utilities/SmartCardConnections.swift
+++ b/YubiKit/YubiKit/Utilities/SmartCardConnections.swift
@@ -18,7 +18,7 @@ import Foundation
 import CoreNFC
 #endif
 
-public enum WiredSmartCardConnection {
+public enum WiredSmartCardConnection: Sendable {
     /// Establishes a Lightning or SmartCard connection to a YubiKey.
     ///
     /// Call this method to connect to a YubiKey using a wired interface such as Lightning or SmartCard.
@@ -35,7 +35,7 @@ public enum WiredSmartCardConnection {
     }
 }
 
-public enum AnySmartCardConnection {
+public enum AnySmartCardConnection: Sendable {
     /// Establishes a connection to a YubiKey over either wired or NFC.
     ///
     /// Use this method to connect to a YubiKey using any available interface. If no wired YubiKey


### PR DESCRIPTION
This is required for the callers of this SDK to be able send these types across actor boundaries.
These annotations fix a bunch of warnings in our sample apps.

All these types are pure value types and have all reasons to be marked as Sendable.