### PR TITLE
WebAuthn Sample App

### DIFF
--- a/FullStackTests/FullStackTests.xcodeproj/xcshareddata/xcschemes/FullStackTests.xcscheme
+++ b/FullStackTests/FullStackTests.xcodeproj/xcshareddata/xcschemes/FullStackTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1630"
+   LastUpgradeVersion = "2620"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Samples/OATHSample/OATHSample.xcodeproj/xcshareddata/xcschemes/OATHSample.xcscheme
+++ b/Samples/OATHSample/OATHSample.xcodeproj/xcshareddata/xcschemes/OATHSample.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1630"
+   LastUpgradeVersion = "2620"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Samples/WebAuthnInterceptorSample/README.md
+++ b/Samples/WebAuthnInterceptorSample/README.md
@@ -1,6 +1,6 @@
 # WebAuthnInterceptorSample
 
-Sample app demonstrating FIDO2/WebAuthn functionality by intercepting browser credentials API in a WKWebView and routing requests to a YubiKey.
+Sample app that bypasses WebKit's WebAuthn implementation and uses the YubiKit SDK instead, giving you full control over the authentication flow, PIN UI, and access to extensions like PRF.
 
 ## Overview
 

--- a/Samples/WebAuthnInterceptorSample/README.md
+++ b/Samples/WebAuthnInterceptorSample/README.md
@@ -1,0 +1,26 @@
+# WebAuthnInterceptorSample
+
+Sample app demonstrating FIDO2/WebAuthn functionality by intercepting browser credentials API in a WKWebView and routing requests to a YubiKey.
+
+## Overview
+
+This sample app shows how to:
+- Intercept `navigator.credentials.create()` and `navigator.credentials.get()` in a WKWebView
+- Route WebAuthn requests to YubiKey via NFC (iOS) or USB HID (macOS)
+- Handle PIN entry and verification
+- Support PRF extension (hmac-secret) for deriving secrets from credentials
+
+## Documentation
+
+For a detailed walkthrough of this sample, see the [WebAuthnInterceptorSample documentation](https://yubico.github.io/yubikit-swift/documentation/yubikit/webauthninterceptorsamplecode).
+
+## Build and Run
+
+Open `WebAuthnInterceptorSample.xcodeproj` in Xcode and run on a physical device (iOS) or macOS.
+
+## Usage
+
+1. Navigate to a WebAuthn-enabled site (defaults to demo.yubico.com)
+2. Register or authenticate with your YubiKey
+3. Enter PIN when prompted
+4. Tap (NFC) or insert (USB) your YubiKey

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample.xcodeproj/project.pbxproj
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		AA000008273D537800F999A4 /* YubiKit in Frameworks */ = {isa = PBXBuildFile; productRef = AA000031273D537800F999A4 /* YubiKit */; };
 		AA000009273D537500F999A4 /* PINEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00001A273D537500F999A4 /* PINEntryView.swift */; };
 		AA00000A273D537500F999A4 /* WebAuthnClientLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00001B273D537500F999A4 /* WebAuthnClientLogic.swift */; };
+		AA00000B273D537500F999A4 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00001C273D537500F999A4 /* Log.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -32,6 +33,7 @@
 		AA000019273D537800F999A4 /* WebAuthnInterceptorSample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = WebAuthnInterceptorSample.entitlements; sourceTree = "<group>"; };
 		AA00001A273D537500F999A4 /* PINEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PINEntryView.swift; sourceTree = "<group>"; };
 		AA00001B273D537500F999A4 /* WebAuthnClientLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebAuthnClientLogic.swift; sourceTree = "<group>"; };
+		AA00001C273D537500F999A4 /* Log.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -66,6 +68,7 @@
 				AA000014273D537500F999A4 /* WebAuthnHandler.swift */,
 				AA000015273D537500F999A4 /* WebAuthnTypes.swift */,
 				AA00001B273D537500F999A4 /* WebAuthnClientLogic.swift */,
+				AA00001C273D537500F999A4 /* Log.swift */,
 				AA000016273D537500F999A4 /* Interceptor.js */,
 				AA000017273D537800F999A4 /* Assets.xcassets */,
 			);
@@ -163,6 +166,7 @@
 				AA000004273D537500F999A4 /* WebAuthnHandler.swift in Sources */,
 				AA000005273D537500F999A4 /* WebAuthnTypes.swift in Sources */,
 				AA00000A273D537500F999A4 /* WebAuthnClientLogic.swift in Sources */,
+				AA00000B273D537500F999A4 /* Log.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample.xcodeproj/project.pbxproj
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample.xcodeproj/project.pbxproj
@@ -10,8 +10,8 @@
 		AA000001273D537500F999A4 /* WebAuthnInterceptorSampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000011273D537500F999A4 /* WebAuthnInterceptorSampleApp.swift */; };
 		AA000002273D537500F999A4 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000012273D537500F999A4 /* ContentView.swift */; };
 		AA000003273D537500F999A4 /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000013273D537500F999A4 /* WebView.swift */; };
-		AA000004273D537500F999A4 /* Bridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000014273D537500F999A4 /* Bridge.swift */; };
-		AA000005273D537500F999A4 /* BridgeTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000015273D537500F999A4 /* BridgeTypes.swift */; };
+		AA000004273D537500F999A4 /* WebAuthnHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000014273D537500F999A4 /* WebAuthnHandler.swift */; };
+		AA000005273D537500F999A4 /* WebAuthnTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000015273D537500F999A4 /* WebAuthnTypes.swift */; };
 		AA000006273D537500F999A4 /* Interceptor.js in Resources */ = {isa = PBXBuildFile; fileRef = AA000016273D537500F999A4 /* Interceptor.js */; };
 		AA000007273D537800F999A4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AA000017273D537800F999A4 /* Assets.xcassets */; };
 		AA000008273D537800F999A4 /* YubiKit in Frameworks */ = {isa = PBXBuildFile; productRef = AA000031273D537800F999A4 /* YubiKit */; };
@@ -24,8 +24,8 @@
 		AA000011273D537500F999A4 /* WebAuthnInterceptorSampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebAuthnInterceptorSampleApp.swift; sourceTree = "<group>"; };
 		AA000012273D537500F999A4 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		AA000013273D537500F999A4 /* WebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
-		AA000014273D537500F999A4 /* Bridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bridge.swift; sourceTree = "<group>"; };
-		AA000015273D537500F999A4 /* BridgeTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeTypes.swift; sourceTree = "<group>"; };
+		AA000014273D537500F999A4 /* WebAuthnHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebAuthnHandler.swift; sourceTree = "<group>"; };
+		AA000015273D537500F999A4 /* WebAuthnTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebAuthnTypes.swift; sourceTree = "<group>"; };
 		AA000016273D537500F999A4 /* Interceptor.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = Interceptor.js; sourceTree = "<group>"; };
 		AA000017273D537800F999A4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		AA000018273D537800F999A4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -63,8 +63,8 @@
 				AA000012273D537500F999A4 /* ContentView.swift */,
 				AA000013273D537500F999A4 /* WebView.swift */,
 				AA00001A273D537500F999A4 /* PINEntryView.swift */,
-				AA000014273D537500F999A4 /* Bridge.swift */,
-				AA000015273D537500F999A4 /* BridgeTypes.swift */,
+				AA000014273D537500F999A4 /* WebAuthnHandler.swift */,
+				AA000015273D537500F999A4 /* WebAuthnTypes.swift */,
 				AA00001B273D537500F999A4 /* WebAuthnClientLogic.swift */,
 				AA000016273D537500F999A4 /* Interceptor.js */,
 				AA000017273D537800F999A4 /* Assets.xcassets */,
@@ -160,8 +160,8 @@
 				AA000002273D537500F999A4 /* ContentView.swift in Sources */,
 				AA000003273D537500F999A4 /* WebView.swift in Sources */,
 				AA000009273D537500F999A4 /* PINEntryView.swift in Sources */,
-				AA000004273D537500F999A4 /* Bridge.swift in Sources */,
-				AA000005273D537500F999A4 /* BridgeTypes.swift in Sources */,
+				AA000004273D537500F999A4 /* WebAuthnHandler.swift in Sources */,
+				AA000005273D537500F999A4 /* WebAuthnTypes.swift in Sources */,
 				AA00000A273D537500F999A4 /* WebAuthnClientLogic.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample.xcodeproj/project.pbxproj
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		AA000007273D537800F999A4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AA000017273D537800F999A4 /* Assets.xcassets */; };
 		AA000008273D537800F999A4 /* YubiKit in Frameworks */ = {isa = PBXBuildFile; productRef = AA000031273D537800F999A4 /* YubiKit */; };
 		AA000009273D537500F999A4 /* PINEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00001A273D537500F999A4 /* PINEntryView.swift */; };
+		AA00000A273D537500F999A4 /* WebAuthnClientLogic.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00001B273D537500F999A4 /* WebAuthnClientLogic.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -30,6 +31,7 @@
 		AA000018273D537800F999A4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		AA000019273D537800F999A4 /* WebAuthnInterceptorSample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = WebAuthnInterceptorSample.entitlements; sourceTree = "<group>"; };
 		AA00001A273D537500F999A4 /* PINEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PINEntryView.swift; sourceTree = "<group>"; };
+		AA00001B273D537500F999A4 /* WebAuthnClientLogic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebAuthnClientLogic.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -63,6 +65,7 @@
 				AA00001A273D537500F999A4 /* PINEntryView.swift */,
 				AA000014273D537500F999A4 /* Bridge.swift */,
 				AA000015273D537500F999A4 /* BridgeTypes.swift */,
+				AA00001B273D537500F999A4 /* WebAuthnClientLogic.swift */,
 				AA000016273D537500F999A4 /* Interceptor.js */,
 				AA000017273D537800F999A4 /* Assets.xcassets */,
 			);
@@ -159,6 +162,7 @@
 				AA000009273D537500F999A4 /* PINEntryView.swift in Sources */,
 				AA000004273D537500F999A4 /* Bridge.swift in Sources */,
 				AA000005273D537500F999A4 /* BridgeTypes.swift in Sources */,
+				AA00000A273D537500F999A4 /* WebAuthnClientLogic.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample.xcodeproj/project.pbxproj
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample.xcodeproj/project.pbxproj
@@ -1,0 +1,403 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 60;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		AA000001273D537500F999A4 /* WebAuthnInterceptorSampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000011273D537500F999A4 /* WebAuthnInterceptorSampleApp.swift */; };
+		AA000002273D537500F999A4 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000012273D537500F999A4 /* ContentView.swift */; };
+		AA000003273D537500F999A4 /* WebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000013273D537500F999A4 /* WebView.swift */; };
+		AA000004273D537500F999A4 /* Bridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000014273D537500F999A4 /* Bridge.swift */; };
+		AA000005273D537500F999A4 /* BridgeTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000015273D537500F999A4 /* BridgeTypes.swift */; };
+		AA000006273D537500F999A4 /* Interceptor.js in Resources */ = {isa = PBXBuildFile; fileRef = AA000016273D537500F999A4 /* Interceptor.js */; };
+		AA000007273D537800F999A4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AA000017273D537800F999A4 /* Assets.xcassets */; };
+		AA000008273D537800F999A4 /* YubiKit in Frameworks */ = {isa = PBXBuildFile; productRef = AA000031273D537800F999A4 /* YubiKit */; };
+		AA000009273D537500F999A4 /* PINEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00001A273D537500F999A4 /* PINEntryView.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		AA000010273D537500F999A4 /* WebAuthnInterceptorSample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WebAuthnInterceptorSample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		AA000011273D537500F999A4 /* WebAuthnInterceptorSampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebAuthnInterceptorSampleApp.swift; sourceTree = "<group>"; };
+		AA000012273D537500F999A4 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		AA000013273D537500F999A4 /* WebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebView.swift; sourceTree = "<group>"; };
+		AA000014273D537500F999A4 /* Bridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bridge.swift; sourceTree = "<group>"; };
+		AA000015273D537500F999A4 /* BridgeTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BridgeTypes.swift; sourceTree = "<group>"; };
+		AA000016273D537500F999A4 /* Interceptor.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = Interceptor.js; sourceTree = "<group>"; };
+		AA000017273D537800F999A4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		AA000018273D537800F999A4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		AA000019273D537800F999A4 /* WebAuthnInterceptorSample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = WebAuthnInterceptorSample.entitlements; sourceTree = "<group>"; };
+		AA00001A273D537500F999A4 /* PINEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PINEntryView.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		AA00000D273D537500F999A4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AA000008273D537800F999A4 /* YubiKit in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		AA000020273D537500F999A4 = {
+			isa = PBXGroup;
+			children = (
+				AA000021273D537500F999A4 /* WebAuthnInterceptorSample */,
+				AA000022273D537500F999A4 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		AA000021273D537500F999A4 /* WebAuthnInterceptorSample */ = {
+			isa = PBXGroup;
+			children = (
+				AA000018273D537800F999A4 /* Info.plist */,
+				AA000019273D537800F999A4 /* WebAuthnInterceptorSample.entitlements */,
+				AA000011273D537500F999A4 /* WebAuthnInterceptorSampleApp.swift */,
+				AA000012273D537500F999A4 /* ContentView.swift */,
+				AA000013273D537500F999A4 /* WebView.swift */,
+				AA00001A273D537500F999A4 /* PINEntryView.swift */,
+				AA000014273D537500F999A4 /* Bridge.swift */,
+				AA000015273D537500F999A4 /* BridgeTypes.swift */,
+				AA000016273D537500F999A4 /* Interceptor.js */,
+				AA000017273D537800F999A4 /* Assets.xcassets */,
+			);
+			path = WebAuthnInterceptorSample;
+			sourceTree = "<group>";
+		};
+		AA000022273D537500F999A4 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				AA000010273D537500F999A4 /* WebAuthnInterceptorSample.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		AA00000F273D537500F999A4 /* WebAuthnInterceptorSample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AA00001B273D537900F999A4 /* Build configuration list for PBXNativeTarget "WebAuthnInterceptorSample" */;
+			buildPhases = (
+				AA00000C273D537500F999A4 /* Sources */,
+				AA00000D273D537500F999A4 /* Frameworks */,
+				AA00000E273D537500F999A4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = WebAuthnInterceptorSample;
+			packageProductDependencies = (
+				AA000031273D537800F999A4 /* YubiKit */,
+			);
+			productName = WebAuthnInterceptorSample;
+			productReference = AA000010273D537500F999A4 /* WebAuthnInterceptorSample.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		AA000023273D537500F999A4 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1500;
+				LastUpgradeCheck = 2620;
+				TargetAttributes = {
+					AA00000F273D537500F999A4 = {
+						CreatedOnToolsVersion = 15.0;
+					};
+				};
+			};
+			buildConfigurationList = AA000024273D537500F999A4 /* Build configuration list for PBXProject "WebAuthnInterceptorSample" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = AA000020273D537500F999A4;
+			packageReferences = (
+				AA000030273D537800F999A4 /* XCLocalSwiftPackageReference "../../" */,
+			);
+			productRefGroup = AA000022273D537500F999A4 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				AA00000F273D537500F999A4 /* WebAuthnInterceptorSample */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		AA00000E273D537500F999A4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AA000007273D537800F999A4 /* Assets.xcassets in Resources */,
+				AA000006273D537500F999A4 /* Interceptor.js in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		AA00000C273D537500F999A4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AA000001273D537500F999A4 /* WebAuthnInterceptorSampleApp.swift in Sources */,
+				AA000002273D537500F999A4 /* ContentView.swift in Sources */,
+				AA000003273D537500F999A4 /* WebView.swift in Sources */,
+				AA000009273D537500F999A4 /* PINEntryView.swift in Sources */,
+				AA000004273D537500F999A4 /* Bridge.swift in Sources */,
+				AA000005273D537500F999A4 /* BridgeTypes.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		AA000025273D537900F999A4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = LQA3CS5MM7;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		AA000026273D537900F999A4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = LQA3CS5MM7;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		AA000027273D537900F999A4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = WebAuthnInterceptorSample/WebAuthnInterceptorSample.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = WebAuthnInterceptorSample/Info.plist;
+				INFOPLIST_KEY_NFCReaderUsageDescription = "This app uses NFC to communicate with your YubiKey for WebAuthn operations.";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yubico.ios.WebAuthnInterceptorSample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		AA000028273D537900F999A4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = WebAuthnInterceptorSample/WebAuthnInterceptorSample.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = WebAuthnInterceptorSample/Info.plist;
+				INFOPLIST_KEY_NFCReaderUsageDescription = "This app uses NFC to communicate with your YubiKey for WebAuthn operations.";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yubico.ios.WebAuthnInterceptorSample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		AA00001B273D537900F999A4 /* Build configuration list for PBXNativeTarget "WebAuthnInterceptorSample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AA000027273D537900F999A4 /* Debug */,
+				AA000028273D537900F999A4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		AA000024273D537500F999A4 /* Build configuration list for PBXProject "WebAuthnInterceptorSample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AA000025273D537900F999A4 /* Debug */,
+				AA000026273D537900F999A4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		AA000030273D537800F999A4 /* XCLocalSwiftPackageReference "../../" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../../;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		AA000031273D537800F999A4 /* YubiKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AA000030273D537800F999A4 /* XCLocalSwiftPackageReference "../../" */;
+			productName = YubiKit;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = AA000023273D537500F999A4 /* Project object */;
+}

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,63 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "16x16"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "32x32"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "128x128"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "256x256"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "1x",
+      "size" : "512x512"
+    },
+    {
+      "idiom" : "mac",
+      "scale" : "2x",
+      "size" : "512x512"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/Assets.xcassets/Contents.json
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/Bridge.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/Bridge.swift
@@ -238,17 +238,8 @@ actor Bridge {
         }
 
         if let prf = state.prf, let prfResult = try prf.makeCredential.output(from: response) {
-            switch prfResult {
-            case .enabled:
-                trace("PRF extension enabled")
-                results.prf = PRFOutput(enabled: true)
-            case .secrets(let secrets):
-                trace("PRF extension returned secrets (hmac-secret-mc)")
-                results.prf = PRFOutput(
-                    first: secrets.first.base64urlEncodedString(),
-                    second: secrets.second?.base64urlEncodedString()
-                )
-            }
+            trace("PRF extension result received")
+            results.prf = PRFOutput(prfResult)
         }
 
         return results
@@ -337,10 +328,7 @@ actor Bridge {
 
         if let prf = state.prf, let secrets = try prf.getAssertion.output(from: response) {
             trace("PRF extension returned secrets")
-            results.prf = PRFOutput(
-                first: secrets.first.base64urlEncodedString(),
-                second: secrets.second?.base64urlEncodedString()
-            )
+            results.prf = PRFOutput(secrets)
         }
 
         return results

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/Bridge.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/Bridge.swift
@@ -1,0 +1,370 @@
+//
+//  Bridge.swift
+//  WebAuthnInterceptorSample
+//
+
+import CryptoKit
+import Foundation
+import YubiKit
+
+func trace(_ message: String, file: String = #file, line: Int = #line) {
+    let filename = (file as NSString).lastPathComponent
+    print("[TRACE] \(filename):\(line) - \(message)")
+}
+
+actor Bridge {
+
+    // MARK: - State & Init
+    private var connection: (any Connection)?
+    private let pinProvider: @Sendable (String?) async -> String?
+
+    init(pinProvider: @escaping @Sendable (String?) async -> String?) {
+        self.pinProvider = pinProvider
+        trace("Bridge initialized")
+    }
+
+    // MARK: - Session Management
+    #if os(iOS)
+    private func makeSession(alertMessage: String = "Tap your YubiKey") async throws -> CTAP2.Session {
+        trace("Requesting NFC connection...")
+        let conn = try await NFCSmartCardConnection(alertMessage: alertMessage)
+        connection = conn
+        trace("Connection established, creating CTAP2 session...")
+        let session = try await CTAP2.Session.makeSession(connection: conn)
+        trace("CTAP2 session created")
+        return session
+    }
+    #else
+    private func makeSession() async throws -> CTAP2.Session {
+        trace("Waiting for USB HID FIDO connection...")
+        let conn = try await HIDFIDOConnection()
+        connection = conn
+        trace("Connection established, creating CTAP2 session...")
+        let session = try await CTAP2.Session.makeSession(connection: conn)
+        trace("CTAP2 session created")
+        return session
+    }
+    #endif
+
+    private func closeConnection(message: String? = nil) async {
+        trace("Closing connection" + (message.map { ": \($0)" } ?? ""))
+        #if os(iOS)
+        if let nfc = connection as? NFCSmartCardConnection {
+            await nfc.close(message: message)
+        } else {
+            await connection?.close(error: nil)
+        }
+        #else
+        await connection?.close(error: nil)
+        #endif
+        connection = nil
+    }
+
+    // MARK: - PIN Flow
+    private func promptForPin(_ errorMessage: String?) async throws -> String {
+        trace("PIN required, requesting from user...")
+        guard let pin = await pinProvider(errorMessage) else {
+            trace("User cancelled PIN entry")
+            throw BridgeError.userCancelled
+        }
+        return pin
+    }
+
+    /// Get PIN token if device requires PIN. iOS uses two-tap flow (close NFC, ask PIN, reconnect).
+    private func getPinTokenIfNeeded(
+        session: CTAP2.Session,
+        permissions: CTAP2.ClientPin.Permission,
+        rpId: String
+    ) async throws -> (session: CTAP2.Session, pinToken: CTAP2.ClientPin.Token?) {
+        let info = try await session.getInfo()
+        trace("Device clientPin option: \(String(describing: info.options.clientPin))")
+
+        guard info.options.clientPin == true else {
+            return (session, nil)
+        }
+
+        #if os(iOS)
+        await closeConnection(message: "Enter PIN")
+        #endif
+
+        var errorMessage: String?
+        var currentSession = session
+        while true {
+            let pin = try await promptForPin(errorMessage)
+
+            #if os(iOS)
+            trace("Got PIN, reconnecting...")
+            currentSession = try await makeSession(alertMessage: "Tap again to complete")
+            #endif
+
+            trace("Obtaining PIN token...")
+            do throws(CTAP2.SessionError) {
+                let token = try await currentSession.getPinUVToken(
+                    using: .pin(pin),
+                    permissions: permissions,
+                    rpId: rpId
+                )
+                return (currentSession, token)
+            } catch {
+                if case .ctapError(.pinInvalid, _) = error {
+                    trace("Invalid PIN, retrying...")
+                    #if os(iOS)
+                    await closeConnection(message: "Invalid PIN")
+                    #endif
+                    errorMessage = "Invalid PIN. Please try again."
+                } else {
+                    throw error
+                }
+            }
+        }
+    }
+
+    // MARK: - Operations
+    func handleCreate(_ data: Data) async throws -> String {
+        trace("handleCreate: \(String(data: data, encoding: .utf8) ?? "nil")")
+        let wrapper = try JSONDecoder().decode(CreateRequestWrapper.self, from: data)
+        let request = wrapper.request
+        let origin = wrapper.origin
+        let rpId = request.rp.effectiveId(origin: origin)
+        trace("RP: \(rpId), User: \(request.user.name ?? "nil"), Origin: \(origin)")
+
+        defer { Task { await closeConnection() } }
+        var session = try await makeSession()
+
+        let rpEntity = WebAuthn.PublicKeyCredential.RPEntity(id: rpId, name: request.rp.name)
+        let userEntity = WebAuthn.PublicKeyCredential.UserEntity(
+            id: Data(base64urlDecoding: request.user.id) ?? Data(),
+            name: request.user.name,
+            displayName: request.user.displayName
+        )
+
+        let pubKeyParams = request.pubKeyCredParams.map { COSE.Algorithm(rawValue: $0.alg) }
+        let excludeList = request.excludeCredentials?.compactMap { $0.toDescriptor() }
+        if let count = excludeList?.count { trace("Exclude list has \(count) credentials") }
+
+        let residentKeyRequired =
+            request.authenticatorSelection?.residentKey == "required"
+            || request.authenticatorSelection?.residentKey == "preferred"
+            || request.authenticatorSelection?.requireResidentKey == true
+        let options = CTAP2.MakeCredential.Parameters.Options(
+            rk: residentKeyRequired,
+            uv: request.authenticatorSelection?.userVerification == "required"
+        )
+
+        let (activeSession, pinToken) = try await getPinTokenIfNeeded(
+            session: session,
+            permissions: .makeCredential,
+            rpId: rpId
+        )
+        session = activeSession
+
+        let extState = try await buildCreateExtensions(request: request, session: session)
+        let clientDataJSON = try request.clientDataJSON(origin: origin)
+        let clientDataHash = Data(SHA256.hash(data: clientDataJSON))
+
+        let params = CTAP2.MakeCredential.Parameters(
+            clientDataHash: clientDataHash,
+            rp: rpEntity,
+            user: userEntity,
+            pubKeyCredParams: pubKeyParams,
+            excludeList: excludeList,
+            extensions: extState.inputs,
+            options: options
+        )
+
+        trace("Calling makeCredential...")
+        let response = try await session.makeCredential(parameters: params, pinToken: pinToken).value
+        let extensionResults = try extractCreateExtensionResults(state: extState, response: response)
+
+        let credentials = CredentialResponse(
+            clientDataJSON: clientDataJSON,
+            makeCredentialResponse: response,
+            extensionResults: extensionResults.isEmpty ? nil : extensionResults
+        )
+        return try encodeResponse(credentials, operation: "handleCreate")
+    }
+
+    private struct CreateExtensionState {
+        var inputs: [CTAP2.Extension.MakeCredential.Input] = []
+        var credProtect: CTAP2.Extension.CredProtect?
+        var prf: WebAuthn.Extension.PRF?
+    }
+
+    // MARK: - Extensions
+    private func buildCreateExtensions(
+        request: CreateRequest,
+        session: CTAP2.Session
+    ) async throws -> CreateExtensionState {
+        var state = CreateExtensionState()
+
+        if let credProtectLevel = request.extensions?.credProtect,
+            let level = CTAP2.Extension.CredProtect.Level(rawValue: credProtectLevel)
+        {
+            trace("Adding credProtect extension with level \(credProtectLevel)")
+            let credProtect = try await CTAP2.Extension.CredProtect(level: level, session: session)
+            state.inputs.append(credProtect.input())
+            state.credProtect = credProtect
+        }
+
+        if let prfEval = request.extensions?.prf?.eval,
+            let firstData = Data(base64urlDecoding: prfEval.first)
+        {
+            trace("Adding PRF extension for makeCredential with secrets")
+            let prf = try await WebAuthn.Extension.PRF(session: session)
+            let secondData = prfEval.second.flatMap { Data(base64urlDecoding: $0) }
+            state.inputs.append(try prf.makeCredential.input(first: firstData, second: secondData))
+            state.prf = prf
+        } else if request.extensions?.hmacCreateSecret == true || request.extensions?.prf != nil {
+            trace("Adding PRF extension for makeCredential (enable only)")
+            let prf = try await WebAuthn.Extension.PRF(session: session)
+            state.inputs.append(prf.makeCredential.input())
+            state.prf = prf
+        }
+
+        return state
+    }
+
+    private func extractCreateExtensionResults(
+        state: CreateExtensionState,
+        response: CTAP2.MakeCredential.Response
+    ) throws -> ExtensionResults {
+        var results = ExtensionResults()
+
+        if let credProtect = state.credProtect,
+            let level = credProtect.output(from: response)
+        {
+            trace("credProtect applied with level \(level.rawValue)")
+            results.credProtect = level.rawValue
+        }
+
+        if let prf = state.prf, let prfResult = try prf.makeCredential.output(from: response) {
+            switch prfResult {
+            case .enabled:
+                trace("PRF extension enabled")
+                results.prf = PRFOutput(enabled: true)
+            case .secrets(let secrets):
+                trace("PRF extension returned secrets (hmac-secret-mc)")
+                results.prf = PRFOutput(
+                    first: secrets.first.base64urlEncodedString(),
+                    second: secrets.second?.base64urlEncodedString()
+                )
+            }
+        }
+
+        return results
+    }
+
+    // MARK: - Operations
+    func handleGet(_ data: Data) async throws -> String {
+        trace("handleGet: \(String(data: data, encoding: .utf8) ?? "nil")")
+        let wrapper = try JSONDecoder().decode(GetRequestWrapper.self, from: data)
+        let request = wrapper.request
+        let origin = wrapper.origin
+        let rpId = request.effectiveRpId(origin: origin)
+        trace("RP: \(rpId), Origin: \(origin)")
+
+        defer { Task { await closeConnection() } }
+        var session = try await makeSession()
+
+        let allowList = request.allowCredentials?.compactMap { $0.toDescriptor() }
+        if let count = allowList?.count { trace("Allow list has \(count) credentials") }
+
+        let options = CTAP2.GetAssertion.Parameters.Options(
+            uv: request.userVerification == "required"
+        )
+
+        let (activeSession, pinToken) = try await getPinTokenIfNeeded(
+            session: session,
+            permissions: .getAssertion,
+            rpId: rpId
+        )
+        session = activeSession
+
+        let extState = try await buildGetExtensions(request: request, session: session)
+        let clientDataJSON = try request.clientDataJSON(origin: origin)
+        let clientDataHash = Data(SHA256.hash(data: clientDataJSON))
+
+        let params = CTAP2.GetAssertion.Parameters(
+            rpId: rpId,
+            clientDataHash: clientDataHash,
+            allowList: allowList,
+            extensions: extState.inputs,
+            options: options
+        )
+
+        trace("Calling getAssertion...")
+        let response = try await session.getAssertion(parameters: params, pinToken: pinToken).value
+        let extensionResults = try extractGetExtensionResults(state: extState, response: response)
+
+        let credentials = CredentialResponse(
+            clientDataJSON: clientDataJSON,
+            getAssertionResponse: response,
+            extensionResults: extensionResults.isEmpty ? nil : extensionResults
+        )
+        return try encodeResponse(credentials, operation: "handleGet")
+    }
+
+    private struct GetExtensionState {
+        var inputs: [CTAP2.Extension.GetAssertion.Input] = []
+        var prf: WebAuthn.Extension.PRF?
+    }
+
+    // MARK: - Extensions
+    private func buildGetExtensions(
+        request: GetRequest,
+        session: CTAP2.Session
+    ) async throws -> GetExtensionState {
+        var state = GetExtensionState()
+
+        if let prfEval = request.extensions?.prf?.eval,
+            let firstData = Data(base64urlDecoding: prfEval.first)
+        {
+            trace("Adding PRF extension")
+            let prf = try await WebAuthn.Extension.PRF(session: session)
+            let secondData = prfEval.second.flatMap { Data(base64urlDecoding: $0) }
+            state.inputs.append(try prf.getAssertion.input(first: firstData, second: secondData))
+            state.prf = prf
+        }
+
+        return state
+    }
+
+    private func extractGetExtensionResults(
+        state: GetExtensionState,
+        response: CTAP2.GetAssertion.Response
+    ) throws -> ExtensionResults {
+        var results = ExtensionResults()
+
+        if let prf = state.prf, let secrets = try prf.getAssertion.output(from: response) {
+            trace("PRF extension returned secrets")
+            results.prf = PRFOutput(
+                first: secrets.first.base64urlEncodedString(),
+                second: secrets.second?.base64urlEncodedString()
+            )
+        }
+
+        return results
+    }
+
+    // MARK: - Encoding
+    private func encodeResponse(_ credentials: CredentialResponse, operation: String) throws -> String {
+        let jsonData = try JSONEncoder().encode(credentials)
+        let jsonString = String(data: jsonData, encoding: .utf8) ?? ""
+        trace("\(operation) completed successfully")
+        trace("Response: \(jsonString)")
+        return jsonString
+    }
+}
+
+// MARK: - BridgeError
+
+enum BridgeError: LocalizedError {
+    case userCancelled
+
+    var errorDescription: String? {
+        switch self {
+        case .userCancelled:
+            return "User cancelled the operation"
+        }
+    }
+}

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/BridgeTypes.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/BridgeTypes.swift
@@ -1,0 +1,277 @@
+//
+//  BridgeTypes.swift
+//  WebAuthnInterceptorSample
+//
+//  Types for JSON serialization between browser WebAuthn API and YubiKit SDK.
+//
+
+import Foundation
+import YubiKit
+
+// MARK: - Browser → SDK (Input)
+
+struct CreateRequestWrapper: Decodable {
+    let type: String
+    let origin: String
+    let request: CreateRequest
+}
+
+struct CreateRequest: Decodable {
+    let rp: RelyingParty
+    let user: User
+    let challenge: String
+    let pubKeyCredParams: [PubKeyCredParams]
+    let excludeCredentials: [CredentialDescriptor]?
+    let authenticatorSelection: AuthenticatorSelection?
+    let attestation: String?
+    let extensions: CreateExtensions?
+
+    func clientDataJSON(origin: String) throws -> Data {
+        try makeClientDataJSON(type: "webauthn.create", challenge: challenge, origin: origin)
+    }
+}
+
+struct GetRequestWrapper: Decodable {
+    let type: String
+    let origin: String
+    let request: GetRequest
+}
+
+struct GetRequest: Decodable {
+    let rpId: String?
+    let challenge: String
+    let allowCredentials: [CredentialDescriptor]?
+    let userVerification: String?
+    let extensions: GetExtensions?
+
+    func clientDataJSON(origin: String) throws -> Data {
+        try makeClientDataJSON(type: "webauthn.get", challenge: challenge, origin: origin)
+    }
+
+    func effectiveRpId(origin: String) -> String {
+        rpId ?? hostFromOrigin(origin)
+    }
+}
+
+// MARK: - Helpers
+private func makeClientDataJSON(type: String, challenge: String, origin: String) throws -> Data {
+    let clientData: [String: Any] = [
+        "type": type,
+        "challenge": challenge,
+        "origin": origin,
+        "crossOrigin": false,
+    ]
+    return try JSONSerialization.data(withJSONObject: clientData)
+}
+
+private func hostFromOrigin(_ origin: String) -> String {
+    if let url = URL(string: origin), let host = url.host { return host }
+    return origin
+}
+
+struct CreateExtensions: Decodable {
+    let credProtect: Int?
+    let hmacCreateSecret: Bool?
+    let prf: PRFInput?
+}
+
+struct GetExtensions: Decodable {
+    let prf: PRFInput?
+}
+
+struct PRFInput: Decodable {
+    let eval: PRFEval?
+}
+
+struct PRFEval: Decodable {
+    let first: String  // base64url encoded
+    let second: String?
+}
+
+// MARK: - SDK → Browser (Output)
+
+struct CredentialResponse: Codable {
+    let type: String
+    let id: String?
+    let rawId: String?
+    let response: AuthenticatorResponse
+    let clientExtensionResults: ExtensionResults?
+    let authenticatorAttachment: String?
+
+    init(
+        clientDataJSON: Data,
+        makeCredentialResponse: CTAP2.MakeCredential.Response,
+        extensionResults: ExtensionResults? = nil
+    ) {
+        let credentialId = makeCredentialResponse.authenticatorData.attestedCredentialData?.credentialId
+            .base64urlEncodedString()
+        self.type = "public-key"
+        self.id = credentialId
+        self.rawId = credentialId
+        self.response = AuthenticatorResponse(
+            clientDataJSON: clientDataJSON,
+            makeCredentialResponse: makeCredentialResponse
+        )
+        self.clientExtensionResults = extensionResults
+        self.authenticatorAttachment = "cross-platform"
+    }
+
+    init(
+        clientDataJSON: Data,
+        getAssertionResponse: CTAP2.GetAssertion.Response,
+        extensionResults: ExtensionResults? = nil
+    ) {
+        let credentialId = getAssertionResponse.credential?.id.base64urlEncodedString()
+        self.type = "public-key"
+        self.id = credentialId
+        self.rawId = credentialId
+        self.response = AuthenticatorResponse(
+            clientDataJSON: clientDataJSON,
+            getAssertionResponse: getAssertionResponse
+        )
+        self.clientExtensionResults = extensionResults
+        self.authenticatorAttachment = "cross-platform"
+    }
+}
+
+struct AuthenticatorResponse: Codable {
+    let clientDataJSON: String
+    let authenticatorData: String
+    let signature: String?
+    let userHandle: String?
+    let transports: [String]?
+    let attestationObject: String?
+    let publicKeyAlgorithm: Int?
+
+    init(clientDataJSON: Data, makeCredentialResponse response: CTAP2.MakeCredential.Response) {
+        self.clientDataJSON = clientDataJSON.base64urlEncodedString()
+        self.authenticatorData = response.authenticatorData.rawData.base64urlEncodedString()
+        self.signature = nil
+        self.userHandle = nil
+        self.transports = ["nfc", "usb"]
+        self.attestationObject = response.attestationObject.rawData.base64urlEncodedString()
+        self.publicKeyAlgorithm =
+            response.authenticatorData.attestedCredentialData?.credentialPublicKey.algorithmRawValue
+    }
+
+    init(clientDataJSON: Data, getAssertionResponse response: CTAP2.GetAssertion.Response) {
+        self.clientDataJSON = clientDataJSON.base64urlEncodedString()
+        self.authenticatorData = response.authenticatorData.rawData.base64urlEncodedString()
+        self.signature = response.signature.base64urlEncodedString()
+        self.userHandle = response.user?.id.base64urlEncodedString()
+        self.transports = nil
+        self.attestationObject = nil
+        self.publicKeyAlgorithm = nil
+    }
+}
+
+struct ExtensionResults: Codable {
+    var prf: PRFOutput?
+    var hmacCreateSecret: Bool?
+    var credProtect: Int?
+
+    var isEmpty: Bool { prf == nil && hmacCreateSecret == nil && credProtect == nil }
+}
+
+struct PRFOutput: Codable {
+    let enabled: Bool?
+    let results: PRFSecrets?
+
+    /// For makeCredential when PRF is just enabled (no hmac-secret-mc)
+    init(enabled: Bool) {
+        self.enabled = enabled
+        self.results = nil
+    }
+
+    /// For getAssertion or makeCredential with hmac-secret-mc secrets
+    init(first: String, second: String?) {
+        self.enabled = true
+        self.results = PRFSecrets(first: first, second: second)
+    }
+}
+
+struct PRFSecrets: Codable {
+    let first: String  // base64url encoded
+    let second: String?
+}
+
+// MARK: - Shared Types
+
+struct RelyingParty: Decodable {
+    let id: String?
+    let name: String?
+
+    func effectiveId(origin: String) -> String {
+        id ?? hostFromOrigin(origin)
+    }
+}
+
+struct User: Decodable {
+    let id: String
+    let name: String?
+    let displayName: String?
+}
+
+struct PubKeyCredParams: Decodable {
+    let type: String?
+    let alg: Int
+}
+
+struct AuthenticatorSelection: Decodable {
+    let requireResidentKey: Bool?
+    let residentKey: String?
+    let userVerification: String?
+}
+
+struct CredentialDescriptor: Decodable {
+    let type: String
+    let id: String?
+    let transports: [String]?
+
+    func toDescriptor() -> WebAuthn.PublicKeyCredential.Descriptor? {
+        guard let id else {
+            trace("CredentialDescriptor missing id")
+            return nil
+        }
+        guard let data = Data(base64urlDecoding: id) else {
+            trace("CredentialDescriptor failed to decode id: \(id)")
+            return nil
+        }
+        return WebAuthn.PublicKeyCredential.Descriptor(id: data)
+    }
+}
+
+// MARK: - Base64URL
+
+extension Data {
+    init?(base64urlDecoding string: String) {
+        var base64 =
+            string
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        while base64.count % 4 != 0 {
+            base64.append("=")
+        }
+        self.init(base64Encoded: base64)
+    }
+
+    func base64urlEncodedString() -> String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}
+
+// MARK: - COSE.Key Helper
+
+extension COSE.Key {
+    var algorithmRawValue: Int? {
+        switch self {
+        case .ec2(let alg, _, _, _, _): return alg.rawValue
+        case .okp(let alg, _, _, _): return alg.rawValue
+        case .rsa(let alg, _, _, _): return alg.rawValue
+        case .other: return nil
+        }
+    }
+}

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/ContentView.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/ContentView.swift
@@ -1,0 +1,61 @@
+//
+//  ContentView.swift
+//  WebAuthnInterceptorSample
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    private static let defaultURLString = "https://demo.yubico.com/webauthn-developers"
+
+    @State private var urlString = defaultURLString
+    @State private var currentURL = URL(string: defaultURLString)!
+    @StateObject private var pinHandler = PINRequestHandler()
+    @StateObject private var navigator = WebViewNavigator()
+
+    var body: some View {
+        VStack(spacing: 0) {
+            urlBar
+            WebView(url: currentURL, pinHandler: pinHandler, navigator: navigator)
+        }
+        .sheet(isPresented: $pinHandler.isShowingPINEntry) {
+            PINEntryView(
+                onSubmit: pinHandler.submitPIN,
+                onCancel: pinHandler.cancel,
+                errorMessage: pinHandler.errorMessage
+            )
+        }
+    }
+
+    private var urlBar: some View {
+        HStack {
+            Button(action: navigator.goBack) {
+                Image(systemName: "chevron.left")
+            }
+            .disabled(!navigator.canGoBack)
+
+            TextField("URL", text: $urlString)
+                .textFieldStyle(.roundedBorder)
+                #if os(iOS)
+            .textInputAutocapitalization(.never)
+                #endif
+                .disableAutocorrection(true)
+                .onSubmit(navigate)
+
+            Button("Go", action: navigate)
+                .buttonStyle(.borderedProminent)
+        }
+        .padding()
+    }
+
+    private func navigate() {
+        let hasScheme = urlString.hasPrefix("http://") || urlString.hasPrefix("https://")
+        let urlWithScheme = hasScheme ? urlString : "https://" + urlString
+        guard let url = URL(string: urlWithScheme) else { return }
+        currentURL = url
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/ContentView.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/ContentView.swift
@@ -1,9 +1,4 @@
-//
-//  ContentView.swift
-//  WebAuthnInterceptorSample
-//
-//  Main UI: URL bar with navigation controls and WebView.
-//
+/// Main UI: URL bar with navigation controls and WebView.
 
 import SwiftUI
 

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/ContentView.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/ContentView.swift
@@ -22,7 +22,7 @@ struct ContentView: View {
             urlBar
             WebView(url: currentURL, pinHandler: pinHandler, navigator: navigator)
         }
-        .sheet(isPresented: $pinHandler.isShowingPINEntry) {
+        .sheet(isPresented: $pinHandler.isShowingPINEntry, onDismiss: pinHandler.cancel) {
             PINEntryView(
                 onSubmit: pinHandler.submitPIN,
                 onCancel: pinHandler.cancel,

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/ContentView.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/ContentView.swift
@@ -2,8 +2,12 @@
 //  ContentView.swift
 //  WebAuthnInterceptorSample
 //
+//  Main UI: URL bar with navigation controls and WebView.
+//
 
 import SwiftUI
+
+// MARK: - Content View
 
 struct ContentView: View {
     private static let defaultURLString = "https://demo.yubico.com/webauthn-developers"
@@ -27,6 +31,8 @@ struct ContentView: View {
         }
     }
 
+    // MARK: - URL Bar
+
     private var urlBar: some View {
         HStack {
             Button(action: navigator.goBack) {
@@ -48,6 +54,8 @@ struct ContentView: View {
         .padding()
     }
 
+    // MARK: - Navigation
+
     private func navigate() {
         let hasScheme = urlString.hasPrefix("http://") || urlString.hasPrefix("https://")
         let urlWithScheme = hasScheme ? urlString : "https://" + urlString
@@ -55,6 +63,8 @@ struct ContentView: View {
         currentURL = url
     }
 }
+
+// MARK: - Preview
 
 #Preview {
     ContentView()

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/Info.plist
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/Info.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NFCReaderUsageDescription</key>
+	<string>This app uses NFC to communicate with your YubiKey for WebAuthn operations.</string>
+	<key>com.apple.developer.nfc.readersession.iso7816.select-identifiers</key>
+	<array>
+		<string>A0000006472F0001</string>
+		<string>A000000308</string>
+		<string>A0000005272101</string>
+		<string>A000000527471117</string>
+	</array>
+</dict>
+</plist>

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/Interceptor.js
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/Interceptor.js
@@ -7,9 +7,7 @@
 (function() {
     'use strict';
 
-    // ============================================================================
     // MARK: - Setup
-    // ============================================================================
 
     const originalCreate = navigator.credentials.create.bind(navigator.credentials);
     const originalGet = navigator.credentials.get.bind(navigator.credentials);
@@ -17,9 +15,7 @@
     let pendingResolve = null;
     let pendingReject = null;
 
-    // ============================================================================
     // MARK: - Native Callbacks
-    // ============================================================================
 
     window.__webauthn_callback__ = function(encoded) {
         console.log('[WebAuthn] Received success callback');
@@ -46,9 +42,7 @@
         }
     };
 
-    // ============================================================================
     // MARK: - Binary Decoding (Swift → JS)
-    // ============================================================================
 
     function base64urlDecode(str) {
         str = str.replace(/-/g, '+').replace(/_/g, '/');
@@ -74,9 +68,7 @@
         return result;
     }
 
-    // ============================================================================
     // MARK: - Binary Encoding (JS → Swift)
-    // ============================================================================
 
     function base64urlEncode(buffer) {
         const bytes = new Uint8Array(buffer);
@@ -99,9 +91,7 @@
         }));
     }
 
-    // ============================================================================
     // MARK: - Credential Decoding
-    // ============================================================================
 
     function decodeCredential(response) {
         // Decode all binary fields in one pass
@@ -152,9 +142,7 @@
         return credential;
     }
 
-    // ============================================================================
     // MARK: - Interception
-    // ============================================================================
 
     function shouldIntercept(options) {
         // Intercept all WebAuthn requests and route them to the YubiKey.
@@ -185,9 +173,7 @@
         });
     }
 
-    // ============================================================================
     // MARK: - API Patching
-    // ============================================================================
 
     navigator.credentials.create = function(options) {
         return interceptWebAuthn('create', options, originalCreate);

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/Interceptor.js
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/Interceptor.js
@@ -63,6 +63,8 @@
 
     // MARK: - Binary Encoding (JS → Swift)
 
+    // Note: Spread operator may hit stack limits for very large ArrayBuffers.
+    // Typical WebAuthn payloads are well under this limit.
     function base64Encode(buffer) {
         return btoa(String.fromCharCode(...new Uint8Array(buffer)));
     }

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/Interceptor.js
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/Interceptor.js
@@ -1,0 +1,213 @@
+// Bridge.js - WebAuthn API Interceptor
+// Monkey-patches navigator.credentials to route through native Swift
+
+(function() {
+    'use strict';
+
+    // Store original functions
+    const originalCreate = navigator.credentials.create.bind(navigator.credentials);
+    const originalGet = navigator.credentials.get.bind(navigator.credentials);
+
+    // Promise resolvers for async callbacks
+    let pendingResolve = null;
+    let pendingReject = null;
+
+    // Callback from native code on success
+    window.__webauthn_callback__ = function(responseJson) {
+        console.log('[WebAuthn] Received success callback');
+        if (pendingResolve) {
+            try {
+                const response = JSON.parse(responseJson);
+                const credential = decodeCredential(response);
+                pendingResolve(credential);
+            } catch (e) {
+                pendingReject(new DOMException(e.message, 'NotAllowedError'));
+            }
+            pendingResolve = null;
+            pendingReject = null;
+        }
+    };
+
+    // Callback from native code on error
+    window.__webauthn_error__ = function(errorMessage) {
+        console.log('[WebAuthn] Received error:', errorMessage);
+        if (pendingReject) {
+            pendingReject(new DOMException(errorMessage, 'NotAllowedError'));
+            pendingResolve = null;
+            pendingReject = null;
+        }
+    };
+
+    // Base64URL decode to ArrayBuffer
+    function base64urlDecode(str) {
+        // Add padding
+        str = str.replace(/-/g, '+').replace(/_/g, '/');
+        while (str.length % 4) str += '=';
+        const binary = atob(str);
+        const bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i++) {
+            bytes[i] = binary.charCodeAt(i);
+        }
+        return bytes.buffer;
+    }
+
+    // Decode extension results from native
+    function decodeExtensionResults(results) {
+        if (!results) return {};
+
+        const decoded = {};
+
+        // Decode PRF results (base64url → ArrayBuffer)
+        if (results.prf) {
+            decoded.prf = {};
+            if (results.prf.enabled !== undefined) {
+                decoded.prf.enabled = results.prf.enabled;
+            }
+            if (results.prf.results) {
+                decoded.prf.results = {
+                    first: base64urlDecode(results.prf.results.first)
+                };
+                if (results.prf.results.second) {
+                    decoded.prf.results.second = base64urlDecode(results.prf.results.second);
+                }
+            }
+        }
+
+        // Copy credProtect as-is (integer)
+        if (results.credProtect !== undefined) {
+            decoded.credProtect = results.credProtect;
+        }
+
+        // Copy hmacCreateSecret as-is (boolean)
+        if (results.hmacCreateSecret !== undefined) {
+            decoded.hmacCreateSecret = results.hmacCreateSecret;
+        }
+
+        return decoded;
+    }
+
+    // Decode credential response from native
+    function decodeCredential(response) {
+        const credential = {
+            id: response.id,
+            rawId: base64urlDecode(response.rawId),
+            type: response.type,
+            authenticatorAttachment: response.authenticatorAttachment,
+            getClientExtensionResults: function() {
+                return decodeExtensionResults(response.clientExtensionResults);
+            }
+        };
+
+        // Build response object
+        credential.response = {
+            clientDataJSON: base64urlDecode(response.response.clientDataJSON)
+        };
+
+        // MakeCredential response fields
+        if (response.response.attestationObject) {
+            credential.response.attestationObject = base64urlDecode(response.response.attestationObject);
+            credential.response.getTransports = function() {
+                return response.response.transports || [];
+            };
+            credential.response.getAuthenticatorData = function() {
+                return base64urlDecode(response.response.authenticatorData);
+            };
+            credential.response.getPublicKey = function() {
+                // TODO: Implement SPKI encoding to return the public key in SubjectPublicKeyInfo format.
+                // Without this, RPs that call getPublicKey() will receive null and may fail.
+                // See DerRepresentable helpers in Samples/yubikit-piv-tool for SPKI encoding reference.
+                return null;
+            };
+            credential.response.getPublicKeyAlgorithm = function() {
+                return response.response.publicKeyAlgorithm || -7;
+            };
+        }
+
+        // GetAssertion response fields
+        if (response.response.signature) {
+            credential.response.authenticatorData = base64urlDecode(response.response.authenticatorData);
+            credential.response.signature = base64urlDecode(response.response.signature);
+            // Per spec, userHandle should be null (not undefined) when absent
+            credential.response.userHandle = response.response.userHandle
+                ? base64urlDecode(response.response.userHandle)
+                : null;
+        }
+
+        return credential;
+    }
+
+    // Base64URL encode ArrayBuffer
+    function base64urlEncode(buffer) {
+        const bytes = new Uint8Array(buffer);
+        let binary = '';
+        for (let i = 0; i < bytes.length; i++) {
+            binary += String.fromCharCode(bytes[i]);
+        }
+        return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+    }
+
+    // Encode request for native
+    function encodeRequest(options) {
+        const encoded = JSON.parse(JSON.stringify(options, (key, value) => {
+            if (value instanceof ArrayBuffer) {
+                return base64urlEncode(value);
+            }
+            if (value instanceof Uint8Array) {
+                return base64urlEncode(value.buffer);
+            }
+            return value;
+        }));
+        return encoded;
+    }
+
+    // Intercept all WebAuthn requests and route them to the YubiKey.
+    // To only intercept when security-key hint is present, use:
+    // return Array.isArray(pk.hints) && pk.hints.includes('security-key');
+    function shouldIntercept(options) {
+        const pk = options?.publicKey;
+        return pk != null;
+    }
+
+    function interceptWebAuthn(type, options, originalFn) {
+        if (!shouldIntercept(options)) {
+            console.log('[WebAuthn] Forwarding to OS');
+            return originalFn(options);
+        }
+
+        console.log(`[WebAuthn] Intercepting ${type}`);
+
+        return new Promise((resolve, reject) => {
+            pendingResolve = resolve;
+            pendingReject = reject;
+
+            const request = {
+                type: type,
+                origin: window.location.origin,
+                request: encodeRequest(options.publicKey)
+            };
+
+            window.webkit.messageHandlers[`__webauthn_${type}__`].postMessage(JSON.stringify(request));
+        });
+    }
+
+    navigator.credentials.create = function(options) {
+        return interceptWebAuthn('create', options, originalCreate);
+    };
+
+    navigator.credentials.get = function(options) {
+        return interceptWebAuthn('get', options, originalGet);
+    };
+
+    // Override platform authenticator checks to return false since we route to YubiKey.
+    // Preserve native PublicKeyCredential for other methods (e.g. isExternalCTAP2SecurityKeySupported).
+    if (window.PublicKeyCredential) {
+        window.PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable = function() {
+            return Promise.resolve(false);
+        };
+        window.PublicKeyCredential.isConditionalMediationAvailable = function() {
+            return Promise.resolve(false);
+        };
+    }
+
+    console.log('[WebAuthn] Interceptor installed');
+})();

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/Interceptor.js
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/Interceptor.js
@@ -122,8 +122,10 @@
                 return decoded.response.authenticatorData;
             };
             credential.response.getPublicKey = function() {
-                // TODO: Implement SPKI encoding to return the public key in SubjectPublicKeyInfo format.
-                // Without this, RPs that call getPublicKey() will receive null and may fail.
+                // This sample does not implement SPKI encoding for getPublicKey().
+                // RPs that require the public key should extract it from attestationObject
+                // or extend the native implementation to provide SPKI-encoded key data.
+                console.warn('[WebAuthn] getPublicKey() is not implemented in this sample and returns null');
                 return null;
             };
             credential.response.getPublicKeyAlgorithm = function() {

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/Log.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/Log.swift
@@ -1,10 +1,3 @@
-//
-//  Log.swift
-//  WebAuthnInterceptorSample
-//
-//  Simple error logging for debugging.
-//
-
 import Foundation
 
 func logError(_ message: String, file: String = #file, line: Int = #line) {

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/Log.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/Log.swift
@@ -1,0 +1,13 @@
+//
+//  Log.swift
+//  WebAuthnInterceptorSample
+//
+//  Simple error logging for debugging.
+//
+
+import Foundation
+
+func logError(_ message: String, file: String = #file, line: Int = #line) {
+    let filename = (file as NSString).lastPathComponent
+    print("[ERROR] \(filename):\(line) - \(message)")
+}

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/PINEntryView.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/PINEntryView.swift
@@ -1,0 +1,86 @@
+//
+//  PINEntryView.swift
+//  WebAuthnInterceptorSample
+//
+
+import SwiftUI
+
+struct PINEntryView: View {
+    let onSubmit: (String) -> Void
+    let onCancel: () -> Void
+    var errorMessage: String?
+
+    @State private var pin = ""
+    @FocusState private var isFocused: Bool
+
+    private var isValid: Bool { pin.count >= 4 }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("Enter YubiKey PIN")
+                .font(.headline)
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+
+            SecureField("PIN", text: $pin)
+                .textFieldStyle(.roundedBorder)
+                .focused($isFocused)
+                .onSubmit { if isValid { onSubmit(pin) } }
+
+            if !pin.isEmpty && !isValid {
+                Text("PIN must be at least 4 characters")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            HStack(spacing: 12) {
+                Button("Cancel", action: onCancel)
+                    .buttonStyle(.bordered)
+                Button("Done") { onSubmit(pin) }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!isValid)
+            }
+        }
+        .padding()
+        .onAppear { isFocused = true }
+    }
+}
+
+// MARK: - PIN Request Handler
+
+@MainActor
+class PINRequestHandler: ObservableObject {
+    @Published var isShowingPINEntry = false
+    @Published var errorMessage: String?
+    private var pendingContinuation: CheckedContinuation<String?, Never>?
+
+    func requestPIN(errorMessage: String? = nil) async -> String? {
+        self.errorMessage = errorMessage
+        return await withCheckedContinuation { continuation in
+            pendingContinuation = continuation
+            isShowingPINEntry = true
+        }
+    }
+
+    func submitPIN(_ pin: String) {
+        isShowingPINEntry = false
+        errorMessage = nil
+        pendingContinuation?.resume(returning: pin)
+        pendingContinuation = nil
+    }
+
+    func cancel() {
+        isShowingPINEntry = false
+        errorMessage = nil
+        pendingContinuation?.resume(returning: nil)
+        pendingContinuation = nil
+    }
+}
+
+#Preview {
+    PINEntryView(onSubmit: { _ in }, onCancel: {})
+}

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/PINEntryView.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/PINEntryView.swift
@@ -2,8 +2,12 @@
 //  PINEntryView.swift
 //  WebAuthnInterceptorSample
 //
+//  PIN entry UI and async handler for bridging SwiftUI sheets with async/await.
+//
 
 import SwiftUI
+
+// MARK: - PIN Entry View
 
 struct PINEntryView: View {
     let onSubmit: (String) -> Void
@@ -52,10 +56,13 @@ struct PINEntryView: View {
 
 // MARK: - PIN Request Handler
 
+/// Bridges async PIN requests from the Bridge actor to SwiftUI sheet presentation.
+/// Uses CheckedContinuation to suspend until the user submits or cancels.
 @MainActor
 class PINRequestHandler: ObservableObject {
     @Published var isShowingPINEntry = false
     @Published var errorMessage: String?
+
     private var pendingContinuation: CheckedContinuation<String?, Never>?
 
     func requestPIN(errorMessage: String? = nil) async -> String? {
@@ -80,6 +87,8 @@ class PINRequestHandler: ObservableObject {
         pendingContinuation = nil
     }
 }
+
+// MARK: - Preview
 
 #Preview {
     PINEntryView(onSubmit: { _ in }, onCancel: {})

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/PINEntryView.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/PINEntryView.swift
@@ -1,9 +1,4 @@
-//
-//  PINEntryView.swift
-//  WebAuthnInterceptorSample
-//
-//  PIN entry UI and async handler for bridging SwiftUI sheets with async/await.
-//
+/// PIN entry UI and async handler for bridging SwiftUI sheets with async/await.
 
 import SwiftUI
 
@@ -56,7 +51,7 @@ struct PINEntryView: View {
 
 // MARK: - PIN Request Handler
 
-/// Bridges async PIN requests from the Bridge actor to SwiftUI sheet presentation.
+/// Bridges async PIN requests from WebAuthnHandler to SwiftUI sheet presentation.
 /// Uses CheckedContinuation to suspend until the user submits or cancels.
 @MainActor
 class PINRequestHandler: ObservableObject {

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnClientLogic.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnClientLogic.swift
@@ -1,0 +1,202 @@
+//
+//  WebAuthnClientLogic.swift
+//  WebAuthnInterceptorSample
+//
+//  TODO: Move this to the SDK as a WebAuthn.Client API.
+//
+//  This file contains WebAuthn client-level logic that bridges between WebAuthn API requests
+//  and CTAP2 SDK calls. Currently lives in the sample app, but should eventually be part of
+//  the SDK to simplify WebAuthn implementations.
+//
+//  What this file handles:
+//  - Building CTAP2 extension inputs from WebAuthn extension requests
+//  - Extracting WebAuthn extension results from CTAP2 responses
+//  - LargeBlob orchestration (key retrieval + blob read/write)
+//  - Extension state tracking across request/response
+//
+
+import Foundation
+import YubiKit
+
+// MARK: - Extension State
+
+/// State for tracking extensions during makeCredential.
+struct CreateExtensionState {
+    var inputs: [CTAP2.Extension.MakeCredential.Input] = []
+    var credProtect: CTAP2.Extension.CredProtect?
+    var prf: WebAuthn.Extension.PRF?
+    var largeBlobKey: CTAP2.Extension.LargeBlobKey?
+}
+
+/// State for tracking extensions during getAssertion.
+struct GetExtensionState {
+    var inputs: [CTAP2.Extension.GetAssertion.Input] = []
+    var prf: WebAuthn.Extension.PRF?
+    var largeBlobKey: CTAP2.Extension.LargeBlobKey?
+    var largeBlobRead: Bool = false
+    var largeBlobWrite: Data?
+}
+
+// MARK: - Extension Input Building
+
+/// Builds CTAP2 extension inputs from a WebAuthn create request.
+func buildCreateExtensions(
+    request: CreateRequest,
+    session: CTAP2.Session
+) async throws -> CreateExtensionState {
+    var state = CreateExtensionState()
+
+    // credProtect extension
+    if let credProtectLevel = request.extensions?.credProtect,
+        let level = CTAP2.Extension.CredProtect.Level(rawValue: credProtectLevel)
+    {
+        trace("Adding credProtect extension with level \(credProtectLevel)")
+        let credProtect = try await CTAP2.Extension.CredProtect(level: level, session: session)
+        state.inputs.append(credProtect.input())
+        state.credProtect = credProtect
+    }
+
+    // PRF extension (with or without secrets)
+    if let prfEval = request.extensions?.prf?.eval,
+        let firstData = Data(base64urlDecoding: prfEval.first)
+    {
+        trace("Adding PRF extension for makeCredential with secrets")
+        let prf = try await WebAuthn.Extension.PRF(session: session)
+        let secondData = prfEval.second.flatMap { Data(base64urlDecoding: $0) }
+        state.inputs.append(try prf.makeCredential.input(first: firstData, second: secondData))
+        state.prf = prf
+    } else if request.extensions?.hmacCreateSecret == true || request.extensions?.prf != nil {
+        trace("Adding PRF extension for makeCredential (enable only)")
+        let prf = try await WebAuthn.Extension.PRF(session: session)
+        state.inputs.append(prf.makeCredential.input())
+        state.prf = prf
+    }
+
+    // largeBlob extension
+    if let support = request.extensions?.largeBlob?.support,
+        support == "required" || support == "preferred"
+    {
+        trace("Adding largeBlobKey extension for makeCredential (support: \(support))")
+        let largeBlobKey = CTAP2.Extension.LargeBlobKey()
+        state.inputs.append(largeBlobKey.makeCredential.input())
+        state.largeBlobKey = largeBlobKey
+    }
+
+    return state
+}
+
+/// Builds CTAP2 extension inputs from a WebAuthn get request.
+func buildGetExtensions(
+    request: GetRequest,
+    session: CTAP2.Session
+) async throws -> GetExtensionState {
+    var state = GetExtensionState()
+
+    // PRF extension
+    if let prfEval = request.extensions?.prf?.eval,
+        let firstData = Data(base64urlDecoding: prfEval.first)
+    {
+        trace("Adding PRF extension")
+        let prf = try await WebAuthn.Extension.PRF(session: session)
+        let secondData = prfEval.second.flatMap { Data(base64urlDecoding: $0) }
+        state.inputs.append(try prf.getAssertion.input(first: firstData, second: secondData))
+        state.prf = prf
+    }
+
+    // largeBlob extension (read or write)
+    let wantsRead = request.extensions?.largeBlob?.read == true
+    let writeData = request.extensions?.largeBlob?.write.flatMap { Data(base64urlDecoding: $0) }
+    if wantsRead || writeData != nil {
+        trace("Adding largeBlobKey extension for getAssertion (read: \(wantsRead), write: \(writeData != nil))")
+        let largeBlobKey = CTAP2.Extension.LargeBlobKey()
+        state.inputs.append(largeBlobKey.getAssertion.input())
+        state.largeBlobKey = largeBlobKey
+        state.largeBlobRead = wantsRead
+        state.largeBlobWrite = writeData
+    }
+
+    return state
+}
+
+// MARK: - Extension Result Extraction
+
+/// Extracts WebAuthn extension results from a makeCredential response.
+func extractCreateExtensionResults(
+    state: CreateExtensionState,
+    response: CTAP2.MakeCredential.Response
+) throws -> ExtensionResults {
+    var results = ExtensionResults()
+
+    if let credProtect = state.credProtect, let level = credProtect.output(from: response) {
+        trace("credProtect applied with level \(level.rawValue)")
+        results.credProtect = level.rawValue
+    }
+
+    if let prf = state.prf, let prfResult = try prf.makeCredential.output(from: response) {
+        trace("PRF extension result received")
+        results.prf = PRFOutput(prfResult)
+    }
+
+    if let largeBlobKey = state.largeBlobKey {
+        let key = largeBlobKey.makeCredential.output(from: response)
+        trace("largeBlobKey extension: \(key != nil ? "supported" : "not supported")")
+        results.largeBlob = .supported(key != nil)
+    }
+
+    return results
+}
+
+/// Extracts WebAuthn extension results from a getAssertion response.
+/// Also handles largeBlob read/write operations which require additional CTAP calls.
+func extractGetExtensionResults(
+    state: GetExtensionState,
+    response: CTAP2.GetAssertion.Response,
+    session: CTAP2.Session,
+    pinToken: CTAP2.ClientPin.Token?
+) async throws -> ExtensionResults {
+    var results = ExtensionResults()
+
+    if let prf = state.prf, let secrets = try prf.getAssertion.output(from: response) {
+        trace("PRF extension returned secrets")
+        results.prf = PRFOutput(secrets)
+    }
+
+    // Handle largeBlob read/write
+    if let largeBlobKey = state.largeBlobKey,
+        let key = largeBlobKey.getAssertion.output(from: response)
+    {
+        if state.largeBlobRead {
+            trace("Reading largeBlob...")
+            let blob = try await session.getBlob(key: key)
+            trace("largeBlob read: \(blob != nil ? "\(blob!.count) bytes" : "no blob found")")
+            results.largeBlob = .read(blob)
+        } else if let writeData = state.largeBlobWrite, let pinToken {
+            trace("Writing largeBlob (\(writeData.count) bytes)...")
+            try await session.putBlob(key: key, data: writeData, pinToken: pinToken)
+            trace("largeBlob write successful")
+            results.largeBlob = .written(true)
+        }
+    } else if state.largeBlobKey != nil {
+        trace("largeBlobKey not returned by authenticator")
+        if state.largeBlobRead {
+            results.largeBlob = .read(nil)
+        } else if state.largeBlobWrite != nil {
+            results.largeBlob = .written(false)
+        }
+    }
+
+    return results
+}
+
+// MARK: - Permission Calculation
+
+/// Calculates the CTAP2 permissions needed for a getAssertion request.
+func permissionsForGetAssertion(request: GetRequest) -> CTAP2.ClientPin.Permission {
+    var permissions: CTAP2.ClientPin.Permission = .getAssertion
+
+    if request.extensions?.largeBlob?.write != nil {
+        permissions.insert(.largeBlobWrite)
+    }
+
+    return permissions
+}

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnClientLogic.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnClientLogic.swift
@@ -49,10 +49,10 @@ func buildCreateExtensions(
 
     // PRF extension (with or without secrets)
     if let prfEval = request.extensions?.prf?.eval,
-        let firstData = Data(base64urlDecoding: prfEval.first)
+        let firstData = Data(base64Encoded: prfEval.first)
     {
         let prf = try await WebAuthn.Extension.PRF(session: session)
-        let secondData = prfEval.second.flatMap { Data(base64urlDecoding: $0) }
+        let secondData = prfEval.second.flatMap { Data(base64Encoded: $0) }
         state.inputs.append(try prf.makeCredential.input(first: firstData, second: secondData))
         state.prf = prf
     } else if request.extensions?.hmacCreateSecret == true || request.extensions?.prf != nil {
@@ -82,17 +82,17 @@ func buildGetExtensions(
 
     // PRF extension
     if let prfEval = request.extensions?.prf?.eval,
-        let firstData = Data(base64urlDecoding: prfEval.first)
+        let firstData = Data(base64Encoded: prfEval.first)
     {
         let prf = try await WebAuthn.Extension.PRF(session: session)
-        let secondData = prfEval.second.flatMap { Data(base64urlDecoding: $0) }
+        let secondData = prfEval.second.flatMap { Data(base64Encoded: $0) }
         state.inputs.append(try prf.getAssertion.input(first: firstData, second: secondData))
         state.prf = prf
     }
 
     // largeBlob extension (read or write)
     let wantsRead = request.extensions?.largeBlob?.read == true
-    let writeData = request.extensions?.largeBlob?.write.flatMap { Data(base64urlDecoding: $0) }
+    let writeData = request.extensions?.largeBlob?.write.flatMap { Data(base64Encoded: $0) }
     if wantsRead || writeData != nil {
         let largeBlobKey = CTAP2.Extension.LargeBlobKey()
         state.inputs.append(largeBlobKey.getAssertion.input())

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnClientLogic.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnClientLogic.swift
@@ -1,19 +1,11 @@
-//
-//  WebAuthnClientLogic.swift
-//  WebAuthnInterceptorSample
-//
-//  TODO: Move this to the SDK as a WebAuthn.Client API.
-//
-//  This file contains WebAuthn client-level logic that bridges between WebAuthn API requests
-//  and CTAP2 SDK calls. Currently lives in the sample app, but should eventually be part of
-//  the SDK to simplify WebAuthn implementations.
-//
-//  What this file handles:
-//  - Building CTAP2 extension inputs from WebAuthn extension requests
-//  - Extracting WebAuthn extension results from CTAP2 responses
-//  - LargeBlob orchestration (key retrieval + blob read/write)
-//  - Extension state tracking across request/response
-//
+/// WebAuthn client-level logic bridging WebAuthn API requests and CTAP2 SDK calls.
+///
+/// TODO: Move this to the SDK as a WebAuthn.Client API.
+///
+/// Handles:
+/// - Building CTAP2 extension inputs from WebAuthn extension requests
+/// - Extracting WebAuthn extension results from CTAP2 responses
+/// - LargeBlob orchestration (key retrieval + blob read/write)
 
 import Foundation
 import YubiKit

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnHandler.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnHandler.swift
@@ -1,8 +1,8 @@
 //
-//  Bridge.swift
+//  WebAuthnHandler.swift
 //  WebAuthnInterceptorSample
 //
-//  Thin bridge layer: receives WebAuthn requests from JS, manages connection/PIN,
+//  Receives WebAuthn requests from JS, manages YubiKey connection and PIN flow,
 //  delegates to WebAuthnClientLogic for extension handling, returns responses.
 //
 
@@ -10,16 +10,16 @@ import CryptoKit
 import Foundation
 import YubiKit
 
-// MARK: - Bridge
+// MARK: - WebAuthnHandler
 
-actor Bridge {
+actor WebAuthnHandler {
 
     private var connection: (any Connection)?
     private let pinProvider: @Sendable (String?) async -> String?
 
     init(pinProvider: @escaping @Sendable (String?) async -> String?) {
         self.pinProvider = pinProvider
-        trace("Bridge initialized")
+        trace("WebAuthnHandler initialized")
     }
 
     // MARK: - Public API
@@ -209,7 +209,7 @@ actor Bridge {
             trace("Prompting for PIN...")
             guard let pin = await pinProvider(errorMessage) else {
                 trace("User cancelled PIN entry")
-                throw BridgeError.userCancelled
+                throw WebAuthnHandlerError.userCancelled
             }
 
             #if os(iOS)
@@ -241,9 +241,9 @@ actor Bridge {
 
 }
 
-// MARK: - BridgeError
+// MARK: - WebAuthnHandlerError
 
-enum BridgeError: LocalizedError {
+enum WebAuthnHandlerError: LocalizedError {
     case userCancelled
 
     var errorDescription: String? {

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnHandler.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnHandler.swift
@@ -73,7 +73,7 @@ actor WebAuthnHandler {
         let credentials = CredentialResponse(
             clientDataJSON: clientDataJSON,
             makeCredentialResponse: response,
-            extensionResults: extensionResults.isEmpty ? nil : extensionResults
+            extensionResults: extensionResults
         )
         let jsonData = try JSONEncoder().encode(credentials)
         return String(data: jsonData, encoding: .utf8) ?? ""
@@ -124,7 +124,7 @@ actor WebAuthnHandler {
         let credentials = CredentialResponse(
             clientDataJSON: clientDataJSON,
             getAssertionResponse: response,
-            extensionResults: extensionResults.isEmpty ? nil : extensionResults
+            extensionResults: extensionResults
         )
         let jsonData = try JSONEncoder().encode(credentials)
         return String(data: jsonData, encoding: .utf8) ?? ""

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnHandler.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnHandler.swift
@@ -29,7 +29,7 @@ actor WebAuthnHandler {
 
         let rpEntity = WebAuthn.PublicKeyCredential.RPEntity(id: rpId, name: request.rp.name)
         let userEntity = WebAuthn.PublicKeyCredential.UserEntity(
-            id: Data(base64urlDecoding: request.user.id) ?? Data(),
+            id: Data(base64Encoded: request.user.id) ?? Data(),
             name: request.user.name,
             displayName: request.user.displayName
         )

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnHandler.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnHandler.swift
@@ -1,10 +1,5 @@
-//
-//  WebAuthnHandler.swift
-//  WebAuthnInterceptorSample
-//
-//  Receives WebAuthn requests from JS, manages YubiKey connection and PIN flow,
-//  delegates to WebAuthnClientLogic for extension handling, returns responses.
-//
+/// Receives WebAuthn requests from JS, manages YubiKey connection and PIN flow,
+/// delegates to WebAuthnClientLogic for extension handling, returns responses.
 
 import CryptoKit
 import Foundation

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnInterceptorSample.entitlements
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnInterceptorSample.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.nfc.readersession.formats</key>
+	<array>
+		<string>TAG</string>
+	</array>
+	<key>com.apple.security.smartcard</key>
+	<true/>
+	<key>com.apple.security.device.usb</key>
+	<true/>
+</dict>
+</plist>

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnInterceptorSampleApp.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnInterceptorSampleApp.swift
@@ -1,8 +1,3 @@
-//
-//  WebAuthnInterceptorSampleApp.swift
-//  WebAuthnInterceptorSample
-//
-
 import SwiftUI
 
 @main

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnInterceptorSampleApp.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnInterceptorSampleApp.swift
@@ -1,0 +1,15 @@
+//
+//  WebAuthnInterceptorSampleApp.swift
+//  WebAuthnInterceptorSample
+//
+
+import SwiftUI
+
+@main
+struct WebAuthnInterceptorSampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnTypes.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnTypes.swift
@@ -1,9 +1,4 @@
-//
-//  WebAuthnTypes.swift
-//  WebAuthnInterceptorSample
-//
-//  Types for JSON serialization between browser WebAuthn API and YubiKit SDK.
-//
+/// Types for JSON serialization between browser WebAuthn API and YubiKit SDK.
 
 import Foundation
 import YubiKit
@@ -197,7 +192,11 @@ struct AuthenticatorResponse: Codable {
         self.authenticatorData = BinaryValue(response.authenticatorData)
         self.signature = nil
         self.userHandle = nil
+        #if os(iOS)
         self.transports = ["nfc", "usb"]
+        #else
+        self.transports = ["usb"]
+        #endif
         self.attestationObject = BinaryValue(response.attestationObject)
         self.publicKeyAlgorithm =
             response.authenticatorData.attestedCredentialData?.credentialPublicKey.algorithmRawValue
@@ -360,10 +359,10 @@ private func hostFromOrigin(_ origin: String) -> String {
 extension COSE.Key {
     var algorithmRawValue: Int? {
         switch self {
-        case .ec2(let alg, _, _, _, _): return alg.rawValue
-        case .okp(let alg, _, _, _): return alg.rawValue
-        case .rsa(let alg, _, _, _): return alg.rawValue
-        case .other: return nil
+        case .ec2(let alg, _, _, _, _), .okp(let alg, _, _, _), .rsa(let alg, _, _, _):
+            alg.rawValue
+        case .other:
+            nil
         }
     }
 }

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnTypes.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnTypes.swift
@@ -295,6 +295,8 @@ extension WebAuthn.AttestationObject: BinaryEncodable {}
 
 /// Encodes binary data as `{"__binary__": "<base64url>"}` for the JS side to decode to ArrayBuffer.
 struct BinaryValue: Codable {
+    // The double-underscore property name is required by the JavaScript bridge contract.
+    // The JS side expects `{"__binary__": "..."}` objects and decodes them to ArrayBuffer.
     // swiftlint:disable:next identifier_name
     let __binary__: String
 

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnTypes.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnTypes.swift
@@ -88,11 +88,11 @@ struct CredentialDescriptor: Decodable {
 
     func toDescriptor() -> WebAuthn.PublicKeyCredential.Descriptor? {
         guard let id else {
-            trace("CredentialDescriptor missing id")
+            logError("CredentialDescriptor missing id")
             return nil
         }
         guard let data = Data(base64urlDecoding: id) else {
-            trace("CredentialDescriptor failed to decode id: \(id)")
+            logError("CredentialDescriptor failed to decode id: \(id)")
             return nil
         }
         return WebAuthn.PublicKeyCredential.Descriptor(id: data)

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnTypes.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnTypes.swift
@@ -1,5 +1,5 @@
 //
-//  BridgeTypes.swift
+//  WebAuthnTypes.swift
 //  WebAuthnInterceptorSample
 //
 //  Types for JSON serialization between browser WebAuthn API and YubiKit SDK.

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnTypes.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnTypes.swift
@@ -223,10 +223,6 @@ struct ExtensionResults: Codable {
     var hmacCreateSecret: Bool?
     var credProtect: Int?
     var largeBlob: LargeBlobOutput?
-
-    var isEmpty: Bool {
-        prf == nil && hmacCreateSecret == nil && credProtect == nil && largeBlob == nil
-    }
 }
 
 struct PRFOutput: Codable {

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebView.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebView.swift
@@ -173,6 +173,9 @@ extension WebView {
                 case .get:
                     response = try await handler.handleGet(data)
                 }
+                // Note: For very large responses (e.g., largeBlob data), interpolating into
+                // evaluateJavaScript may hit size limits. Production apps handling large blobs
+                // should consider using WKScriptMessage for bidirectional communication.
                 let encodedResponse = Data(response.utf8).base64EncodedString()
                 _ = try? await webView?.evaluateJavaScript("__webauthn_callback__('\(encodedResponse)')")
             } catch {

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebView.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebView.swift
@@ -154,10 +154,10 @@ extension WebView {
 extension WebView {
     class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
         weak var webView: WKWebView?
-        private let bridge: Bridge
+        private let handler: WebAuthnHandler
 
         init(pinHandler: PINRequestHandler) {
-            self.bridge = Bridge { [weak pinHandler] errorMessage in
+            self.handler = WebAuthnHandler { [weak pinHandler] errorMessage in
                 await pinHandler?.requestPIN(errorMessage: errorMessage)
             }
         }
@@ -188,10 +188,10 @@ extension WebView {
                 let response: String
                 if name == MessageHandler.create {
                     trace("Dispatching to handleCreate")
-                    response = try await bridge.handleCreate(data)
+                    response = try await handler.handleCreate(data)
                 } else {
                     trace("Dispatching to handleGet")
-                    response = try await bridge.handleGet(data)
+                    response = try await handler.handleGet(data)
                 }
 
                 trace("Operation succeeded, executing JS callback")

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebView.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebView.swift
@@ -1,0 +1,208 @@
+//
+//  WebView.swift
+//  WebAuthnInterceptorSample
+//
+
+import SwiftUI
+import WebKit
+
+// MARK: - Navigator
+
+@MainActor
+class WebViewNavigator: ObservableObject {
+    weak var webView: WKWebView? {
+        didSet { setupObservation() }
+    }
+
+    @Published var canGoBack = false
+    private var observation: NSKeyValueObservation?
+
+    func goBack() {
+        webView?.goBack()
+    }
+
+    private func setupObservation() {
+        observation = webView?.observe(\.canGoBack, options: [.initial, .new]) { [weak self] webView, _ in
+            Task { @MainActor in
+                self?.canGoBack = webView.canGoBack
+            }
+        }
+    }
+}
+
+#if os(iOS)
+struct WebView: UIViewRepresentable {
+    let url: URL
+    let pinHandler: PINRequestHandler
+    let navigator: WebViewNavigator
+
+    func makeUIView(context: Context) -> WKWebView {
+        let webView = createWebView(context: context)
+        navigator.webView = webView
+        return webView
+    }
+
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        updateWebView(webView)
+    }
+
+    static func dismantleUIView(_ webView: WKWebView, coordinator: Coordinator) {
+        cleanupWebView(webView)
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(pinHandler: pinHandler)
+    }
+}
+#else
+struct WebView: NSViewRepresentable {
+    let url: URL
+    let pinHandler: PINRequestHandler
+    let navigator: WebViewNavigator
+
+    func makeNSView(context: Context) -> WKWebView {
+        let webView = createWebView(context: context)
+        navigator.webView = webView
+        return webView
+    }
+
+    func updateNSView(_ webView: WKWebView, context: Context) {
+        updateWebView(webView)
+    }
+
+    static func dismantleNSView(_ webView: WKWebView, coordinator: Coordinator) {
+        cleanupWebView(webView)
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(pinHandler: pinHandler)
+    }
+}
+#endif
+
+// MARK: - Shared Implementation
+
+private let messageHandlerNames = ["__webauthn_create__", "__webauthn_get__"]
+
+extension WebView {
+    static func cleanupWebView(_ webView: WKWebView) {
+        trace("Cleaning up WebView message handlers")
+        let controller = webView.configuration.userContentController
+        for name in messageHandlerNames {
+            controller.removeScriptMessageHandler(forName: name)
+        }
+    }
+
+    func createWebView(context: Context) -> WKWebView {
+        trace("Creating WebView...")
+        let config = WKWebViewConfiguration()
+        let coordinator = context.coordinator
+
+        if let interceptorScript = loadInterceptorScript() {
+            let script = WKUserScript(
+                source: interceptorScript,
+                injectionTime: .atDocumentStart,
+                forMainFrameOnly: true
+            )
+            config.userContentController.addUserScript(script)
+            trace("Interceptor.js injected")
+        }
+
+        for name in messageHandlerNames {
+            config.userContentController.add(coordinator, name: name)
+        }
+        trace("Message handlers registered")
+
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = coordinator
+        coordinator.webView = webView
+
+        trace("Loading URL: \(url.absoluteString)")
+        webView.load(URLRequest(url: url))
+        return webView
+    }
+
+    func updateWebView(_ webView: WKWebView) {
+        guard webView.url != url else { return }
+        webView.load(URLRequest(url: url))
+    }
+
+    private func loadInterceptorScript() -> String? {
+        guard let url = Bundle.main.url(forResource: "Interceptor", withExtension: "js"),
+            let script = try? String(contentsOf: url, encoding: .utf8)
+        else {
+            trace("Failed to load Interceptor.js!")
+            return nil
+        }
+        return script
+    }
+}
+
+// MARK: - Coordinator
+
+extension WebView {
+    class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
+        weak var webView: WKWebView?
+        private let bridgeModel: Bridge
+
+        init(pinHandler: PINRequestHandler) {
+            self.bridgeModel = Bridge { [weak pinHandler] errorMessage in
+                await pinHandler?.requestPIN(errorMessage: errorMessage)
+            }
+        }
+
+        func userContentController(
+            _ userContentController: WKUserContentController,
+            didReceive message: WKScriptMessage
+        ) {
+            trace("Received message: \(message.name)")
+
+            guard let body = message.body as? String,
+                let data = body.data(using: .utf8)
+            else {
+                trace("Failed to parse message body")
+                return
+            }
+
+            trace("Message body: \(body)")
+
+            Task {
+                await handleWebAuthnMessage(name: message.name, data: data)
+            }
+        }
+
+        @MainActor
+        private func handleWebAuthnMessage(name: String, data: Data) async {
+            do {
+                let response: String
+                if name == "__webauthn_create__" {
+                    trace("Dispatching to handleCreate")
+                    response = try await bridgeModel.handleCreate(data)
+                } else {
+                    trace("Dispatching to handleGet")
+                    response = try await bridgeModel.handleGet(data)
+                }
+
+                trace("Operation succeeded, executing JS callback")
+                let js = "__webauthn_callback__('\(response.escapedForJavaScript())')"
+                _ = try? await webView?.evaluateJavaScript(js)
+            } catch {
+                trace("Operation failed: \(error) (\(type(of: error)))")
+                let js = "__webauthn_error__('\(error.localizedDescription.escapedForJavaScript())')"
+                _ = try? await webView?.evaluateJavaScript(js)
+            }
+        }
+    }
+}
+
+// MARK: - String Escaping
+
+extension String {
+    fileprivate func escapedForJavaScript() -> String {
+        self.replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "'", with: "\\'")
+            .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\r", with: "\\r")
+            .replacingOccurrences(of: "\t", with: "\\t")
+    }
+}

--- a/Samples/yubikit-piv-tool/yubikit-piv-tool.xcodeproj/xcshareddata/xcschemes/yubikit-piv-tool.xcscheme
+++ b/Samples/yubikit-piv-tool/yubikit-piv-tool.xcodeproj/xcshareddata/xcschemes/yubikit-piv-tool.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1640"
+   LastUpgradeVersion = "2620"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/YubiKit/YubiKit/YubiKit.docc/Resources/WebAuthnInterceptorSampleCode.md
+++ b/YubiKit/YubiKit/YubiKit.docc/Resources/WebAuthnInterceptorSampleCode.md
@@ -1,0 +1,257 @@
+# WebAuthnInterceptorSample: FIDO2/WebAuthn client for WKWebView
+
+This sample shows how to build a FIDO2 client that intercepts WebAuthn API calls in a WKWebView and routes them to a YubiKey via NFC (iOS) or USB HID (macOS). The app demonstrates using ``CTAP2/Session`` for FIDO2 operations and handling the PRF extension for deriving secrets.
+
+@Metadata {
+    @CallToAction(
+        purpose: link,
+        url: "https://github.com/Yubico/yubikit-swift/tree/main/Samples/WebAuthnInterceptorSample")
+    @PageKind(sampleCode)
+    @PageColor(yellow)
+}
+
+The WebAuthn interceptor shows how to build applications that:
+- Intercept `navigator.credentials.create()` and `navigator.credentials.get()` in a WKWebView
+- Convert between WebAuthn API types and CTAP2 protocol structures
+- Handle PIN entry with retry logic
+- Support the PRF extension (hmac-secret) for deriving cryptographic secrets
+- Connect via NFC on iOS or USB HID on macOS
+
+This sample enables using hardware security keys on websites that don't natively support them, by acting as a WebAuthn client that bridges the browser API to the YubiKey.
+
+## Architecture Overview
+
+The sample consists of three main components:
+
+- **Interceptor.js**: Injected into the WKWebView to intercept WebAuthn API calls
+- **Bridge.swift**: Converts WebAuthn requests to CTAP2 commands and handles YubiKey communication
+- **WebView.swift**: Sets up the WKWebView with the interceptor and message handlers
+
+The flow works as follows:
+1. JavaScript intercepts `navigator.credentials.create()` or `navigator.credentials.get()`
+2. The request is serialized and sent to Swift via `WKScriptMessageHandler`
+3. Swift converts the request to CTAP2 format and communicates with the YubiKey
+4. The response is converted back to WebAuthn format and returned to JavaScript
+
+## Intercepting WebAuthn Calls
+
+### JavaScript Injection
+
+The interceptor replaces the browser's WebAuthn API with custom implementations:
+
+```javascript
+const originalCreate = navigator.credentials.create.bind(navigator.credentials);
+const originalGet = navigator.credentials.get.bind(navigator.credentials);
+
+navigator.credentials.create = function(options) {
+    console.log('[WebAuthn] Intercepting create');
+    return new Promise((resolve, reject) => {
+        pendingResolve = resolve;
+        pendingReject = reject;
+
+        const request = {
+            type: 'create',
+            origin: window.location.origin,
+            request: encodeRequest(options.publicKey)
+        };
+        window.webkit.messageHandlers.__webauthn_create__.postMessage(JSON.stringify(request));
+    });
+};
+```
+
+The script is injected at document start to ensure it runs before any website code:
+
+```swift
+let script = WKUserScript(
+    source: interceptorScript,
+    injectionTime: .atDocumentStart,
+    forMainFrameOnly: true
+)
+config.userContentController.addUserScript(script)
+```
+
+### Receiving Messages in Swift
+
+The `Coordinator` class implements `WKScriptMessageHandler` to receive the intercepted requests:
+
+```swift
+func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+    guard let body = message.body as? String,
+          let data = body.data(using: .utf8) else { return }
+
+    Task {
+        await handleWebAuthnMessage(name: message.name, data: data)
+    }
+}
+```
+
+## CTAP2 Communication
+
+### Creating Credentials
+
+The `handleCreate` method converts WebAuthn `PublicKeyCredentialCreationOptions` to CTAP2 `MakeCredential` parameters:
+
+```swift
+func handleCreate(_ data: Data) async throws -> String {
+    let wrapper = try JSONDecoder().decode(CreateRequestWrapper.self, from: data)
+    let request = wrapper.request
+
+    let session = try await makeSession()
+
+    let rpEntity = WebAuthn.PublicKeyCredential.RPEntity(
+        id: request.rp.id,
+        name: request.rp.name
+    )
+    let userEntity = WebAuthn.PublicKeyCredential.UserEntity(
+        id: Data(base64urlDecoding: request.user.id) ?? Data(),
+        name: request.user.name,
+        displayName: request.user.displayName
+    )
+
+    let params = CTAP2.MakeCredential.Parameters(
+        clientDataHash: clientDataHash,
+        rp: rpEntity,
+        user: userEntity,
+        pubKeyCredParams: pubKeyParams,
+        excludeList: excludeList,
+        extensions: extState.inputs,
+        options: options
+    )
+
+    let response = try await session.makeCredential(parameters: params, pinToken: pinToken).value
+    // Convert response back to WebAuthn format...
+}
+```
+
+### Getting Assertions
+
+Similarly, `handleGet` converts `PublicKeyCredentialRequestOptions` to CTAP2 `GetAssertion`:
+
+```swift
+func handleGet(_ data: Data) async throws -> String {
+    let wrapper = try JSONDecoder().decode(GetRequestWrapper.self, from: data)
+    let request = wrapper.request
+
+    let session = try await makeSession()
+
+    let params = CTAP2.GetAssertion.Parameters(
+        rpId: request.rpId,
+        clientDataHash: clientDataHash,
+        allowList: allowList,
+        extensions: extState.inputs,
+        options: options
+    )
+
+    let response = try await session.getAssertion(parameters: params, pinToken: pinToken).value
+    // Convert response back to WebAuthn format...
+}
+```
+
+## PIN Handling
+
+The sample implements a PIN retry loop that prompts the user when verification fails. If the YubiKey has a PIN configured, it requests a PIN token using `session.getPinUVToken()` before performing CTAP2 operations. Invalid PIN attempts are caught and the user is prompted to retry.
+
+## PRF Extension (hmac-secret)
+
+The PRF extension allows deriving cryptographic secrets from credentials. This is useful for encryption keys that are bound to both the credential and user-provided salts.
+
+### Requesting PRF During Credential Creation
+
+```swift
+if let prfEval = request.extensions?.prf?.eval,
+   let firstData = Data(base64urlDecoding: prfEval.first) {
+    let prf = try await WebAuthn.Extension.PRF(session: session)
+    let secondData = prfEval.second.flatMap { Data(base64urlDecoding: $0) }
+    state.inputs.append(try prf.makeCredential.input(first: firstData, second: secondData))
+    state.prf = prf
+} else if request.extensions?.prf != nil {
+    // Just enable PRF without evaluating
+    let prf = try await WebAuthn.Extension.PRF(session: session)
+    state.inputs.append(prf.makeCredential.input())
+    state.prf = prf
+}
+```
+
+### Extracting PRF Results
+
+During credential creation, you typically get confirmation that PRF is enabled:
+
+```swift
+if let prf = state.prf, let prfResult = try prf.makeCredential.output(from: response) {
+    switch prfResult {
+    case .enabled:
+        results.prf = PRFOutput(enabled: true)
+    case .secrets(let secrets):
+        results.prf = PRFOutput(
+            first: secrets.first.base64urlEncodedString(),
+            second: secrets.second?.base64urlEncodedString()
+        )
+    }
+}
+```
+
+During assertion (authentication), you get the actual derived secrets:
+
+```swift
+if let prf = state.prf, let secrets = try prf.getAssertion.output(from: response) {
+    results.prf = PRFOutput(
+        first: secrets.first.base64urlEncodedString(),
+        second: secrets.second?.base64urlEncodedString()
+    )
+}
+```
+
+The secrets are 32-byte HMAC-SHA256 outputs derived from the credential's secret key and the provided salt values. These are deterministic - the same salts always produce the same outputs for a given credential.
+
+## Platform-Specific Connections
+
+The sample handles iOS and macOS differently:
+
+```swift
+private func makeSession() async throws -> CTAP2.Session {
+    #if os(iOS)
+    let conn = try await NFCSmartCardConnection(alertMessage: "Tap your YubiKey")
+    #else
+    let conn = try await HIDFIDOConnection()
+    #endif
+
+    connection = conn
+    let session = try await CTAP2.Session.makeSession(connection: conn)
+    return session
+}
+```
+
+On iOS, NFC provides a system dialog prompting the user to tap their YubiKey. On macOS, USB HID waits for a FIDO-capable device to be connected.
+
+## Response Encoding
+
+The WebAuthn API expects specific response formats. The sample converts CTAP2 responses back to the expected structure:
+
+```swift
+struct CredentialResponse: Codable {
+    let type: String
+    let id: String?
+    let rawId: String?
+    let response: AuthenticatorResponse
+    let clientExtensionResults: ExtensionResults?
+    let authenticatorAttachment: String?
+
+    init(clientDataJSON: Data, makeCredentialResponse: CTAP2.MakeCredential.Response, extensionResults: ExtensionResults? = nil) {
+        let credentialId = makeCredentialResponse.authenticatorData.attestedCredentialData?.credentialId.base64urlEncodedString()
+        self.type = "public-key"
+        self.id = credentialId
+        self.rawId = credentialId
+        self.response = AuthenticatorResponse(clientDataJSON: clientDataJSON, makeCredentialResponse: makeCredentialResponse)
+        self.clientExtensionResults = extensionResults
+        self.authenticatorAttachment = "cross-platform"
+    }
+}
+```
+
+The response is then JSON-encoded and passed back to JavaScript via a callback:
+
+```swift
+let js = "__webauthn_callback__('\(response.escapedForJavaScript())')"
+try? await webView?.evaluateJavaScript(js)
+```
+

--- a/YubiKit/YubiKit/YubiKit.docc/Resources/YubiKit.md
+++ b/YubiKit/YubiKit/YubiKit.docc/Resources/YubiKit.md
@@ -38,6 +38,7 @@ let codes = try await session.calculateCredentialCodes()
 @Links(visualStyle: detailedGrid) {
     - <doc:OATHSampleCode>
     - <doc:PIVToolSampleCode>
+    - <doc:WebAuthnInterceptorSampleCode>
 }
 
 ### Creating a SmartCardConnection to a YubiKey


### PR DESCRIPTION
## Summary

Adds a new sample app demonstrating how to build a FIDO2/WebAuthn client that intercepts WebAuthn API calls in a WKWebView and routes them to YubiKey via NFC (iOS) or USB HID (macOS).

### Features
- Intercepts `navigator.credentials.create()` and `navigator.credentials.get()` in WKWebView
- Full PIN handling with retry loop and user feedback
- Extension support: PRF (hmac-secret), largeBlob, credProtect
- Platform-specific connections: NFC on iOS, USB HID on macOS
- DocC documentation with code walkthrough
