### PR TITLE
CTAP2 - AuthenticatorConfig command for configuring authenticator settings

### DIFF
--- a/FullStackTests/FullStackTests.xcodeproj/project.pbxproj
+++ b/FullStackTests/FullStackTests.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		B4F9375F2B519D940007D394 /* Logger+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F9375D2B519D8E0007D394 /* Logger+Extensions.swift */; };
 		B4F937642B51A7DD0007D394 /* PIVFullStackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F937632B51A7DD0007D394 /* PIVFullStackTests.swift */; };
 		CD75D32C2F1114C7000624CB /* LargeBlobsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD75D32B2F1114C7000624CB /* LargeBlobsTests.swift */; };
+		DA1BB9E330014BCBBD93BF69 /* ConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD89AB9B1BB24FA6B5FD79D3 /* ConfigTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -72,6 +73,7 @@
 		B4F9375D2B519D8E0007D394 /* Logger+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logger+Extensions.swift"; sourceTree = "<group>"; };
 		B4F937632B51A7DD0007D394 /* PIVFullStackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PIVFullStackTests.swift; sourceTree = "<group>"; };
 		CD75D32B2F1114C7000624CB /* LargeBlobsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeBlobsTests.swift; sourceTree = "<group>"; };
+		CD89AB9B1BB24FA6B5FD79D3 /* ConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -160,6 +162,7 @@
 			isa = PBXGroup;
 			children = (
 				CD75D32D2F1114C8000624CB /* Extensions */,
+				CD89AB9B1BB24FA6B5FD79D3 /* ConfigTests.swift */,
 				6C734BB42EE860E100972E2A /* CredentialTests.swift */,
 				6C734BAA2EE860AF00972E2A /* HIDTransportTests.swift */,
 				6C734BB82EE861EE00972E2A /* TestHelpers.swift */,
@@ -328,6 +331,7 @@
 				6C2B14542DC8CF4C00B5C482 /* SCPFullStackTests.swift in Sources */,
 				6C734BAC2EE860AF00972E2A /* HIDTransportTests.swift in Sources */,
 				6CCAB7BA2EEC35EA00A789E7 /* PRFTests.swift in Sources */,
+				DA1BB9E330014BCBBD93BF69 /* ConfigTests.swift in Sources */,
 				6C2B14552DC8CF4C00B5C482 /* XCTestCase+SCP.swift in Sources */,
 				6CDATAHEX2EF1234500000001 /* Data+Hex.swift in Sources */,
 			);

--- a/FullStackTests/Tests/CTAP2/ConfigTests.swift
+++ b/FullStackTests/Tests/CTAP2/ConfigTests.swift
@@ -1,0 +1,207 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Testing
+import YubiKit
+
+@Suite("AuthenticatorConfig Full Stack Tests", .serialized)
+struct ConfigFullStackTests {
+
+    // MARK: - Support Check
+
+    @Test("Check authenticatorConfig support")
+    func testConfigSupport() async throws {
+        try await withCTAP2Session { session in
+            let info = try await session.getInfo()
+            let isSupported = info.options.authenticatorConfig == true
+
+            if isSupported {
+                print("✅ authenticatorConfig is supported")
+            } else {
+                print("ℹ️ authenticatorConfig is not supported by this authenticator")
+            }
+        }
+    }
+
+    // MARK: - Toggle AlwaysUV
+
+    @Test("Toggle alwaysUV setting")
+    func testToggleAlwaysUV() async throws {
+        try await withReconnectableCTAP2Session { session, reconnectWhenOverNFC in
+            var session = session
+
+            let info = try await session.getInfo()
+            guard info.options.authenticatorConfig == true else {
+                print("authenticatorConfig not supported - skipping")
+                return
+            }
+
+            guard info.options.alwaysUV != nil else {
+                print("alwaysUV option not supported - skipping")
+                return
+            }
+
+            let initialAlwaysUV = info.options.alwaysUV ?? false
+
+            let pinToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.authenticatorConfig]
+            )
+
+            let config = await session.config(pinToken: pinToken)
+            try await config.toggleAlwaysUV()
+
+            let newInfo = try await session.getInfo()
+            let newAlwaysUV = newInfo.options.alwaysUV ?? false
+            #expect(newAlwaysUV != initialAlwaysUV, "alwaysUV should have toggled")
+            print("✅ alwaysUV toggled from \(initialAlwaysUV) to \(newAlwaysUV)")
+
+            // Reconnect if over NFC before second toggle
+            session = try await reconnectWhenOverNFC()
+
+            // Toggle back to restore original state
+            let pinToken2 = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.authenticatorConfig]
+            )
+            try await session.config(pinToken: pinToken2).toggleAlwaysUV()
+
+            let restoredInfo = try await session.getInfo()
+            let restoredAlwaysUV = restoredInfo.options.alwaysUV ?? false
+            #expect(restoredAlwaysUV == initialAlwaysUV, "alwaysUV should be restored")
+            print("✅ alwaysUV restored to \(restoredAlwaysUV)")
+        }
+    }
+
+    // MARK: - Enterprise Attestation
+
+    @Test("Enable enterprise attestation")
+    func testEnableEnterpriseAttestation() async throws {
+        try await withCTAP2Session { session in
+            let info = try await session.getInfo()
+            guard info.options.authenticatorConfig == true else {
+                print("authenticatorConfig not supported - skipping")
+                return
+            }
+
+            guard info.options.enterpriseAttestation != nil else {
+                print("Enterprise attestation not supported - skipping")
+                return
+            }
+
+            let pinToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.authenticatorConfig]
+            )
+
+            try await session.config(pinToken: pinToken).enableEnterpriseAttestation()
+
+            let newInfo = try await session.getInfo()
+            #expect(newInfo.options.enterpriseAttestation == true)
+            print("✅ Enterprise attestation enabled")
+        }
+    }
+
+    @Test(
+        "Set force PIN change",
+        .disabled("Destructive - requires PIN change or reset to restore")
+    )
+    func testSetForcePinChange() async throws {
+        try await withCTAP2Session { session in
+            let info = try await session.getInfo()
+            guard info.options.authenticatorConfig == true else {
+                print("authenticatorConfig not supported - skipping")
+                return
+            }
+
+            guard info.forcePinChange != true else {
+                print("Force PIN change already set - reset key and retry")
+                return
+            }
+
+            let pinToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.authenticatorConfig]
+            )
+
+            try await session.config(pinToken: pinToken).setMinPINLength(forceChangePin: true)
+
+            let newInfo = try await session.getInfo()
+            #expect(newInfo.forcePinChange == true)
+            print("✅ Force PIN change set - reset authenticator to restore")
+        }
+    }
+
+    @Test(
+        "Set minimum PIN length",
+        .disabled("Destructive - minPinLength can only increase, requires reset to restore")
+    )
+    func testSetMinPinLength() async throws {
+        try await withReconnectableCTAP2Session { session, reconnectWhenOverNFC in
+            var session = session
+
+            let info = try await session.getInfo()
+            guard info.options.authenticatorConfig == true else {
+                print("authenticatorConfig not supported - skipping")
+                return
+            }
+
+            guard let currentMinPinLength = info.minPinLength else {
+                print("minPinLength not reported - skipping")
+                return
+            }
+
+            guard let maxPinLength = info.maxPINLength else {
+                print("maxPINLength not reported - skipping")
+                return
+            }
+
+            let newMinPinLength = currentMinPinLength + 1
+            guard newMinPinLength <= maxPinLength else {
+                print("Cannot increase minPinLength (\(currentMinPinLength) near max \(maxPinLength)) - skipping")
+                return
+            }
+
+            let pinToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.authenticatorConfig]
+            )
+
+            try await session.config(pinToken: pinToken).setMinPINLength(newMinPINLength: newMinPinLength)
+
+            let newInfo = try await session.getInfo()
+            #expect(newInfo.minPinLength == newMinPinLength)
+            print("✅ minPinLength increased from \(currentMinPinLength) to \(newMinPinLength)")
+
+            // Reconnect if over NFC before second operation
+            session = try await reconnectWhenOverNFC()
+
+            // Verify we cannot decrease it (spec requirement)
+            let pinToken2 = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.authenticatorConfig]
+            )
+
+            do {
+                try await session.config(pinToken: pinToken2).setMinPINLength(newMinPINLength: currentMinPinLength)
+                Issue.record("Should not be able to decrease minPinLength")
+            } catch is CTAP2.SessionError {
+                print("✅ Decreasing minPinLength correctly rejected")
+            }
+
+            print("✅ Test complete - reset authenticator to restore default minPinLength")
+        }
+    }
+}

--- a/FullStackTests/Tests/CTAP2/ConfigTests.swift
+++ b/FullStackTests/Tests/CTAP2/ConfigTests.swift
@@ -42,9 +42,7 @@ struct ConfigFullStackTests {
 
     @Test("Toggle alwaysUV setting")
     func testToggleAlwaysUV() async throws {
-        try await withReconnectableCTAP2Session { session, reconnectWhenOverNFC in
-            var session = session
-
+        try await withCTAP2Session { session in
             let info = try await session.getInfo()
             guard info.options.authenticatorConfig == true else {
                 print("authenticatorConfig not supported - skipping")
@@ -71,15 +69,8 @@ struct ConfigFullStackTests {
             #expect(newAlwaysUV != initialAlwaysUV, "alwaysUV should have toggled")
             print("✅ alwaysUV toggled from \(initialAlwaysUV) to \(newAlwaysUV)")
 
-            // Reconnect if over NFC before second toggle
-            session = try await reconnectWhenOverNFC()
-
             // Toggle back to restore original state
-            let pinToken2 = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
-                permissions: [.authenticatorConfig]
-            )
-            try await session.config(pinToken: pinToken2).toggleAlwaysUV()
+            try await config.toggleAlwaysUV()
 
             let restoredInfo = try await session.getInfo()
             let restoredAlwaysUV = restoredInfo.options.alwaysUV ?? false
@@ -152,9 +143,7 @@ struct ConfigFullStackTests {
         .disabled("Destructive - minPinLength can only increase, requires reset to restore")
     )
     func testSetMinPinLength() async throws {
-        try await withReconnectableCTAP2Session { session, reconnectWhenOverNFC in
-            var session = session
-
+        try await withCTAP2Session { session in
             let info = try await session.getInfo()
             guard info.options.authenticatorConfig == true else {
                 print("authenticatorConfig not supported - skipping")
@@ -182,23 +171,16 @@ struct ConfigFullStackTests {
                 permissions: [.authenticatorConfig]
             )
 
-            try await session.config(pinToken: pinToken).setMinPINLength(newMinPINLength: newMinPinLength)
+            let config = try await session.config(pinToken: pinToken)
+            try await config.setMinPINLength(newMinPINLength: newMinPinLength)
 
             let newInfo = try await session.getInfo()
             #expect(newInfo.minPinLength == newMinPinLength)
             print("✅ minPinLength increased from \(currentMinPinLength) to \(newMinPinLength)")
 
-            // Reconnect if over NFC before second operation
-            session = try await reconnectWhenOverNFC()
-
             // Verify we cannot decrease it (spec requirement)
-            let pinToken2 = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
-                permissions: [.authenticatorConfig]
-            )
-
             do {
-                try await session.config(pinToken: pinToken2).setMinPINLength(newMinPINLength: currentMinPinLength)
+                try await config.setMinPINLength(newMinPINLength: currentMinPinLength)
                 Issue.record("Should not be able to decrease minPinLength")
             } catch is CTAP2.SessionError {
                 print("✅ Decreasing minPinLength correctly rejected")

--- a/FullStackTests/Tests/CTAP2/ConfigTests.swift
+++ b/FullStackTests/Tests/CTAP2/ConfigTests.swift
@@ -24,12 +24,15 @@ struct ConfigFullStackTests {
     @Test("Check authenticatorConfig support")
     func testConfigSupport() async throws {
         try await withCTAP2Session { session in
-            let info = try await session.getInfo()
-            let isSupported = info.options.authenticatorConfig == true
+            let pinToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.authenticatorConfig]
+            )
 
-            if isSupported {
+            do {
+                _ = try await session.config(pinToken: pinToken)
                 print("✅ authenticatorConfig is supported")
-            } else {
+            } catch CTAP2.SessionError.featureNotSupported {
                 print("ℹ️ authenticatorConfig is not supported by this authenticator")
             }
         }
@@ -60,7 +63,7 @@ struct ConfigFullStackTests {
                 permissions: [.authenticatorConfig]
             )
 
-            let config = await session.config(pinToken: pinToken)
+            let config = try await session.config(pinToken: pinToken)
             try await config.toggleAlwaysUV()
 
             let newInfo = try await session.getInfo()

--- a/YubiKit/YubiKit/FIDO/CTAP/Config/Config.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/Config/Config.swift
@@ -1,0 +1,184 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+// MARK: - Session Config Accessor
+
+extension CTAP2.Session {
+    /// Returns authenticatorConfig operations bound to a PIN/UV auth token.
+    ///
+    /// ```swift
+    /// let pinToken = try await session.getPinUVToken(
+    ///     using: .pin("123456"),
+    ///     permissions: [.authenticatorConfig]
+    /// )
+    /// let config = session.config(pinToken: pinToken)
+    /// try await config.toggleAlwaysUV()
+    /// try await config.enableEnterpriseAttestation()
+    /// ```
+    ///
+    /// - Parameter pinToken: PIN/UV auth token with `authenticatorConfig` permission.
+    /// - Returns: Config operations bound to the token.
+    /// - SeeAlso: [CTAP2 authenticatorConfig](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorConfig)
+    public func config(pinToken: CTAP2.ClientPin.Token) -> CTAP2.Config {
+        CTAP2.Config(session: self, pinToken: pinToken)
+    }
+}
+
+// MARK: - Config
+
+extension CTAP2 {
+    /// AuthenticatorConfig operations bound to a PIN/UV auth token.
+    ///
+    /// - SeeAlso: [CTAP2 authenticatorConfig](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorConfig)
+    public struct Config: Sendable {
+        private let session: CTAP2.Session
+        private let pinToken: CTAP2.ClientPin.Token
+
+        init(session: CTAP2.Session, pinToken: CTAP2.ClientPin.Token) {
+            self.session = session
+            self.pinToken = pinToken
+        }
+
+        /// Enables enterprise attestation. If already enabled, this command is ignored.
+        ///
+        /// - SeeAlso: [Enable Enterprise Attestation](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#enable-enterprise-attestation)
+        public func enableEnterpriseAttestation() async throws(CTAP2.SessionError) {
+            try await execute(subcommand: .enableEnterpriseAttestation)
+        }
+
+        /// Toggles the alwaysUV setting.
+        ///
+        /// When enabled, the authenticator always requires user verification for assertions.
+        ///
+        /// - SeeAlso: [Toggle Always Require User Verification](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#toggle-alwaysUv)
+        public func toggleAlwaysUV() async throws(CTAP2.SessionError) {
+            try await execute(subcommand: .toggleAlwaysUV)
+        }
+
+        /// Sets the minimum PIN length and related configuration.
+        ///
+        /// - Parameters:
+        ///   - newMinPINLength: The minimum PIN length to allow. Pass `nil` to keep current.
+        ///   - rpIDs: RP IDs allowed to query minimum PIN length via extension.
+        ///   - forceChangePin: Enforce PIN change before next use.
+        ///   - pinComplexityPolicy: Enable PIN complexity enforcement.
+        /// - Throws: `CTAP2.SessionError.illegalArgument` if `pinComplexityPolicy` is unsupported.
+        /// - SeeAlso: [Setting a Minimum PIN Length](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#setMinPINLength)
+        public func setMinPINLength(
+            newMinPINLength: UInt? = nil,
+            rpIDs: [String]? = nil,
+            forceChangePin: Bool = false,
+            pinComplexityPolicy: Bool = false
+        ) async throws(CTAP2.SessionError) {
+            var params: [UInt8: CBOR.Value] = [:]
+            if let length = newMinPINLength {
+                params[Parameter.newMinPINLength.rawValue] = length.cbor()
+            }
+            if let rpIDs {
+                params[Parameter.minPINLengthRPIDs.rawValue] = rpIDs.cbor()
+            }
+            if forceChangePin {
+                params[Parameter.forceChangePin.rawValue] = true.cbor()
+            }
+            if pinComplexityPolicy {
+                let info = try await session.getInfo()
+                guard info.pinComplexityPolicy != nil else {
+                    throw .illegalArgument(
+                        "Authenticator does not support PIN complexity policy",
+                        source: .here()
+                    )
+                }
+                params[Parameter.pinComplexityPolicy.rawValue] = true.cbor()
+            }
+
+            try await execute(subcommand: .setMinPINLength, params: params)
+        }
+
+        // MARK: - Internal
+
+        private func execute(
+            subcommand: Subcommand,
+            params: [UInt8: CBOR.Value]? = nil
+        ) async throws(CTAP2.SessionError) {
+            let message = authMessage(subcommand: subcommand, params: params)
+            let pinUVAuthParam = pinToken.authenticate(message: message)
+
+            let parameters = RequestParameters(
+                subCommand: subcommand,
+                subCommandParams: params,
+                pinUVAuthProtocol: pinToken.protocolVersion,
+                pinUVAuthParam: pinUVAuthParam
+            )
+
+            try await session.interface.send(
+                command: .config,
+                payload: parameters
+            ).value
+        }
+
+        // Format: 0xFF * 32 || 0x0D || subCommand || CBOR(params)
+        private func authMessage(subcommand: Subcommand, params: [UInt8: CBOR.Value]?) -> Data {
+            var message = Data(repeating: 0xFF, count: 32)
+            message.append(CTAP2.Command.config.rawValue)
+            message.append(subcommand.rawValue)
+            if let params {
+                let cborParams = params.cbor()
+                message.append(cborParams.encode())
+            }
+            return message
+        }
+    }
+}
+
+// MARK: - Internal Types
+
+extension CTAP2.Config {
+    fileprivate enum Subcommand: UInt8, Sendable {
+        case enableEnterpriseAttestation = 0x01
+        case toggleAlwaysUV = 0x02
+        case setMinPINLength = 0x03
+        case vendorPrototype = 0xFF
+    }
+
+    fileprivate enum Parameter: UInt8, Sendable {
+        case newMinPINLength = 0x01
+        case minPINLengthRPIDs = 0x02
+        case forceChangePin = 0x03
+        case pinComplexityPolicy = 0x04
+    }
+
+    fileprivate struct RequestParameters: Sendable, CBOR.Encodable {
+        let subCommand: Subcommand
+        let subCommandParams: [UInt8: CBOR.Value]?
+        let pinUVAuthProtocol: CTAP2.ClientPin.ProtocolVersion
+        let pinUVAuthParam: Data
+
+        func cbor() -> CBOR.Value {
+            var map: [CBOR.Value: CBOR.Value] = [:]
+            map[.int(0x01)] = .int(Int(subCommand.rawValue))
+            if let params = subCommandParams, !params.isEmpty {
+                var paramsMap: [CBOR.Value: CBOR.Value] = [:]
+                for (key, value) in params {
+                    paramsMap[.int(Int(key))] = value
+                }
+                map[.int(0x02)] = .map(paramsMap)
+            }
+            map[.int(0x03)] = pinUVAuthProtocol.cbor()
+            map[.int(0x04)] = pinUVAuthParam.cbor()
+            return .map(map)
+        }
+    }
+}

--- a/YubiKit/YubiKit/FIDO/CTAP/Config/Config.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/Config/Config.swift
@@ -24,16 +24,21 @@ extension CTAP2.Session {
     ///     using: .pin("123456"),
     ///     permissions: [.authenticatorConfig]
     /// )
-    /// let config = session.config(pinToken: pinToken)
+    /// let config = try await session.config(pinToken: pinToken)
     /// try await config.toggleAlwaysUV()
     /// try await config.enableEnterpriseAttestation()
     /// ```
     ///
     /// - Parameter pinToken: PIN/UV auth token with `authenticatorConfig` permission.
     /// - Returns: Config operations bound to the token.
+    /// - Throws: `CTAP2.SessionError.featureNotSupported` if authenticatorConfig is not supported.
     /// - SeeAlso: [CTAP2 authenticatorConfig](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorConfig)
-    public func config(pinToken: CTAP2.ClientPin.Token) -> CTAP2.Config {
-        CTAP2.Config(session: self, pinToken: pinToken)
+    public func config(pinToken: CTAP2.ClientPin.Token) async throws(CTAP2.SessionError) -> CTAP2.Config {
+        let info = try await getInfo()
+        guard info.options.authenticatorConfig == true else {
+            throw .featureNotSupported(source: .here())
+        }
+        return CTAP2.Config(session: self, pinToken: pinToken)
     }
 }
 
@@ -47,7 +52,7 @@ extension CTAP2 {
         private let session: CTAP2.Session
         private let pinToken: CTAP2.ClientPin.Token
 
-        init(session: CTAP2.Session, pinToken: CTAP2.ClientPin.Token) {
+        fileprivate init(session: CTAP2.Session, pinToken: CTAP2.ClientPin.Token) {
             self.session = session
             self.pinToken = pinToken
         }


### PR DESCRIPTION
Add authenticatorConfig command for configuring authenticator settings

Implements CTAP2 authenticatorConfig (0x0D) per the CTAP 2.2 specification.

## Subcommands

- **enableEnterpriseAttestation** - Enable enterprise attestation feature
- **toggleAlwaysUV** - Toggle the alwaysUV setting on/off
- **setMinPINLength** - Configure minimum PIN length, RP ID allowlist, force PIN change, and PIN complexity policy

## API

```swift
let pinToken = try await session.getPinUVToken(
    using: .pin(pin),
    permissions: [.authenticatorConfig]
)
let config = session.config(pinToken: pinToken)
try await config.toggleAlwaysUV()
try await config.enableEnterpriseAttestation()
try await config.setMinPINLength(newMinPINLength: 8, forceChangePin: true)
```
