### PR TITLE
CTAP2 Missing extensions

### DIFF
--- a/FullStackTests/FullStackTests.xcodeproj/project.pbxproj
+++ b/FullStackTests/FullStackTests.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		B4F937642B51A7DD0007D394 /* PIVFullStackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F937632B51A7DD0007D394 /* PIVFullStackTests.swift */; };
 		CD75D32C2F1114C7000624CB /* LargeBlobsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD75D32B2F1114C7000624CB /* LargeBlobsTests.swift */; };
 		DA1BB9E330014BCBBD93BF69 /* ConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD89AB9B1BB24FA6B5FD79D3 /* ConfigTests.swift */; };
+		6CCREDBLOB2F1115000000001 /* CredBlobTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CCREDBLOB2F1115000000000 /* CredBlobTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -74,6 +75,7 @@
 		B4F937632B51A7DD0007D394 /* PIVFullStackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PIVFullStackTests.swift; sourceTree = "<group>"; };
 		CD75D32B2F1114C7000624CB /* LargeBlobsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeBlobsTests.swift; sourceTree = "<group>"; };
 		CD89AB9B1BB24FA6B5FD79D3 /* ConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigTests.swift; sourceTree = "<group>"; };
+		6CCREDBLOB2F1115000000000 /* CredBlobTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredBlobTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -173,6 +175,7 @@
 		CD75D32D2F1114C8000624CB /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				6CCREDBLOB2F1115000000000 /* CredBlobTests.swift */,
 				6C734BB32EE860E100972E2A /* CredProtectTests.swift */,
 				CD75D32B2F1114C7000624CB /* LargeBlobsTests.swift */,
 				6CCAB7B92EEC35EA00A789E7 /* PRFTests.swift */,
@@ -332,6 +335,7 @@
 				6C734BAC2EE860AF00972E2A /* HIDTransportTests.swift in Sources */,
 				6CCAB7BA2EEC35EA00A789E7 /* PRFTests.swift in Sources */,
 				DA1BB9E330014BCBBD93BF69 /* ConfigTests.swift in Sources */,
+				6CCREDBLOB2F1115000000001 /* CredBlobTests.swift in Sources */,
 				6C2B14552DC8CF4C00B5C482 /* XCTestCase+SCP.swift in Sources */,
 				6CDATAHEX2EF1234500000001 /* Data+Hex.swift in Sources */,
 			);

--- a/FullStackTests/FullStackTests.xcodeproj/project.pbxproj
+++ b/FullStackTests/FullStackTests.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		CD75D32C2F1114C7000624CB /* LargeBlobsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD75D32B2F1114C7000624CB /* LargeBlobsTests.swift */; };
 		DA1BB9E330014BCBBD93BF69 /* ConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD89AB9B1BB24FA6B5FD79D3 /* ConfigTests.swift */; };
 		6CCREDBLOB2F1115000000001 /* CredBlobTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CCREDBLOB2F1115000000000 /* CredBlobTests.swift */; };
+		6CMINPINLEN2F1116000000001 /* MinPinLengthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CMINPINLEN2F1116000000000 /* MinPinLengthTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -76,6 +77,7 @@
 		CD75D32B2F1114C7000624CB /* LargeBlobsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeBlobsTests.swift; sourceTree = "<group>"; };
 		CD89AB9B1BB24FA6B5FD79D3 /* ConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigTests.swift; sourceTree = "<group>"; };
 		6CCREDBLOB2F1115000000000 /* CredBlobTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredBlobTests.swift; sourceTree = "<group>"; };
+		6CMINPINLEN2F1116000000000 /* MinPinLengthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinPinLengthTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -178,6 +180,7 @@
 				6CCREDBLOB2F1115000000000 /* CredBlobTests.swift */,
 				6C734BB32EE860E100972E2A /* CredProtectTests.swift */,
 				CD75D32B2F1114C7000624CB /* LargeBlobsTests.swift */,
+				6CMINPINLEN2F1116000000000 /* MinPinLengthTests.swift */,
 				6CCAB7B92EEC35EA00A789E7 /* PRFTests.swift */,
 			);
 			path = Extensions;
@@ -336,6 +339,7 @@
 				6CCAB7BA2EEC35EA00A789E7 /* PRFTests.swift in Sources */,
 				DA1BB9E330014BCBBD93BF69 /* ConfigTests.swift in Sources */,
 				6CCREDBLOB2F1115000000001 /* CredBlobTests.swift in Sources */,
+				6CMINPINLEN2F1116000000001 /* MinPinLengthTests.swift in Sources */,
 				6C2B14552DC8CF4C00B5C482 /* XCTestCase+SCP.swift in Sources */,
 				6CDATAHEX2EF1234500000001 /* Data+Hex.swift in Sources */,
 			);

--- a/FullStackTests/Tests/CTAP2/Extensions/CredBlobTests.swift
+++ b/FullStackTests/Tests/CTAP2/Extensions/CredBlobTests.swift
@@ -1,0 +1,203 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Testing
+import YubiKit
+
+@Suite("CredBlob Full Stack Tests", .serialized)
+struct CredBlobFullStackTests {
+
+    // MARK: - Store and Retrieve
+
+    @Test("Store Blob at MakeCredential and Retrieve at GetAssertion")
+    func testStoreAndRetrieveCredBlob() async throws {
+        try await withReconnectableCTAP2Session { session, reconnectWhenOverNFC in
+            var session = session
+
+            guard try await CTAP2.Extension.CredBlob.isSupported(by: session) else {
+                print("credBlob not supported - skipping")
+                return
+            }
+
+            let info = try await session.getInfo()
+            guard info.options.clientPin == true else {
+                print("PIN not set - skipping (credBlob with rk requires PIN)")
+                return
+            }
+
+            let rpId = "credblob-test.example.com"
+            let clientDataHash = Data(repeating: 0xCD, count: 32)
+            let testBlob = Data("Hello from CredBlob test!".utf8)
+
+            // 1. Create credential with credBlob extension
+            session = try await reconnectWhenOverNFC()
+            let pinToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.makeCredential, .getAssertion],
+                rpId: rpId
+            )
+
+            let credBlob = try await CTAP2.Extension.CredBlob(session: session)
+
+            let makeCredParams = CTAP2.MakeCredential.Parameters(
+                clientDataHash: clientDataHash,
+                rp: WebAuthn.PublicKeyCredential.RPEntity(id: rpId, name: "CredBlob Test"),
+                user: WebAuthn.PublicKeyCredential.UserEntity(
+                    id: Data(repeating: 0x01, count: 32),
+                    name: "blob@test.com",
+                    displayName: "CredBlob Test User"
+                ),
+                pubKeyCredParams: [.es256],
+                extensions: [try credBlob.makeCredential.input(blob: testBlob)],
+                options: .init(rk: true)
+            )
+
+            print("👆 Touch YubiKey: creating credential with credBlob...")
+            let credential = try await session.makeCredential(parameters: makeCredParams, pinToken: pinToken).value
+
+            let stored = credBlob.makeCredential.output(from: credential)
+            #expect(stored == true, "credBlob should indicate successful storage")
+            print("✅ Credential created with credBlob stored")
+
+            // 2. GetAssertion with credBlob extension to retrieve blob
+            session = try await reconnectWhenOverNFC()
+            let gaToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.getAssertion],
+                rpId: rpId
+            )
+
+            let credBlobGA = try await CTAP2.Extension.CredBlob(session: session)
+            let getAssertionParams = CTAP2.GetAssertion.Parameters(
+                rpId: rpId,
+                clientDataHash: clientDataHash,
+                extensions: [credBlobGA.getAssertion.input()]
+            )
+
+            print("👆 Touch YubiKey: authenticating to retrieve credBlob...")
+            let assertion = try await session.getAssertion(parameters: getAssertionParams, pinToken: gaToken).value
+
+            let retrievedBlob = credBlobGA.getAssertion.output(from: assertion)
+            #expect(retrievedBlob == testBlob, "Retrieved blob should match stored blob")
+            print("✅ CredBlob retrieved and verified")
+        }
+    }
+
+    // MARK: - Without Extension
+
+    @Test("GetAssertion Without CredBlob Extension Returns No Blob")
+    func testGetAssertionWithoutExtension() async throws {
+        try await withReconnectableCTAP2Session { session, reconnectWhenOverNFC in
+            var session = session
+
+            guard try await CTAP2.Extension.CredBlob.isSupported(by: session) else {
+                print("credBlob not supported - skipping")
+                return
+            }
+
+            let info = try await session.getInfo()
+            guard info.options.clientPin == true else {
+                print("PIN not set - skipping")
+                return
+            }
+
+            let rpId = "credblob-noext.example.com"
+            let clientDataHash = Data(repeating: 0xCD, count: 32)
+            let testBlob = Data("Blob that should not be returned".utf8)
+
+            // 1. Create credential with credBlob
+            session = try await reconnectWhenOverNFC()
+            let pinToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.makeCredential, .getAssertion],
+                rpId: rpId
+            )
+
+            let credBlob = try await CTAP2.Extension.CredBlob(session: session)
+
+            let makeCredParams = CTAP2.MakeCredential.Parameters(
+                clientDataHash: clientDataHash,
+                rp: WebAuthn.PublicKeyCredential.RPEntity(id: rpId, name: "CredBlob NoExt Test"),
+                user: WebAuthn.PublicKeyCredential.UserEntity(
+                    id: Data(repeating: 0x02, count: 32),
+                    name: "noext@test.com",
+                    displayName: "NoExt User"
+                ),
+                pubKeyCredParams: [.es256],
+                extensions: [try credBlob.makeCredential.input(blob: testBlob)],
+                options: .init(rk: true)
+            )
+
+            print("👆 Touch YubiKey: creating credential with credBlob...")
+            _ = try await session.makeCredential(parameters: makeCredParams, pinToken: pinToken).value
+            print("✅ Credential created")
+
+            // 2. GetAssertion WITHOUT credBlob extension
+            session = try await reconnectWhenOverNFC()
+            let gaToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.getAssertion],
+                rpId: rpId
+            )
+
+            // GetAssertion without extensions
+            let getAssertionParams = CTAP2.GetAssertion.Parameters(
+                rpId: rpId,
+                clientDataHash: clientDataHash
+            )
+
+            print("👆 Touch YubiKey: authenticating without credBlob extension...")
+            let assertion = try await session.getAssertion(parameters: getAssertionParams, pinToken: gaToken).value
+
+            let credBlobGA = try await CTAP2.Extension.CredBlob(session: session)
+            let retrievedBlob = credBlobGA.getAssertion.output(from: assertion)
+            #expect(retrievedBlob == nil, "Blob should not be returned without extension")
+            print("✅ Verified no blob returned without extension")
+        }
+    }
+
+    // MARK: - Max Length Validation
+
+    @Test("CredBlob Rejects Oversized Blob")
+    func testOversizedBlobRejected() async throws {
+        try await withCTAP2Session { session in
+            guard try await CTAP2.Extension.CredBlob.isSupported(by: session) else {
+                print("credBlob not supported - skipping")
+                return
+            }
+
+            let info = try await session.getInfo()
+            guard let maxLength = info.maxCredBlobLength else {
+                print("maxCredBlobLength not available - skipping")
+                return
+            }
+
+            let credBlob = try await CTAP2.Extension.CredBlob(session: session)
+            let oversizedBlob = Data(repeating: 0xFF, count: Int(maxLength) + 1)
+
+            do {
+                _ = try credBlob.makeCredential.input(blob: oversizedBlob)
+                Issue.record("Expected error for oversized blob")
+            } catch let error as CTAP2.SessionError {
+                guard case .illegalArgument = error else {
+                    Issue.record("Expected illegalArgument error, got \(error)")
+                    return
+                }
+                print("✅ Correctly rejected oversized blob (\(oversizedBlob.count) > \(maxLength) bytes)")
+            }
+        }
+    }
+
+}

--- a/FullStackTests/Tests/CTAP2/Extensions/CredBlobTests.swift
+++ b/FullStackTests/Tests/CTAP2/Extensions/CredBlobTests.swift
@@ -45,7 +45,7 @@ struct CredBlobFullStackTests {
             session = try await reconnectWhenOverNFC()
             let pinToken = try await session.getPinUVToken(
                 using: .pin(defaultTestPin),
-                permissions: [.makeCredential, .getAssertion],
+                permissions: [.makeCredential],
                 rpId: rpId
             )
 
@@ -121,7 +121,7 @@ struct CredBlobFullStackTests {
             session = try await reconnectWhenOverNFC()
             let pinToken = try await session.getPinUVToken(
                 using: .pin(defaultTestPin),
-                permissions: [.makeCredential, .getAssertion],
+                permissions: [.makeCredential],
                 rpId: rpId
             )
 

--- a/FullStackTests/Tests/CTAP2/Extensions/LargeBlobsTests.swift
+++ b/FullStackTests/Tests/CTAP2/Extensions/LargeBlobsTests.swift
@@ -50,7 +50,7 @@ struct LargeBlobsFullStackTests {
                 rpId: rpId
             )
 
-            let largeBlobKey = CTAP2.Extension.LargeBlobKey()
+            let largeBlobKey = try await CTAP2.Extension.LargeBlobKey(session: session)
 
             let makeCredParams = CTAP2.MakeCredential.Parameters(
                 clientDataHash: clientDataHash,
@@ -137,7 +137,7 @@ struct LargeBlobsFullStackTests {
                 rpId: rpId
             )
 
-            let largeBlobKey = CTAP2.Extension.LargeBlobKey()
+            let largeBlobKey = try await CTAP2.Extension.LargeBlobKey(session: session)
 
             let makeCredParams = CTAP2.MakeCredential.Parameters(
                 clientDataHash: clientDataHash,
@@ -235,7 +235,7 @@ struct LargeBlobsFullStackTests {
                 rpId: rpId
             )
 
-            let largeBlobKey = CTAP2.Extension.LargeBlobKey()
+            let largeBlobKey = try await CTAP2.Extension.LargeBlobKey(session: session)
 
             let params1 = CTAP2.MakeCredential.Parameters(
                 clientDataHash: clientDataHash,

--- a/FullStackTests/Tests/CTAP2/Extensions/MinPinLengthTests.swift
+++ b/FullStackTests/Tests/CTAP2/Extensions/MinPinLengthTests.swift
@@ -29,7 +29,7 @@ struct MinPinLengthFullStackTests {
                 return
             }
 
-            guard try await CTAP2.Config.Operations.isSupported(by: session) else {
+            guard try await CTAP2.Config.isSupported(by: session) else {
                 print("authenticatorConfig not supported - skipping")
                 return
             }
@@ -47,7 +47,7 @@ struct MinPinLengthFullStackTests {
                 using: .pin(defaultTestPin),
                 permissions: [.authenticatorConfig]
             )
-            let config = try await CTAP2.Config.Operations(session: session, pinToken: configToken)
+            let config = try await session.config(pinToken: configToken)
             try await config.setMinPINLength(rpIDs: [rpId])
 
             // Create credential with minPinLength extension

--- a/FullStackTests/Tests/CTAP2/Extensions/MinPinLengthTests.swift
+++ b/FullStackTests/Tests/CTAP2/Extensions/MinPinLengthTests.swift
@@ -1,0 +1,94 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Testing
+import YubiKit
+
+@Suite("MinPinLength Full Stack Tests", .serialized)
+struct MinPinLengthFullStackTests {
+
+    // MARK: - Configured RP Test
+
+    @Test("MinPinLength returns value when RP is configured")
+    func testMinPinLengthWithConfiguredRP() async throws {
+        try await withCTAP2Session { session in
+            guard try await CTAP2.Extension.MinPinLength.isSupported(by: session) else {
+                print("minPinLength not supported - skipping")
+                return
+            }
+
+            guard try await CTAP2.Config.Operations.isSupported(by: session) else {
+                print("authenticatorConfig not supported - skipping")
+                return
+            }
+
+            let info = try await session.getInfo()
+            guard info.options.clientPin == true else {
+                print("PIN not set - skipping")
+                return
+            }
+
+            let rpId = "minpinlength-configured-test.example.com"
+
+            // Configure the RP ID to receive minPinLength
+            let configToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.authenticatorConfig]
+            )
+            let config = try await CTAP2.Config.Operations(session: session, pinToken: configToken)
+            try await config.setMinPINLength(rpIDs: [rpId])
+
+            // Create credential with minPinLength extension
+            let makeCredToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.makeCredential],
+                rpId: rpId
+            )
+
+            let minPinLength = try await CTAP2.Extension.MinPinLength(session: session)
+
+            let makeCredParams = CTAP2.MakeCredential.Parameters(
+                clientDataHash: Data(repeating: 0xCD, count: 32),
+                rp: WebAuthn.PublicKeyCredential.RPEntity(id: rpId, name: "MinPinLength Test"),
+                user: WebAuthn.PublicKeyCredential.UserEntity(
+                    id: Data(repeating: 0x01, count: 32),
+                    name: "minpin@test.com",
+                    displayName: "MinPinLength Test User"
+                ),
+                pubKeyCredParams: [.es256],
+                extensions: [minPinLength.makeCredential.input()]
+            )
+
+            print("👆 Touch YubiKey: creating credential with minPinLength extension...")
+            let credential = try await session.makeCredential(
+                parameters: makeCredParams,
+                pinToken: makeCredToken
+            ).value
+
+            let length = minPinLength.makeCredential.output(from: credential)
+
+            // Since we configured the RP ID, we should get the minPinLength back
+            #expect(length != nil, "minPinLength should be returned for configured RP")
+            if let length {
+                #expect(length >= 4, "minPinLength should be at least 4")
+                if let infoMinPinLength = info.minPinLength {
+                    #expect(length == infoMinPinLength, "Should match info.minPinLength")
+                }
+                print("✅ minPinLength returned: \(length)")
+            }
+        }
+    }
+
+}

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnClientLogic.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnClientLogic.swift
@@ -65,7 +65,7 @@ func buildCreateExtensions(
     if let support = request.extensions?.largeBlob?.support,
         support == "required" || support == "preferred"
     {
-        let largeBlobKey = CTAP2.Extension.LargeBlobKey()
+        let largeBlobKey = try await CTAP2.Extension.LargeBlobKey(session: session)
         state.inputs.append(largeBlobKey.makeCredential.input())
         state.largeBlobKey = largeBlobKey
     }
@@ -94,7 +94,7 @@ func buildGetExtensions(
     let wantsRead = request.extensions?.largeBlob?.read == true
     let writeData = request.extensions?.largeBlob?.write.flatMap { Data(base64Encoded: $0) }
     if wantsRead || writeData != nil {
-        let largeBlobKey = CTAP2.Extension.LargeBlobKey()
+        let largeBlobKey = try await CTAP2.Extension.LargeBlobKey(session: session)
         state.inputs.append(largeBlobKey.getAssertion.input())
         state.largeBlobKey = largeBlobKey
         state.largeBlobRead = wantsRead

--- a/YubiKit/YubiKit/FIDO/CTAP/Config/Config.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/Config/Config.swift
@@ -57,6 +57,15 @@ extension CTAP2 {
             self.pinToken = pinToken
         }
 
+        /// Checks if the authenticator supports authenticatorConfig.
+        ///
+        /// - Parameter session: The CTAP2 session to check.
+        /// - Returns: `true` if the authenticator supports authenticatorConfig.
+        public static func isSupported(by session: CTAP2.Session) async throws(CTAP2.SessionError) -> Bool {
+            let info = try await session.getInfo()
+            return info.options.authenticatorConfig == true
+        }
+
         /// Enables enterprise attestation. If already enabled, this command is ignored.
         ///
         /// - SeeAlso: [Enable Enterprise Attestation](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#enable-enterprise-attestation)

--- a/YubiKit/YubiKit/FIDO/CTAP/Config/Config.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/Config/Config.swift
@@ -88,14 +88,11 @@ extension CTAP2 {
         ///   - newMinPINLength: The minimum PIN length to allow. Pass `nil` to keep current.
         ///   - rpIDs: RP IDs allowed to query minimum PIN length via extension.
         ///   - forceChangePin: Enforce PIN change before next use.
-        ///   - pinComplexityPolicy: Enable PIN complexity enforcement.
-        /// - Throws: `CTAP2.SessionError.illegalArgument` if `pinComplexityPolicy` is unsupported.
         /// - SeeAlso: [Setting a Minimum PIN Length](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#setMinPINLength)
         public func setMinPINLength(
             newMinPINLength: UInt? = nil,
             rpIDs: [String]? = nil,
-            forceChangePin: Bool = false,
-            pinComplexityPolicy: Bool = false
+            forceChangePin: Bool = false
         ) async throws(CTAP2.SessionError) {
             var params: [UInt8: CBOR.Value] = [:]
             if let length = newMinPINLength {
@@ -106,16 +103,6 @@ extension CTAP2 {
             }
             if forceChangePin {
                 params[Parameter.forceChangePin.rawValue] = true.cbor()
-            }
-            if pinComplexityPolicy {
-                let info = try await session.getInfo()
-                guard info.pinComplexityPolicy != nil else {
-                    throw .illegalArgument(
-                        "Authenticator does not support PIN complexity policy",
-                        source: .here()
-                    )
-                }
-                params[Parameter.pinComplexityPolicy.rawValue] = true.cbor()
             }
 
             try await execute(subcommand: .setMinPINLength, params: params)
@@ -171,7 +158,6 @@ extension CTAP2.Config {
         case newMinPINLength = 0x01
         case minPINLengthRPIDs = 0x02
         case forceChangePin = 0x03
-        case pinComplexityPolicy = 0x04
     }
 
     fileprivate struct RequestParameters: Sendable, CBOR.Encodable {

--- a/YubiKit/YubiKit/FIDO/CTAP/Extensions/CredBlob.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/Extensions/CredBlob.swift
@@ -1,0 +1,124 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+// MARK: - CredBlob Extension
+
+extension CTAP2.Extension {
+    /// The credBlob extension for storing small blobs with discoverable credentials.
+    ///
+    /// This extension allows storing a small amount of data (up to `maxCredBlobLength`
+    /// bytes) with a credential during registration, and retrieving it during authentication.
+    ///
+    /// - SeeAlso: [CTAP2 credBlob Extension](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-credBlob-extension)
+    public struct CredBlob: Sendable {
+        /// The extension identifier for credBlob.
+        static let identifier: Identifier = .credBlob
+
+        /// Maximum blob length supported by the authenticator.
+        private let maxLength: UInt?
+
+        // MARK: - Initializer
+
+        /// Creates a CredBlob extension instance.
+        ///
+        /// - Parameter session: The CTAP2 session to check for support.
+        /// - Throws: `CTAP2.SessionError.extensionNotSupported` if credBlob is not supported.
+        public init(session: CTAP2.Session) async throws(CTAP2.SessionError) {
+            let info = try await session.getInfo()
+            guard info.extensions.contains(Self.identifier) else {
+                throw .extensionNotSupported(Self.identifier, source: .here())
+            }
+            self.maxLength = info.maxCredBlobLength
+        }
+
+        /// Checks if the authenticator supports credBlob.
+        ///
+        /// - Parameter session: The CTAP2 session to check.
+        /// - Returns: `true` if the authenticator supports credBlob.
+        public static func isSupported(by session: CTAP2.Session) async throws(CTAP2.SessionError) -> Bool {
+            let info = try await session.getInfo()
+            return info.extensions.contains(identifier)
+        }
+
+        // MARK: - Operations
+
+        /// Operations for MakeCredential.
+        public var makeCredential: MakeCredentialOperations {
+            MakeCredentialOperations(parent: self)
+        }
+
+        /// Operations for GetAssertion.
+        public var getAssertion: GetAssertionOperations {
+            GetAssertionOperations()
+        }
+    }
+}
+
+// MARK: - MakeCredential Operations
+
+extension CTAP2.Extension.CredBlob {
+    /// MakeCredential operations for credBlob.
+    public struct MakeCredentialOperations: Sendable {
+        fileprivate let parent: CTAP2.Extension.CredBlob
+
+        /// Creates a MakeCredential input to store a blob with the credential.
+        ///
+        /// - Parameter blob: The data to store (must not exceed `maxCredBlobLength`).
+        /// - Returns: An extension input for MakeCredential.
+        /// - Throws: `CTAP2.SessionError.illegalArgument` if the blob exceeds the maximum length.
+        public func input(blob: Data) throws(CTAP2.SessionError) -> CTAP2.Extension.MakeCredential.Input {
+            if let maxLength = parent.maxLength, blob.count > maxLength {
+                throw .illegalArgument("Blob exceeds max length (\(blob.count) > \(maxLength))", source: .here())
+            }
+            return CTAP2.Extension.MakeCredential.Input(
+                encoded: [CTAP2.Extension.CredBlob.identifier: .byteString(blob)]
+            )
+        }
+
+        /// Extracts the credBlob result from a MakeCredential response.
+        ///
+        /// - Parameter response: The MakeCredential response from the authenticator.
+        /// - Returns: `true` if stored, `false` if failed, or `nil` if not present.
+        public func output(from response: CTAP2.MakeCredential.Response) -> Bool? {
+            response.authenticatorData.extensions?[CTAP2.Extension.CredBlob.identifier]?.boolValue
+        }
+    }
+}
+
+// MARK: - GetAssertion Operations
+
+extension CTAP2.Extension.CredBlob {
+    /// GetAssertion operations for credBlob.
+    public struct GetAssertionOperations: Sendable {
+
+        /// Creates a GetAssertion input to retrieve the stored blob.
+        ///
+        /// - Returns: An extension input for GetAssertion.
+        public func input() -> CTAP2.Extension.GetAssertion.Input {
+            CTAP2.Extension.GetAssertion.Input(
+                encoded: [CTAP2.Extension.CredBlob.identifier: .boolean(true)]
+            )
+        }
+
+        /// Extracts the credBlob data from a GetAssertion response.
+        ///
+        /// - Parameter response: The GetAssertion response from the authenticator.
+        /// - Returns: The stored blob data, or `nil` if not present.
+        public func output(from response: CTAP2.GetAssertion.Response) -> Data? {
+            response.authenticatorData.extensions?[CTAP2.Extension.CredBlob.identifier]?.dataValue
+        }
+    }
+}

--- a/YubiKit/YubiKit/FIDO/CTAP/Extensions/Extension.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/Extensions/Extension.swift
@@ -40,6 +40,9 @@ extension CTAP2.Extension {
         /// The minPinLength extension for including minimum PIN length in authenticator data.
         case minPinLength
 
+        /// The thirdPartyPayment extension for Secure Payment Confirmation (CTAP 2.2+).
+        case thirdPartyPayment
+
         /// Other extension not explicitly defined.
         case other(String)
 
@@ -52,6 +55,7 @@ extension CTAP2.Extension {
             case .largeBlobKey: return "largeBlobKey"
             case .credBlob: return "credBlob"
             case .minPinLength: return "minPinLength"
+            case .thirdPartyPayment: return "thirdPartyPayment"
             case .other(let value): return value
             }
         }
@@ -67,6 +71,7 @@ extension CTAP2.Extension {
             case "largeBlobKey": self = .largeBlobKey
             case "credBlob": self = .credBlob
             case "minPinLength": self = .minPinLength
+            case "thirdPartyPayment": self = .thirdPartyPayment
             default: self = .other(value)
             }
         }

--- a/YubiKit/YubiKit/FIDO/CTAP/Extensions/Extension.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/Extensions/Extension.swift
@@ -34,6 +34,9 @@ extension CTAP2.Extension {
         /// The largeBlobKey extension for associating large blobs with credentials (CTAP 2.1+).
         case largeBlobKey
 
+        /// The credBlob extension for storing small blobs with credentials (CTAP 2.1+).
+        case credBlob
+
         /// Other extension not explicitly defined.
         case other(String)
 
@@ -44,6 +47,7 @@ extension CTAP2.Extension {
             case .hmacSecretMC: return "hmac-secret-mc"
             case .credProtect: return "credProtect"
             case .largeBlobKey: return "largeBlobKey"
+            case .credBlob: return "credBlob"
             case .other(let value): return value
             }
         }
@@ -57,6 +61,7 @@ extension CTAP2.Extension {
             case "hmac-secret-mc": self = .hmacSecretMC
             case "credProtect": self = .credProtect
             case "largeBlobKey": self = .largeBlobKey
+            case "credBlob": self = .credBlob
             default: self = .other(value)
             }
         }

--- a/YubiKit/YubiKit/FIDO/CTAP/Extensions/Extension.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/Extensions/Extension.swift
@@ -37,6 +37,9 @@ extension CTAP2.Extension {
         /// The credBlob extension for storing small blobs with credentials (CTAP 2.1+).
         case credBlob
 
+        /// The minPinLength extension for including minimum PIN length in authenticator data.
+        case minPinLength
+
         /// Other extension not explicitly defined.
         case other(String)
 
@@ -48,6 +51,7 @@ extension CTAP2.Extension {
             case .credProtect: return "credProtect"
             case .largeBlobKey: return "largeBlobKey"
             case .credBlob: return "credBlob"
+            case .minPinLength: return "minPinLength"
             case .other(let value): return value
             }
         }
@@ -62,6 +66,7 @@ extension CTAP2.Extension {
             case "credProtect": self = .credProtect
             case "largeBlobKey": self = .largeBlobKey
             case "credBlob": self = .credBlob
+            case "minPinLength": self = .minPinLength
             default: self = .other(value)
             }
         }

--- a/YubiKit/YubiKit/FIDO/CTAP/Extensions/LargeBlobKey.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/Extensions/LargeBlobKey.swift
@@ -26,12 +26,30 @@ extension CTAP2.Extension {
     /// - SeeAlso: [CTAP2 largeBlobKey Extension](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-largeBlobKey-extension)
     public struct LargeBlobKey: Sendable {
         /// The extension identifier for largeBlobKey.
-        private static let identifier: Identifier = .largeBlobKey
+        static let identifier: Identifier = .largeBlobKey
 
         // MARK: - Initializer
 
         /// Creates a LargeBlobKey extension instance.
-        public init() {}
+        ///
+        /// - Parameter session: The CTAP2 session to check for support.
+        /// - Throws: `CTAP2.SessionError.extensionNotSupported` if largeBlobKey is not supported.
+        public init(session: CTAP2.Session) async throws(CTAP2.SessionError) {
+            guard try await Self.isSupported(by: session) else {
+                throw .extensionNotSupported(Self.identifier, source: .here())
+            }
+        }
+
+        /// Checks if the authenticator supports largeBlobKey.
+        ///
+        /// Support requires both the `largeBlobKey` extension and the `largeBlobs` option.
+        ///
+        /// - Parameter session: The CTAP2 session to check.
+        /// - Returns: `true` if the authenticator supports largeBlobKey.
+        public static func isSupported(by session: CTAP2.Session) async throws(CTAP2.SessionError) -> Bool {
+            let info = try await session.getInfo()
+            return info.extensions.contains(identifier) && info.options.largeBlobs == true
+        }
 
         // MARK: - Operations
 

--- a/YubiKit/YubiKit/FIDO/CTAP/Extensions/MinPinLength.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/Extensions/MinPinLength.swift
@@ -1,0 +1,88 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+// MARK: - MinPinLength Extension
+
+extension CTAP2.Extension {
+    /// The minPinLength extension for returning minimum PIN length in authenticator data.
+    ///
+    /// This extension allows a relying party to verify that the authenticator enforces
+    /// a minimum PIN length policy. The RP must be configured via authenticatorConfig
+    /// for the value to be returned.
+    ///
+    /// - SeeAlso: [CTAP2 minPinLength Extension](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-minpinlength-extension)
+    public struct MinPinLength: Sendable {
+        /// The extension identifier for minPinLength.
+        static let identifier: Identifier = .minPinLength
+
+        // MARK: - Initializer
+
+        /// Creates a MinPinLength extension instance.
+        ///
+        /// - Parameter session: The CTAP2 session to check for support.
+        /// - Throws: `CTAP2.SessionError.extensionNotSupported` if minPinLength is not supported.
+        public init(session: CTAP2.Session) async throws(CTAP2.SessionError) {
+            guard try await Self.isSupported(by: session) else {
+                throw .extensionNotSupported(Self.identifier, source: .here())
+            }
+        }
+
+        /// Checks if the authenticator supports minPinLength.
+        ///
+        /// - Parameter session: The CTAP2 session to check.
+        /// - Returns: `true` if the authenticator supports minPinLength.
+        public static func isSupported(by session: CTAP2.Session) async throws(CTAP2.SessionError) -> Bool {
+            let info = try await session.getInfo()
+            return info.options.setMinPINLength != nil
+        }
+
+        // MARK: - Operations
+
+        /// Operations for MakeCredential.
+        public var makeCredential: MakeCredentialOperations {
+            MakeCredentialOperations()
+        }
+    }
+}
+
+// MARK: - MakeCredential Operations
+
+extension CTAP2.Extension.MinPinLength {
+    /// MakeCredential operations for minPinLength.
+    public struct MakeCredentialOperations: Sendable {
+
+        /// Creates a MakeCredential input to request the minimum PIN length.
+        ///
+        /// - Returns: An extension input for MakeCredential.
+        public func input() -> CTAP2.Extension.MakeCredential.Input {
+            CTAP2.Extension.MakeCredential.Input(
+                encoded: [CTAP2.Extension.MinPinLength.identifier: .boolean(true)]
+            )
+        }
+
+        /// Extracts the minimum PIN length from a MakeCredential response.
+        ///
+        /// - Parameter response: The MakeCredential response from the authenticator.
+        /// - Returns: The minimum PIN length, or `nil` if not present.
+        public func output(from response: CTAP2.MakeCredential.Response) -> UInt? {
+            let identifier = CTAP2.Extension.MinPinLength.identifier
+            guard let value = response.authenticatorData.extensions?[identifier]?.uint64Value else {
+                return nil
+            }
+            return UInt(value)
+        }
+    }
+}

--- a/YubiKit/YubiKit/FIDO/CTAP/Extensions/ThirdPartyPayment.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/Extensions/ThirdPartyPayment.swift
@@ -1,0 +1,123 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+// MARK: - ThirdPartyPayment Extension
+
+extension CTAP2.Extension {
+    /// The thirdPartyPayment extension for Secure Payment Confirmation (CTAP 2.2+).
+    ///
+    /// This extension allows a Relying Party to indicate that a credential can be used
+    /// for payment authentication initiated by a third party.
+    ///
+    /// - Important: Most of the processing for Secure Payment Confirmation must be done
+    ///   by the WebAuthn client. This extension only handles the CTAP2 authenticator
+    ///   interaction and should not be used without a client that supports the WebAuthn
+    ///   payment extension.
+    ///
+    /// - SeeAlso: [CTAP2 thirdPartyPayment Extension](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#sctn-thirdPartyPayment-extension)
+    /// - SeeAlso: [Secure Payment Confirmation](https://www.w3.org/TR/secure-payment-confirmation)
+    public struct ThirdPartyPayment: Sendable {
+        /// The extension identifier for thirdPartyPayment.
+        static let identifier: Identifier = .thirdPartyPayment
+
+        // MARK: - Initializer
+
+        /// Creates a ThirdPartyPayment extension instance.
+        ///
+        /// - Parameter session: The CTAP2 session to check for support.
+        /// - Throws: `CTAP2.SessionError.extensionNotSupported` if thirdPartyPayment is not supported.
+        public init(session: CTAP2.Session) async throws(CTAP2.SessionError) {
+            guard try await Self.isSupported(by: session) else {
+                throw .extensionNotSupported(Self.identifier, source: .here())
+            }
+        }
+
+        /// Checks if the authenticator supports thirdPartyPayment.
+        ///
+        /// - Parameter session: The CTAP2 session to check.
+        /// - Returns: `true` if the authenticator supports thirdPartyPayment.
+        public static func isSupported(
+            by session: CTAP2.Session
+        ) async throws(CTAP2.SessionError) -> Bool {
+            let info = try await session.getInfo()
+            return info.extensions.contains(identifier)
+        }
+
+        // MARK: - Operations
+
+        /// Operations for MakeCredential.
+        public var makeCredential: MakeCredentialOperations {
+            MakeCredentialOperations()
+        }
+
+        /// Operations for GetAssertion.
+        public var getAssertion: GetAssertionOperations {
+            GetAssertionOperations()
+        }
+    }
+}
+
+// MARK: - MakeCredential Operations
+
+extension CTAP2.Extension.ThirdPartyPayment {
+    /// MakeCredential operations for thirdPartyPayment.
+    public struct MakeCredentialOperations: Sendable {
+
+        /// Creates a MakeCredential input to mark credential as payment-capable.
+        ///
+        /// - Returns: An extension input for MakeCredential.
+        public func input() -> CTAP2.Extension.MakeCredential.Input {
+            CTAP2.Extension.MakeCredential.Input(
+                encoded: [CTAP2.Extension.ThirdPartyPayment.identifier: .boolean(true)]
+            )
+        }
+
+        /// Extracts the thirdPartyPayment result from a MakeCredential response.
+        ///
+        /// - Parameter response: The MakeCredential response from the authenticator.
+        /// - Returns: `true` if enabled, `false` if failed, or `nil` if not present.
+        public func output(from response: CTAP2.MakeCredential.Response) -> Bool? {
+            response.authenticatorData.extensions?[CTAP2.Extension.ThirdPartyPayment.identifier]?
+                .boolValue
+        }
+    }
+}
+
+// MARK: - GetAssertion Operations
+
+extension CTAP2.Extension.ThirdPartyPayment {
+    /// GetAssertion operations for thirdPartyPayment.
+    public struct GetAssertionOperations: Sendable {
+
+        /// Creates a GetAssertion input to request payment confirmation.
+        ///
+        /// - Returns: An extension input for GetAssertion.
+        public func input() -> CTAP2.Extension.GetAssertion.Input {
+            CTAP2.Extension.GetAssertion.Input(
+                encoded: [CTAP2.Extension.ThirdPartyPayment.identifier: .boolean(true)]
+            )
+        }
+
+        /// Extracts the thirdPartyPayment result from a GetAssertion response.
+        ///
+        /// - Parameter response: The GetAssertion response from the authenticator.
+        /// - Returns: `true` if enabled, `false` if failed, or `nil` if not present.
+        public func output(from response: CTAP2.GetAssertion.Response) -> Bool? {
+            response.authenticatorData.extensions?[CTAP2.Extension.ThirdPartyPayment.identifier]?
+                .boolValue
+        }
+    }
+}


### PR DESCRIPTION
This PR implements missing CTAP2 extensions for YubiKit, adding support for credential blob storage, PIN policies, and secure payment confirmation.

#### Changes:

Added four new CTAP2 extensions: credBlob, minPinLength and thirdPartyPayment
Updated LargeBlobKey extension to validate support during initialization
Added comprehensive test coverage for the new extensions