### PR TITLE
Improvements for wrapper apps

### DIFF
--- a/YubiKit/YubiKit/FIDO/CBOR/CBORValue.swift
+++ b/YubiKit/YubiKit/FIDO/CBOR/CBORValue.swift
@@ -16,7 +16,7 @@ import Foundation
 
 extension CBOR {
     // CBOR value representation for CTAP2/FIDO2
-    indirect enum Value: Sendable {
+    indirect public enum Value: Sendable {
         case unsignedInt(UInt64)  // CBOR major type 0
         case negativeInt(UInt64)  // CBOR major type 1, one's complement
         case byteString(Data)  // CBOR major type 2
@@ -32,7 +32,7 @@ extension CBOR {
 
 extension CBOR.Value {
     // Creates a CBOR value from an Int64
-    init(_ value: Int64) {
+    public init(_ value: Int64) {
         if value >= 0 {
             self = .unsignedInt(UInt64(value))
         } else {
@@ -55,32 +55,32 @@ extension CBOR.Value {
     }
 
     // Creates a CBOR value from a UInt64
-    init(_ value: UInt64) {
+    public init(_ value: UInt64) {
         self = .unsignedInt(value)
     }
 
     // Creates a CBOR value from a String
-    init(_ value: String) {
+    public init(_ value: String) {
         self = .textString(value)
     }
 
     // Creates a CBOR value from Data
-    init(_ value: Data) {
+    public init(_ value: Data) {
         self = .byteString(value)
     }
 
     // Creates a CBOR value from a Bool
-    init(_ value: Bool) {
+    public init(_ value: Bool) {
         self = .boolean(value)
     }
 
     // Creates a CBOR array from an array of values
-    init(_ array: [CBOR.Value]) {
+    public init(_ array: [CBOR.Value]) {
         self = .array(array)
     }
 
     // Creates a CBOR map from a dictionary with CBOR.Value keys
-    init(_ dict: [CBOR.Value: CBOR.Value]) {
+    public init(_ dict: [CBOR.Value: CBOR.Value]) {
         self = .map(dict)
     }
 }
@@ -180,14 +180,14 @@ extension CBOR.Value {
 // MARK: - Hashable & Equatable
 
 extension CBOR.Value: Hashable {
-    func hash(into hasher: inout Hasher) {
+    public func hash(into hasher: inout Hasher) {
         // Use the canonical CBOR encoding for hashing
         hasher.combine(self.encode())
     }
 }
 
 extension CBOR.Value: Equatable {
-    static func == (lhs: CBOR.Value, rhs: CBOR.Value) -> Bool {
+    public static func == (lhs: CBOR.Value, rhs: CBOR.Value) -> Bool {
         // Two CBOR values are equal if their canonical encodings are equal
         lhs.encode() == rhs.encode()
     }
@@ -196,31 +196,31 @@ extension CBOR.Value: Equatable {
 // MARK: - ExpressibleBy Literal Conformances
 
 extension CBOR.Value: ExpressibleByIntegerLiteral {
-    init(integerLiteral value: Int) {
+    public init(integerLiteral value: Int) {
         self.init(Int64(value))
     }
 }
 
 extension CBOR.Value: ExpressibleByStringLiteral {
-    init(stringLiteral value: String) {
+    public init(stringLiteral value: String) {
         self.init(value)
     }
 }
 
 extension CBOR.Value: ExpressibleByBooleanLiteral {
-    init(booleanLiteral value: Bool) {
+    public init(booleanLiteral value: Bool) {
         self.init(value)
     }
 }
 
 extension CBOR.Value: ExpressibleByArrayLiteral {
-    init(arrayLiteral elements: CBOR.Value...) {
+    public init(arrayLiteral elements: CBOR.Value...) {
         self = .array(elements)
     }
 }
 
 extension CBOR.Value: ExpressibleByDictionaryLiteral {
-    init(dictionaryLiteral elements: (CBOR.Value, CBOR.Value)...) {
+    public init(dictionaryLiteral elements: (CBOR.Value, CBOR.Value)...) {
         var dict: [CBOR.Value: CBOR.Value] = [:]
         for (key, value) in elements {
             dict[key] = value
@@ -230,7 +230,7 @@ extension CBOR.Value: ExpressibleByDictionaryLiteral {
 }
 
 extension CBOR.Value: ExpressibleByNilLiteral {
-    init(nilLiteral: ()) {
+    public init(nilLiteral: ()) {
         self = .null
     }
 }
@@ -238,7 +238,7 @@ extension CBOR.Value: ExpressibleByNilLiteral {
 // MARK: - CustomStringConvertible
 
 extension CBOR.Value: CustomStringConvertible {
-    var description: String {
+    public var description: String {
         switch self {
         case .unsignedInt(let n):
             return "\(n)"

--- a/YubiKit/YubiKit/FIDO/CTAP/Extensions/Extension.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/Extensions/Extension.swift
@@ -100,7 +100,7 @@ extension CTAP2.Extension.MakeCredential {
     public struct Input: Sendable {
         private let encoded: [CTAP2.Extension.Identifier: CBOR.Value]
 
-        internal init(encoded: [CTAP2.Extension.Identifier: CBOR.Value]) {
+        public init(encoded: [CTAP2.Extension.Identifier: CBOR.Value]) {
             self.encoded = encoded
         }
 
@@ -132,7 +132,7 @@ extension CTAP2.Extension.GetAssertion {
     public struct Input: Sendable {
         private let encoded: [CTAP2.Extension.Identifier: CBOR.Value]
 
-        internal init(encoded: [CTAP2.Extension.Identifier: CBOR.Value]) {
+        public init(encoded: [CTAP2.Extension.Identifier: CBOR.Value]) {
             self.encoded = encoded
         }
 

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Attestation/Apple.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Attestation/Apple.swift
@@ -19,6 +19,10 @@ extension WebAuthn.AttestationStatement {
     ///
     /// - SeeAlso: [Apple Anonymous Attestation Statement Format](https://www.w3.org/TR/webauthn/#sctn-apple-anonymous-attestation)
     public struct Apple: Sendable {
+
+        /// Original raw data.
+        public let rawData: Data
+
         /// Attestation certificate chain.
         public let x5c: [Data]
     }

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Attestation/AttestationStatement+CBOR.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Attestation/AttestationStatement+CBOR.swift
@@ -39,6 +39,8 @@ extension WebAuthn.AttestationStatement.Packed: CBOR.Decodable {
 
         // Optional: ecdaaKeyId (rarely used)
         self.ecdaaKeyId = map["ecdaaKeyId"]?.cborDecoded()
+
+        self.rawData = cbor.encode()
     }
 }
 
@@ -61,6 +63,8 @@ extension WebAuthn.AttestationStatement.FIDOU2F: CBOR.Decodable {
             return nil
         }
         self.x5c = x5c
+
+        self.rawData = cbor.encode()
     }
 }
 
@@ -77,5 +81,7 @@ extension WebAuthn.AttestationStatement.Apple: CBOR.Decodable {
             return nil
         }
         self.x5c = x5c
+
+        self.rawData = cbor.encode()
     }
 }

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Attestation/FIDOU2F.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Attestation/FIDOU2F.swift
@@ -19,6 +19,10 @@ extension WebAuthn.AttestationStatement {
     ///
     /// - SeeAlso: [FIDO U2F Attestation Statement Format](https://www.w3.org/TR/webauthn/#sctn-fido-u2f-attestation)
     public struct FIDOU2F: Sendable {
+
+        /// Original raw data.
+        public let rawData: Data
+
         /// Attestation signature.
         public let sig: Data
 

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Attestation/Packed.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Attestation/Packed.swift
@@ -19,6 +19,10 @@ extension WebAuthn.AttestationStatement {
     ///
     /// - SeeAlso: [Packed Attestation Statement Format](https://www.w3.org/TR/webauthn/#sctn-packed-attestation)
     public struct Packed: Sendable {
+
+        /// Original raw data.
+        public let rawData: Data
+
         /// Attestation signature.
         public let sig: Data
 

--- a/YubiKit/YubiKit/FIDO/WebAuthn/AuthenticatorData.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/AuthenticatorData.swift
@@ -38,7 +38,7 @@ extension WebAuthn {
         /// Raw extension outputs map (present when ED flag is set).
         ///
         /// Use extension-specific `result(from:)` methods for typed access to extension outputs.
-        internal let extensions: [WebAuthn.Extension.Identifier: CBOR.Value]?
+        public let extensions: [WebAuthn.Extension.Identifier: CBOR.Value]?
 
         /// Authenticator data flags.
         public struct Flags: OptionSet, Sendable {

--- a/YubiKit/YubiKit/FIDO/WebAuthn/AuthenticatorData.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/AuthenticatorData.swift
@@ -23,6 +23,10 @@ extension WebAuthn {
     ///
     /// - SeeAlso: [WebAuthn Authenticator Data](https://www.w3.org/TR/webauthn/#authenticator-data)
     public struct AuthenticatorData: Sendable {
+
+        /// The raw data
+        public let rawData: Data
+
         /// SHA-256 hash of the RP ID (32 bytes).
         public let rpIdHash: Data
 
@@ -131,6 +135,8 @@ extension WebAuthn.AuthenticatorData {
         } else {
             self.extensions = nil
         }
+
+        self.rawData = data
     }
 }
 


### PR DESCRIPTION
@jdmoreira, this is what I need to be able to make use of YubiKit-swift in [wwWallet's iOS wrapper app](https://github.com/wwWallet/wallet-ios-wrapper/tree/yubikit-swift).

There's things missing, probably, but this is the bare minimum I need to compile.

The main problem I still have: `CTAP2.GetAssertion.Response.authenticatorData.extensions` is empty, although it should contain some PRF-related stuff. (Which we need - this is the main reason for the wrapper app dance in the first place.)

These two files are the main places of implmentation:

https://github.com/wwWallet/wallet-ios-wrapper/blob/yubikit-swift/wwWallet/Models/BridgeModel.swift
https://github.com/wwWallet/wallet-ios-wrapper/blob/yubikit-swift/wwWallet/Models/JsonModels.swift


Can you review this PR and my wwWallet changes and let me know, if I'm on the right way?

Let me know, if you want to give the wrapper a test drive for yourself, I'll give you instructions on how to set up.
(Hint: You would need to fill in this: https://github.com/wwWallet/wallet-ios-wrapper/blob/yubikit-swift/Config.xcconfig)