### PR TITLE
Make connections reference types and auto-close on deinit 

### DIFF
--- a/FullStackTests/AllowedConnections.swift
+++ b/FullStackTests/AllowedConnections.swift
@@ -93,13 +93,13 @@ enum TestableConnection {
 
     #if os(iOS)
     private static func lightning() async throws -> SmartCardConnection? {
-        let connection = try await LightningSmartCardConnection.connection()
+        let connection = try await LightningSmartCardConnection()
         guard try await connection.isAllowed else { return nil }
         return connection
     }
 
     private static func nfc(alertMessage: String? = nil) async throws -> SmartCardConnection? {
-        let connection = try await NFCSmartCardConnection.connection(alertMessage: alertMessage)
+        let connection = try await NFCSmartCardConnection(alertMessage: alertMessage)
         guard try await connection.isAllowed else { return nil }
         return connection
     }
@@ -113,7 +113,7 @@ extension USBSmartCardConnection {
 
             var connections: [SmartCardConnection?] = []
             for slot in slots {
-                connections.append(try? await USBSmartCardConnection.connection(slot: slot))
+                connections.append(try? await USBSmartCardConnection(slot: slot))
             }
             return connections.compactMap { $0 }
         }

--- a/FullStackTests/Tests/ConnectionFullStackTests.swift
+++ b/FullStackTests/Tests/ConnectionFullStackTests.swift
@@ -25,14 +25,14 @@ struct ConnectionFullStackTests {
 
     @Test("Single Connection", .timeLimit(.minutes(1)))
     func singleConnection() async throws {
-        let connection = try await Connection.connection()
+        let connection = try await Connection()
         #expect(true, "✅ Got connection \(connection)")
         await connection.close(error: nil)
     }
 
     @Test("Connection Did Close", .timeLimit(.minutes(1)))
     func connectionDidClose() async throws {
-        let connection = try await Connection.connection()
+        let connection = try await Connection()
 
         // Start a task to wait for connection closure
         let closureTask = Task {
@@ -55,7 +55,7 @@ struct ConnectionFullStackTests {
 
     @Test("Serial Connections", .timeLimit(.minutes(1)))
     func serialConnections() async throws {
-        let firstConnection = try await Connection.connection()
+        let firstConnection = try await Connection()
         #expect(true, "✅ Got first connection \(firstConnection)")
         let task = Task {
             let result = await firstConnection.connectionDidClose()
@@ -75,7 +75,7 @@ struct ConnectionFullStackTests {
 
         // attempt to create a second connection (now it should succed!)
         try? await Task.sleep(for: .seconds(1))
-        let secondConnection = try await Connection.connection()
+        let secondConnection = try await Connection()
         #expect(true, "✅ Got second connection \(secondConnection)")
 
         // close the second connection

--- a/FullStackTests/Tests/ConnectionFullStackTests.swift
+++ b/FullStackTests/Tests/ConnectionFullStackTests.swift
@@ -27,7 +27,6 @@ struct ConnectionFullStackTests {
     func singleConnection() async throws {
         let connection = try await Connection()
         #expect(true, "✅ Got connection \(connection)")
-        await connection.close(error: nil)
     }
 
     @Test("Connection Did Close", .timeLimit(.minutes(1)))
@@ -78,7 +77,6 @@ struct ConnectionFullStackTests {
         let secondConnection = try await Connection()
         #expect(true, "✅ Got second connection \(secondConnection)")
 
-        // close the second connection
         await secondConnection.close(error: nil)
     }
 
@@ -128,9 +126,6 @@ struct SmartCardConnectionFullStackTests {
         let slot = try #require(random, "No YubiKey slots available")
         let connection = try await USBSmartCardConnection.connection(slot: slot)
         #expect(true, "✅ Got connection \(connection)")
-
-        // close the second connection
-        await connection.close(error: nil)
     }
 
     @Test("Send Manually", .timeLimit(.minutes(1)))
@@ -176,8 +171,6 @@ struct SmartCardConnectionFullStackTests {
                 || notFoundResult.responseStatus.status == .invalidInstruction,
             "Unexpected result: \(notFoundResult.responseStatus)"
         )
-
-        await connection.close(error: nil)
     }
 
     @Test("SmartCard Connection With Slot", .timeLimit(.minutes(1)))
@@ -209,7 +202,6 @@ struct NFCFullStackTests {
     @Test("NFC Closing Error Message")
     func nfcClosingErrorMessage() async throws {
         let connection = try await TestableConnections.create(with: .nfc(alertMessage: "Test Alert Message"))
-        await connection.close(error: nil)
     }
 
 }
@@ -231,8 +223,6 @@ struct HIDFIDOConnectionFullStackTests {
         let device = try #require(random, "No FIDO HID devices available")
         let connection = try await HIDFIDOConnection.connection(device: device)
         #expect(true, "✅ Got connection \(connection)")
-
-        await connection.close(error: nil)
     }
 }
 

--- a/FullStackTests/Tests/FIDOFullStackTests.swift
+++ b/FullStackTests/Tests/FIDOFullStackTests.swift
@@ -47,8 +47,6 @@ struct FIDOInterfaceFullStackTests {
 
         #expect(await fidoInterface.version.description.isEmpty == false)
         #expect(await fidoInterface.capabilities > 0)
-
-        await connection.close(error: nil)
     }
 
     @Test("FIDO Capability Detection")
@@ -65,8 +63,6 @@ struct FIDOInterfaceFullStackTests {
         print("NMSG capability: \(supportsNMSG)")
 
         #expect(supportsWink, "YubiKey should support WINK")
-
-        await connection.close(error: nil)
     }
 
     @Test("FIDO WINK Functionality")
@@ -76,7 +72,6 @@ struct FIDOInterfaceFullStackTests {
 
         guard await fidoInterface.supports(FIDOInterface.Capability.WINK) else {
             print("YubiKey does not support WINK, skipping test")
-            await connection.close(error: nil)
             return
         }
 
@@ -85,8 +80,6 @@ struct FIDOInterfaceFullStackTests {
         print("WINK command completed successfully!")
 
         #expect(true)
-
-        await connection.close(error: nil)
     }
 
     @Test("FIDO PING Command")
@@ -101,8 +94,6 @@ struct FIDOInterfaceFullStackTests {
 
         print("PING response received: \(response.hexEncodedString)")
         #expect(response == pingData, "PING should echo back the same data")
-
-        await connection.close(error: nil)
     }
 
     @Test("FIDO Error Handling")
@@ -122,8 +113,6 @@ struct FIDOInterfaceFullStackTests {
         } catch {
             Issue.record("Unexpected error type: \(error)")
         }
-
-        await connection.close(error: nil)
     }
 }
 

--- a/Samples/OATHSample/OATHSample/ConnectionManager.swift
+++ b/Samples/OATHSample/OATHSample/ConnectionManager.swift
@@ -67,7 +67,7 @@ final class ConnectionManager: ObservableObject {
         error = nil
 
         do {
-            nfcConnection = try await NFCSmartCardConnection.connection() as? NFCSmartCardConnection
+            nfcConnection = try await NFCSmartCardConnection()
         } catch {
             self.error = error
         }

--- a/YubiKit/YubiKit/Connection/Connection.swift
+++ b/YubiKit/YubiKit/Connection/Connection.swift
@@ -44,4 +44,6 @@ public enum ConnectionError: Error, Sendable {
     case cancelled
     /// Awaiting call to connect() was dismissed by the user.
     case cancelledByUser
+    /// Connection was deallocated without being properly closed.
+    case deallocated
 }

--- a/YubiKit/YubiKit/Connection/Connection.swift
+++ b/YubiKit/YubiKit/Connection/Connection.swift
@@ -18,7 +18,7 @@ import Foundation
 ///
 /// This is the base protocol for all YubiKey connections. Specific connection types
 /// like ``SmartCardConnection`` and ``FIDOConnection`` extend this protocol
-public protocol Connection: Sendable {
+public protocol Connection: AnyObject, Sendable {
 
     /// Close the current connection.
     ///

--- a/YubiKit/YubiKit/Connection/FIDO/FIDOConnection.swift
+++ b/YubiKit/YubiKit/Connection/FIDO/FIDOConnection.swift
@@ -19,6 +19,14 @@ import Foundation
 /// Works in terms of fixed-size packets (≤ `mtu`).
 /* public */ protocol FIDOConnection: Connection {
 
+    /// Create a new FIDOConnection to the YubiKey.
+    ///
+    /// Initialize a FIDOConnection to get a connection to a YubiKey.
+    /// The init method will wait until a connection to a YubiKey has been established.
+    ///
+    /// - Throws: Connection errors if no YubiKey is available.
+    init() async throws
+
     /// Maximum payload size (in bytes) for a single packet.
     var mtu: Int { get }
 
@@ -29,7 +37,7 @@ import Foundation
     func receive() async throws -> Data
 
     /// Opens a new connection.
-    static func connection() async throws -> FIDOConnection
+    static func connection() async throws -> Self
 
     /// Close the current connection.
     func close(error: Error?) async

--- a/YubiKit/YubiKit/Connection/SmartCard/LightningSmartCardConnection.swift
+++ b/YubiKit/YubiKit/Connection/SmartCard/LightningSmartCardConnection.swift
@@ -21,12 +21,26 @@ import OSLog
 /// A connection to the YubiKey utilizing the Lightning port and External Accessory framework.
 @available(iOS 16.0, *)
 public struct LightningSmartCardConnection: SmartCardConnection, Sendable {
-    let accessoryConnectionID: Int
+    fileprivate let accessoryConnectionID: LightningConnectionID
 
-    // Starts lightning and wait for a connection
-    public static func connection() async throws -> SmartCardConnection {
+    /// Creates a new Lightning connection to a YubiKey.
+    ///
+    /// Waits for a YubiKey to be connected via Lightning port and establishes a connection.
+    ///
+    /// - Throws: ``ConnectionError.busy`` if there is already an active connection.
+    public init() async throws {
+        accessoryConnectionID = try await LightningConnectionManager.shared.connect()
+    }
+
+    /// Creates a new Lightning connection to a YubiKey.
+    ///
+    /// Waits for a YubiKey to be connected via Lightning port and establishes a connection.
+    ///
+    /// - Returns: A fully–established connection ready for APDU exchange.
+    /// - Throws: ``ConnectionError.busy`` if there is already an active connection.
+    public static func connection() async throws -> LightningSmartCardConnection {
         trace(message: "requesting new connection")
-        return try await LightningConnectionManager.shared.connect()
+        return try await LightningSmartCardConnection()
     }
 
     public func close(error: Error?) async {
@@ -51,6 +65,7 @@ public struct LightningSmartCardConnection: SmartCardConnection, Sendable {
         trace(message: "received \(response.count) bytes")
         return response
     }
+
 }
 
 // MARK: - Internal helpers / extensions
@@ -72,19 +87,19 @@ private actor LightningConnectionManager {
 
     static let shared = LightningConnectionManager()
 
-    private var pendingConnectionPromise: Promise<LightningSmartCardConnection>?
-    private var connectionState: (connectionID: ConnectionID, didCloseConnection: (Promise<Error?>))?
+    private var pendingConnectionPromise: Promise<LightningConnectionID>?
+    private var connectionState: (connectionID: LightningConnectionID, didCloseConnection: (Promise<Error?>))?
 
     private init() {}
 
-    func connect() async throws -> LightningSmartCardConnection {
+    func connect() async throws -> LightningConnectionID {
         // If there is already a connection the caller must close the connection first.
         if connectionState != nil || pendingConnectionPromise != nil {
             throw ConnectionError.busy
         }
 
         // Otherwise, create and store a new connection task.
-        let task = Task { () -> LightningSmartCardConnection in
+        let task = Task { () -> LightningConnectionID in
             trace(message: "begin new connection task")
 
             do {
@@ -95,7 +110,7 @@ private actor LightningConnectionManager {
                 }
 
                 // Create a promise to bridge the callback from EAAccessoryWrapper
-                let connectionPromise: Promise<LightningSmartCardConnection> = .init()
+                let connectionPromise: Promise<LightningConnectionID> = .init()
                 self.pendingConnectionPromise = connectionPromise
 
                 // Connect to YubiKeys that are already plugged in
@@ -156,17 +171,16 @@ private actor LightningConnectionManager {
     }
 
     // Called by EAAccessoryWrapper when an accessory connects
-    func accessoryDidConnect(connectionID: Int) async {
+    func accessoryDidConnect(connectionID: LightningConnectionID) async {
         trace(message: "accessory connected with ID \(connectionID)")
         guard let promise = pendingConnectionPromise else { return }
 
         connectionState = (connectionID: connectionID, didCloseConnection: Promise<Error?>())
-        let connection = LightningSmartCardConnection(accessoryConnectionID: connectionID)
-        await promise.fulfill(connection)
+        await promise.fulfill(connectionID)
     }
 
     // Called by EAAccessoryWrapper when an accessory disconnects
-    func accessoryDidDisconnect(connectionID: Int) async {
+    func accessoryDidDisconnect(connectionID: LightningConnectionID) async {
         trace(message: "accessory disconnected with ID \(connectionID)")
 
         // If a connection attempt is in progress, fail it.
@@ -190,11 +204,11 @@ private actor EAAccessoryWrapper: NSObject, StreamDelegate {
     private override init() {}
 
     private let manager = EAAccessoryManager.shared()
-    private var sessions: [ConnectionID: EASession] = [:]
+    private var sessions: [LightningConnectionID: EASession] = [:]
     private var connectObserver: NSObjectProtocol?
     private var disconnectObserver: NSObjectProtocol?
 
-    func setupConnection(id: ConnectionID, session: EASession) async {
+    func setupConnection(id: LightningConnectionID, session: EASession) async {
         trace(message: "opening session for ID \(id)")
         session.open()
         // Give streams time to stabilize
@@ -205,7 +219,7 @@ private actor EAAccessoryWrapper: NSObject, StreamDelegate {
         sessions[id] = session
     }
 
-    func cleanupConnection(id: ConnectionID) {
+    func cleanupConnection(id: LightningConnectionID) {
         trace(message: "closing session for ID \(id)")
         guard let session = sessions[id] else { return }
 
@@ -225,7 +239,7 @@ private actor EAAccessoryWrapper: NSObject, StreamDelegate {
         let connectedYubiKeys = getConnectedYubiKeys()
         if let connectedKey = connectedYubiKeys.first {
 
-            let connectionID = connectedKey.connectionID
+            let connectionID: LightningConnectionID = connectedKey.connectionID
 
             // Check if we already have a session for this accessory
             if let _ = sessions[connectionID] {
@@ -254,7 +268,7 @@ private actor EAAccessoryWrapper: NSObject, StreamDelegate {
                 let session = EASession(accessory: accessory, forProtocol: "com.yubico.ylp")
             else { return }
 
-            let connectionID = accessory.connectionID
+            let connectionID: LightningConnectionID = accessory.connectionID
 
             Task {
                 await EAAccessoryWrapper.shared.setupConnection(id: connectionID, session: session)
@@ -271,7 +285,7 @@ private actor EAAccessoryWrapper: NSObject, StreamDelegate {
                 accessory.isYubiKey
             else { return }
 
-            let connectionID = accessory.connectionID
+            let connectionID: LightningConnectionID = accessory.connectionID
 
             Task {
                 await EAAccessoryWrapper.shared.cleanupConnection(id: connectionID)
@@ -295,7 +309,7 @@ private actor EAAccessoryWrapper: NSObject, StreamDelegate {
         EAAccessoryManager.shared().unregisterForLocalNotifications()
     }
 
-    func transmit(id: ConnectionID, data: Data) async throws -> Data {
+    func transmit(id: LightningConnectionID, data: Data) async throws -> Data {
         guard let session = sessions[id],
             let inputStream = session.inputStream,
             let outputStream = session.outputStream
@@ -330,7 +344,7 @@ private actor EAAccessoryWrapper: NSObject, StreamDelegate {
     }
 }
 
-private typealias ConnectionID = Int
+private typealias LightningConnectionID = Int
 
 extension EAAccessory {
     fileprivate var isYubiKey: Bool {

--- a/YubiKit/YubiKit/Connection/SmartCard/SmartCardConnection.swift
+++ b/YubiKit/YubiKit/Connection/SmartCard/SmartCardConnection.swift
@@ -19,20 +19,26 @@ import Foundation
 /// Use a connection to create a ``Session``. The connection can also be used for sending raw ``APDU``'s to the YubiKey.
 ///
 /// Protocol implemented in ``LightningSmartCardConnection``, ``NFCSmartCardConnection`` and ``USBSmartCardConnection``.
+
 public protocol SmartCardConnection: Connection {
+
+    /// Create a new SmartCardConnection to the YubiKey.
+    ///
+    /// Initialize a SmartCardConnection to get a connection to a YubiKey.
+    /// The init method will wait until a connection to a YubiKey has been established.
+    ///
+    /// The init will throw with ``.busy`` if there is an already established connection for the same
+    /// resource.
+    init() async throws
 
     /// Create a new SmartCardConnection to the YubiKey.
     ///
     /// Call this method to get a connection to a YubiKey. The method will wait
     /// until a connection to a YubiKey has been established and then return it.
     ///
-    /// If the method is called a second time while already waiting for a connection
-    /// the first call to connection() will be cancelled.
-    ///
-    /// If a connection has been established and this method is called again the
-    /// first connection will be closed and ``connectionDidClose()`` will return for
-    /// the previous connection.
-    static func connection() async throws -> SmartCardConnection
+    /// The method will throw ``.busy`` if there is an already established connection for the same
+    /// resource.
+    static func connection() async throws -> Self
 
     /// Send an APDU to the SmartCardConnection.
     ///

--- a/YubiKit/YubiKit/Connection/SmartCard/SmartCardConnections.swift
+++ b/YubiKit/YubiKit/Connection/SmartCard/SmartCardConnections.swift
@@ -76,12 +76,12 @@ private enum SmartCardConnections {
     fileprivate static func new(kind: SmartCardConnections.Kind) async throws -> SmartCardConnection {
         switch kind {
         case .usb:
-            return try await USBSmartCardConnection.connection()
+            return try await USBSmartCardConnection()
         #if os(iOS)
         case .lightning:
-            return try await LightningSmartCardConnection.connection()
+            return try await LightningSmartCardConnection()
         case let .nfc(alertMessage):
-            return try await NFCSmartCardConnection.connection(alertMessage: alertMessage)
+            return try await NFCSmartCardConnection(alertMessage: alertMessage)
         #endif
         case .wired:
             return try await wired()
@@ -95,16 +95,16 @@ private enum SmartCardConnections {
             #if os(iOS)
             if Device.hasLightningPort {
                 group.addTask {
-                    try await LightningSmartCardConnection.connection()
+                    try await LightningSmartCardConnection()
                 }
             } else {
                 group.addTask {
-                    try await USBSmartCardConnection.connection()
+                    try await USBSmartCardConnection()
                 }
             }
             #else
             group.addTask {
-                try await USBSmartCardConnection.connection()
+                try await USBSmartCardConnection()
             }
             #endif
 
@@ -123,7 +123,7 @@ private enum SmartCardConnections {
                     // wait for wired connected yubikeys to connect before starting NFC
                     try await Task.sleep(for: .seconds(0.75))
                     try Task.checkCancellation()
-                    return try await NFCSmartCardConnection.connection(alertMessage: nfcAlertMessage)
+                    return try await NFCSmartCardConnection(alertMessage: nfcAlertMessage)
                 }
             }
             #endif


### PR DESCRIPTION
In this pull-request we've converted the connections to reference type so we can close the connection on deinit/dealloc.
This change aligns more with people's expectations on how a connection should work (if no one holds the connection it's probably closed). Before we could leak connections, in the sense that there might no been any connection reference but the connection was still (and forever) open.

We've also added inits for the connections that can be used alongside the existing factory methods: [72dd92c](https://github.com/Yubico/yubikit-swift/pull/52/commits/72dd92cffec8a4832be9c849055d249a8f58eed8)
