### PR TITLE
Fixes FIDO tests for lightning connection plus new allowed key

### DIFF
--- a/FullStackTests/AllowedConnections.swift
+++ b/FullStackTests/AllowedConnections.swift
@@ -25,6 +25,7 @@ let allowedSerialNumbers: [UInt] = [
     30_617_000,  // 5C NFC (5.7.1)
     32_133_203,  // NFC FIPS (5.7.4)
     31_683_782,  // YubiKey 5C FIPS (5.7.4)
+    32_061_488,  // YubiKey 5Ci (5.7.1)
 ]
 
 enum TestableConnection: Equatable {

--- a/FullStackTests/Tests/CTAP2/CTAP2FullStackTests.swift
+++ b/FullStackTests/Tests/CTAP2/CTAP2FullStackTests.swift
@@ -132,7 +132,11 @@ struct CTAP2FullStackTests {
                 }
             }
 
-            if !ctap2Transport.isNFC {
+            switch ctap2Transport {
+            case .nfc, .lightning:
+                // SW_KEEPALIVE does not send status over these
+                break
+            default:
                 #expect(receivedWaitingForUser, "Should receive waitingForUser status during selection")
             }
             print("✅ Selection command successful")


### PR DESCRIPTION
This PR fixes FIDO tests by adjusting status update expectations for lightning connections and adds support for a new YubiKey device.

### Changes:

Updated test logic to skip SW_KEEPALIVE status checks for both NFC and lightning transports
Added serial number for YubiKey 5Ci device to the allowed connections list
