### PR TITLE
New connections should fail if there's an already open connection

### DIFF
--- a/YubiKit/YubiKit/Connection.swift
+++ b/YubiKit/YubiKit/Connection.swift
@@ -68,6 +68,8 @@ public protocol SmartCardConnection: Sendable {
 
 /// SmartCardConnection Errors.
 public enum ConnectionError: Error, Sendable {
+    /// There is an active connection.
+    case busy
     /// No current connection.
     case noConnection
     /// Unexpected result returned from YubiKey.


### PR DESCRIPTION
This Pull Request changes the behaviour around Connections creation.

Before this Pull Request when a new connection was requested the previous one was closed.
Now when a new connection is requested, and there is already a connection, `ConnectionError.busy` is thrown.


`ConnectionFullStackTests` had to be changed to test for the new behaviour instead of the old one and I also took the opportunity to migrate them from the old [XCTest](https://developer.apple.com/documentation/xctest) framework to the new[ Swift Testing ](https://developer.apple.com/documentation/testing) framework.


I've run the Connection tests for the three different kinds of connections and made sure they passed both on iOS and macOS. (actually `sendManually()` fails for iOS with NFC but that's a entitlements issue that was already failing before and I will fix in a different pull request).