### PR TITLE
CTAP2.3 Missing GetInfo properties

### DIFF
--- a/FullStackTests/FullStackTests.xcodeproj/project.pbxproj
+++ b/FullStackTests/FullStackTests.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		DA1BB9E330014BCBBD93BF69 /* ConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD89AB9B1BB24FA6B5FD79D3 /* ConfigTests.swift */; };
 		6CCREDBLOB2F1115000000001 /* CredBlobTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CCREDBLOB2F1115000000000 /* CredBlobTests.swift */; };
 		6CMINPINLEN2F1116000000001 /* MinPinLengthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CMINPINLEN2F1116000000000 /* MinPinLengthTests.swift */; };
+		B2A73E5DE80348329B8FA710 /* EncryptedFieldsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E3FD736FBE49ECAAAFA28E /* EncryptedFieldsTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -78,6 +79,7 @@
 		CD89AB9B1BB24FA6B5FD79D3 /* ConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigTests.swift; sourceTree = "<group>"; };
 		6CCREDBLOB2F1115000000000 /* CredBlobTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredBlobTests.swift; sourceTree = "<group>"; };
 		6CMINPINLEN2F1116000000000 /* MinPinLengthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinPinLengthTests.swift; sourceTree = "<group>"; };
+		59E3FD736FBE49ECAAAFA28E /* EncryptedFieldsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptedFieldsTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -168,6 +170,7 @@
 				CD75D32D2F1114C8000624CB /* Extensions */,
 				CD89AB9B1BB24FA6B5FD79D3 /* ConfigTests.swift */,
 				6C734BB42EE860E100972E2A /* CredentialTests.swift */,
+				59E3FD736FBE49ECAAAFA28E /* EncryptedFieldsTests.swift */,
 				6C734BAA2EE860AF00972E2A /* HIDTransportTests.swift */,
 				6C734BB82EE861EE00972E2A /* TestHelpers.swift */,
 			);
@@ -342,6 +345,7 @@
 				6CMINPINLEN2F1116000000001 /* MinPinLengthTests.swift in Sources */,
 				6C2B14552DC8CF4C00B5C482 /* XCTestCase+SCP.swift in Sources */,
 				6CDATAHEX2EF1234500000001 /* Data+Hex.swift in Sources */,
+				B2A73E5DE80348329B8FA710 /* EncryptedFieldsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FullStackTests/Tests/CTAP2/EncryptedFieldsTests.swift
+++ b/FullStackTests/Tests/CTAP2/EncryptedFieldsTests.swift
@@ -59,7 +59,7 @@ struct EncryptedFieldsTests {
             )
 
             let state = try info.encCredStoreState!.decrypted(using: ppuat)
-            print("✅ Decrypted credential store state: high=\(state.high), low=\(state.low)")
+            print("✅ Decrypted credential store state: \(state)")
 
             // Decrypt again to verify same result (without credential changes)
             let info2 = try await session.getInfo()
@@ -74,7 +74,8 @@ struct EncryptedFieldsTests {
     @Test("Persistent pinUvAuthToken works across reconnects")
     func testPersistentTokenAcrossReconnects() async throws {
         // First session: get PPUAT and decrypt fields
-        let (ppuat, identifier1, credStoreState1): (CTAP2.ClientPin.Token, UUID, CTAP2.GetInfo.CredStoreState?) =
+        typealias Opaque128 = CTAP2.GetInfo.Opaque128
+        let (ppuat, identifier1, credStoreState1): (CTAP2.ClientPin.Token, Opaque128, Opaque128?) =
             try await withCTAP2Session { session in
                 let info = try await session.getInfo()
                 try #require(info.encIdentifier != nil, "encIdentifier not supported")

--- a/FullStackTests/Tests/CTAP2/EncryptedFieldsTests.swift
+++ b/FullStackTests/Tests/CTAP2/EncryptedFieldsTests.swift
@@ -33,12 +33,12 @@ struct EncryptedFieldsTests {
                 permissions: [.persistentCredentialManagement]
             )
 
-            let identifier: UUID = try info.encIdentifier!.decrypt(using: ppuat)
+            let identifier = try info.encIdentifier!.decrypted(using: ppuat)
             print("✅ Decrypted device identifier: \(identifier)")
 
             // Decrypt again to verify same result
             let info2 = try await session.getInfo()
-            let identifier2: UUID = try info2.encIdentifier!.decrypt(using: ppuat)
+            let identifier2 = try info2.encIdentifier!.decrypted(using: ppuat)
             #expect(identifier == identifier2)
             print("✅ Decrypted identifier is consistent across GetInfo calls")
         }
@@ -58,12 +58,12 @@ struct EncryptedFieldsTests {
                 permissions: [.persistentCredentialManagement]
             )
 
-            let state: CTAP2.GetInfo.CredStoreState = try info.encCredStoreState!.decrypt(using: ppuat)
+            let state = try info.encCredStoreState!.decrypted(using: ppuat)
             print("✅ Decrypted credential store state: high=\(state.high), low=\(state.low)")
 
             // Decrypt again to verify same result (without credential changes)
             let info2 = try await session.getInfo()
-            let state2: CTAP2.GetInfo.CredStoreState = try info2.encCredStoreState!.decrypt(using: ppuat)
+            let state2 = try info2.encCredStoreState!.decrypted(using: ppuat)
             #expect(state == state2)
             print("✅ Decrypted state is consistent when no credentials changed")
         }
@@ -84,9 +84,9 @@ struct EncryptedFieldsTests {
                     permissions: [.persistentCredentialManagement]
                 )
 
-                let identifier: UUID = try info.encIdentifier!.decrypt(using: ppuat)
-                let credStoreState: CTAP2.GetInfo.CredStoreState? = try info.encCredStoreState.map {
-                    try $0.decrypt(using: ppuat)
+                let identifier = try info.encIdentifier!.decrypted(using: ppuat)
+                let credStoreState = try info.encCredStoreState.map {
+                    try $0.decrypted(using: ppuat)
                 }
 
                 return (ppuat, identifier, credStoreState)
@@ -96,12 +96,12 @@ struct EncryptedFieldsTests {
         try await withCTAP2Session { session in
             let info = try await session.getInfo()
 
-            let identifier2: UUID = try info.encIdentifier!.decrypt(using: ppuat)
+            let identifier2 = try info.encIdentifier!.decrypted(using: ppuat)
             #expect(identifier1 == identifier2)
             print("✅ Device identifier consistent across reconnects")
 
             if let credStoreState1 = credStoreState1 {
-                let credStoreState2: CTAP2.GetInfo.CredStoreState = try info.encCredStoreState!.decrypt(using: ppuat)
+                let credStoreState2 = try info.encCredStoreState!.decrypted(using: ppuat)
                 #expect(credStoreState1 == credStoreState2)
                 print("✅ Credential store state consistent across reconnects")
             }

--- a/FullStackTests/Tests/CTAP2/EncryptedFieldsTests.swift
+++ b/FullStackTests/Tests/CTAP2/EncryptedFieldsTests.swift
@@ -25,10 +25,7 @@ struct EncryptedFieldsTests {
     func testDecryptEncIdentifier() async throws {
         try await withCTAP2Session { session in
             let info = try await session.getInfo()
-            guard info.encIdentifier != nil else {
-                print("encIdentifier not supported - skipping")
-                return
-            }
+            try #require(info.encIdentifier != nil, "encIdentifier not supported")
 
             // Get persistent pinUvAuthToken (PPUAT) with pcmr permission
             let ppuat = try await session.getPinUVToken(
@@ -53,10 +50,7 @@ struct EncryptedFieldsTests {
     func testDecryptEncCredStoreState() async throws {
         try await withCTAP2Session { session in
             let info = try await session.getInfo()
-            guard info.encCredStoreState != nil else {
-                print("encCredStoreState not supported - skipping")
-                return
-            }
+            try #require(info.encCredStoreState != nil, "encCredStoreState not supported")
 
             // Get persistent pinUvAuthToken (PPUAT) with pcmr permission
             let ppuat = try await session.getPinUVToken(
@@ -82,10 +76,7 @@ struct EncryptedFieldsTests {
         // First session: get PPUAT and decrypt fields
         let (ppuat, identifier1, credStoreState1) = try await withCTAP2Session { session in
             let info = try await session.getInfo()
-            guard info.encIdentifier != nil else {
-                print("encIdentifier not supported - skipping")
-                throw XCTSkip("encIdentifier not supported")
-            }
+            try #require(info.encIdentifier != nil, "encIdentifier not supported")
 
             let ppuat = try await session.getPinUVToken(
                 using: .pin(defaultTestPin),
@@ -123,11 +114,4 @@ struct EncryptedFieldsTests {
         // 2. Create discoverable credential -> verify state changes
         // 3. Delete credential via CredentialManagement -> verify state changes again
     }
-}
-
-// MARK: - Skip helper
-
-private struct XCTSkip: Error {
-    let message: String
-    init(_ message: String) { self.message = message }
 }

--- a/FullStackTests/Tests/CTAP2/EncryptedFieldsTests.swift
+++ b/FullStackTests/Tests/CTAP2/EncryptedFieldsTests.swift
@@ -33,12 +33,12 @@ struct EncryptedFieldsTests {
                 permissions: [.persistentCredentialManagement]
             )
 
-            let identifier = try info.encIdentifier!.decrypt(using: ppuat)
+            let identifier: UUID = try info.encIdentifier!.decrypt(using: ppuat)
             print("✅ Decrypted device identifier: \(identifier)")
 
             // Decrypt again to verify same result
             let info2 = try await session.getInfo()
-            let identifier2 = try info2.encIdentifier!.decrypt(using: ppuat)
+            let identifier2: UUID = try info2.encIdentifier!.decrypt(using: ppuat)
             #expect(identifier == identifier2)
             print("✅ Decrypted identifier is consistent across GetInfo calls")
         }
@@ -58,12 +58,12 @@ struct EncryptedFieldsTests {
                 permissions: [.persistentCredentialManagement]
             )
 
-            let state = try info.encCredStoreState!.decrypt(using: ppuat)
+            let state: CTAP2.GetInfo.CredStoreState = try info.encCredStoreState!.decrypt(using: ppuat)
             print("✅ Decrypted credential store state: high=\(state.high), low=\(state.low)")
 
             // Decrypt again to verify same result (without credential changes)
             let info2 = try await session.getInfo()
-            let state2 = try info2.encCredStoreState!.decrypt(using: ppuat)
+            let state2: CTAP2.GetInfo.CredStoreState = try info2.encCredStoreState!.decrypt(using: ppuat)
             #expect(state == state2)
             print("✅ Decrypted state is consistent when no credentials changed")
         }
@@ -74,31 +74,34 @@ struct EncryptedFieldsTests {
     @Test("Persistent pinUvAuthToken works across reconnects")
     func testPersistentTokenAcrossReconnects() async throws {
         // First session: get PPUAT and decrypt fields
-        let (ppuat, identifier1, credStoreState1) = try await withCTAP2Session { session in
-            let info = try await session.getInfo()
-            try #require(info.encIdentifier != nil, "encIdentifier not supported")
+        let (ppuat, identifier1, credStoreState1): (CTAP2.ClientPin.Token, UUID, CTAP2.GetInfo.CredStoreState?) =
+            try await withCTAP2Session { session in
+                let info = try await session.getInfo()
+                try #require(info.encIdentifier != nil, "encIdentifier not supported")
 
-            let ppuat = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
-                permissions: [.persistentCredentialManagement]
-            )
+                let ppuat = try await session.getPinUVToken(
+                    using: .pin(defaultTestPin),
+                    permissions: [.persistentCredentialManagement]
+                )
 
-            let identifier = try info.encIdentifier!.decrypt(using: ppuat)
-            let credStoreState = try? info.encCredStoreState?.decrypt(using: ppuat)
+                let identifier: UUID = try info.encIdentifier!.decrypt(using: ppuat)
+                let credStoreState: CTAP2.GetInfo.CredStoreState? = try info.encCredStoreState.map {
+                    try $0.decrypt(using: ppuat)
+                }
 
-            return (ppuat, identifier, credStoreState)
-        }
+                return (ppuat, identifier, credStoreState)
+            }
 
         // Second session: use same PPUAT to decrypt, verify same values
         try await withCTAP2Session { session in
             let info = try await session.getInfo()
 
-            let identifier2 = try info.encIdentifier!.decrypt(using: ppuat)
+            let identifier2: UUID = try info.encIdentifier!.decrypt(using: ppuat)
             #expect(identifier1 == identifier2)
             print("✅ Device identifier consistent across reconnects")
 
             if let credStoreState1 = credStoreState1 {
-                let credStoreState2 = try info.encCredStoreState!.decrypt(using: ppuat)
+                let credStoreState2: CTAP2.GetInfo.CredStoreState = try info.encCredStoreState!.decrypt(using: ppuat)
                 #expect(credStoreState1 == credStoreState2)
                 print("✅ Credential store state consistent across reconnects")
             }

--- a/FullStackTests/Tests/CTAP2/EncryptedFieldsTests.swift
+++ b/FullStackTests/Tests/CTAP2/EncryptedFieldsTests.swift
@@ -1,0 +1,133 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Testing
+import YubiKit
+
+@Suite("Encrypted GetInfo Fields Tests", .serialized)
+struct EncryptedFieldsTests {
+
+    // MARK: - encIdentifier Tests
+
+    @Test("Decrypt encIdentifier with persistent pinUvAuthToken")
+    func testDecryptEncIdentifier() async throws {
+        try await withCTAP2Session { session in
+            let info = try await session.getInfo()
+            guard info.encIdentifier != nil else {
+                print("encIdentifier not supported - skipping")
+                return
+            }
+
+            // Get persistent pinUvAuthToken (PPUAT) with pcmr permission
+            let ppuat = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.persistentCredentialManagement]
+            )
+
+            let identifier = try info.encIdentifier!.decrypt(using: ppuat)
+            print("✅ Decrypted device identifier: \(identifier)")
+
+            // Decrypt again to verify same result
+            let info2 = try await session.getInfo()
+            let identifier2 = try info2.encIdentifier!.decrypt(using: ppuat)
+            #expect(identifier == identifier2)
+            print("✅ Decrypted identifier is consistent across GetInfo calls")
+        }
+    }
+
+    // MARK: - encCredStoreState Tests
+
+    @Test("Decrypt encCredStoreState with persistent pinUvAuthToken")
+    func testDecryptEncCredStoreState() async throws {
+        try await withCTAP2Session { session in
+            let info = try await session.getInfo()
+            guard info.encCredStoreState != nil else {
+                print("encCredStoreState not supported - skipping")
+                return
+            }
+
+            // Get persistent pinUvAuthToken (PPUAT) with pcmr permission
+            let ppuat = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.persistentCredentialManagement]
+            )
+
+            let state = try info.encCredStoreState!.decrypt(using: ppuat)
+            print("✅ Decrypted credential store state: high=\(state.high), low=\(state.low)")
+
+            // Decrypt again to verify same result (without credential changes)
+            let info2 = try await session.getInfo()
+            let state2 = try info2.encCredStoreState!.decrypt(using: ppuat)
+            #expect(state == state2)
+            print("✅ Decrypted state is consistent when no credentials changed")
+        }
+    }
+
+    // MARK: - Persistent Token Across Reconnects
+
+    @Test("Persistent pinUvAuthToken works across reconnects")
+    func testPersistentTokenAcrossReconnects() async throws {
+        // First session: get PPUAT and decrypt fields
+        let (ppuat, identifier1, credStoreState1) = try await withCTAP2Session { session in
+            let info = try await session.getInfo()
+            guard info.encIdentifier != nil else {
+                print("encIdentifier not supported - skipping")
+                throw XCTSkip("encIdentifier not supported")
+            }
+
+            let ppuat = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.persistentCredentialManagement]
+            )
+
+            let identifier = try info.encIdentifier!.decrypt(using: ppuat)
+            let credStoreState = try? info.encCredStoreState?.decrypt(using: ppuat)
+
+            return (ppuat, identifier, credStoreState)
+        }
+
+        // Second session: use same PPUAT to decrypt, verify same values
+        try await withCTAP2Session { session in
+            let info = try await session.getInfo()
+
+            let identifier2 = try info.encIdentifier!.decrypt(using: ppuat)
+            #expect(identifier1 == identifier2)
+            print("✅ Device identifier consistent across reconnects")
+
+            if let credStoreState1 = credStoreState1 {
+                let credStoreState2 = try info.encCredStoreState!.decrypt(using: ppuat)
+                #expect(credStoreState1 == credStoreState2)
+                print("✅ Credential store state consistent across reconnects")
+            }
+        }
+    }
+
+    // MARK: - Credential Store State Change Detection
+
+    @Test("credStoreState changes when credentials are added or deleted")
+    func testCredStoreStateChangesOnCredentialLifecycle() async throws {
+        // TODO: Implement when CredentialManagement API is added
+        // 1. Get PPUAT and initial credStoreState
+        // 2. Create discoverable credential -> verify state changes
+        // 3. Delete credential via CredentialManagement -> verify state changes again
+    }
+}
+
+// MARK: - Skip helper
+
+private struct XCTSkip: Error {
+    let message: String
+    init(_ message: String) { self.message = message }
+}

--- a/YubiKit/UnitTests/Crypto/HashingPlusKDFTests.swift
+++ b/YubiKit/UnitTests/Crypto/HashingPlusKDFTests.swift
@@ -76,12 +76,11 @@ struct HashingPlusKDFTests {
     // MARK: - HKDF
 
     @Test func hkdfDerivation() {
-        // RFC 5869 Test Case 1 (truncated to 32 bytes)
+        // Test HKDF with string info (as used in CTAP encrypted fields)
         let ikm = Data(repeating: 0x0b, count: 22)
         let salt = Data(hexEncodedString: "000102030405060708090a0b0c")!
-        let info = Data(hexEncodedString: "f0f1f2f3f4f5f6f7f8f9")!
-        let derived = ikm.hkdfDeriveKey(salt: salt, info: info, outputByteCount: 32)
-        #expect(derived.hexEncodedString == "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf")
+        let derived = ikm.hkdfDeriveKey(salt: salt, info: "test", outputByteCount: 32)
+        #expect(derived.hexEncodedString == "0a02d6c8df00fdf93b6c48b13d90ac790cef10cdcc2887c978634f6961532332")
     }
 
     // MARK: - PBKDF2

--- a/YubiKit/YubiKit/Crypto/Crypto.swift
+++ b/YubiKit/YubiKit/Crypto/Crypto.swift
@@ -403,17 +403,13 @@ extension Crypto.TripleDES {
 // MARK: - Crypto.KDF
 
 extension Crypto.KDF {
-    /// Derives a key using HKDF-SHA256.
-    static func hkdf(_ data: Data, salt: Data, info: String, outputLength: Int) -> Data {
-        hkdf(data, salt: salt, info: Data(info.utf8), outputLength: outputLength)
-    }
 
     /// Derives a key using HKDF-SHA256.
-    static func hkdf(_ data: Data, salt: Data, info: Data, outputLength: Int) -> Data {
+    static func hkdf(_ data: Data, salt: Data, info: String, outputLength: Int) -> Data {
         let derivedKey = HKDF<SHA256>.deriveKey(
             inputKeyMaterial: SymmetricKey(data: data),
             salt: salt,
-            info: info,
+            info: Data(info.utf8),
             outputByteCount: outputLength
         )
         return derivedKey.withUnsafeBytes { Data($0) }

--- a/YubiKit/YubiKit/Crypto/Data+Crypto.swift
+++ b/YubiKit/YubiKit/Crypto/Data+Crypto.swift
@@ -131,16 +131,6 @@ extension Data {
         Crypto.KDF.hkdf(self, salt: salt, info: info, outputLength: outputByteCount)
     }
 
-    /// Derives a key using HKDF-SHA256.
-    /// - Parameters:
-    ///   - salt: The salt value.
-    ///   - info: The context/application-specific info data.
-    ///   - outputByteCount: The desired output key length in bytes.
-    /// - Returns: The derived key material.
-    internal func hkdfDeriveKey(salt: Data, info: Data, outputByteCount: Int) -> Data {
-        Crypto.KDF.hkdf(self, salt: salt, info: info, outputLength: outputByteCount)
-    }
-
     // MARK: - Random
 
     /// Generates cryptographically secure random bytes.

--- a/YubiKit/YubiKit/FIDO/CTAP/ClientPIN/Types.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/ClientPIN/Types.swift
@@ -48,7 +48,7 @@ extension CTAP2.ClientPin {
     /// and ``CTAP2/Session/getAssertion(parameters:pinToken:)``.
     public struct Token: Sendable {
         /// The decrypted PIN token.
-        private let token: Data
+        internal let token: Data
 
         /// The PIN/UV auth protocol version used to obtain this token.
         public let protocolVersion: ProtocolVersion

--- a/YubiKit/YubiKit/FIDO/CTAP/ClientPIN/Types.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/ClientPIN/Types.swift
@@ -48,7 +48,7 @@ extension CTAP2.ClientPin {
     /// and ``CTAP2/Session/getAssertion(parameters:pinToken:)``.
     public struct Token: Sendable {
         /// The decrypted PIN token.
-        internal let token: Data
+        private let token: Data
 
         /// The PIN/UV auth protocol version used to obtain this token.
         public let protocolVersion: ProtocolVersion
@@ -64,6 +64,13 @@ extension CTAP2.ClientPin {
         /// - Returns: The authentication parameter to include in the CTAP request.
         func authenticate(message: Data) -> Data {
             protocolVersion.authenticate(key: token, message: message)
+        }
+
+        /// Derives an AES key for decrypting encrypted GetInfo fields.
+        ///
+        /// Uses HKDF-SHA-256 with a 32-byte zero salt as specified in CTAP 2.3.
+        internal func deriveKey(info: String) -> Data {
+            Crypto.KDF.hkdf(token, salt: Data(count: 32), info: info, outputLength: 16)
         }
     }
 }

--- a/YubiKit/YubiKit/FIDO/CTAP/Config/Config.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/Config/Config.swift
@@ -147,11 +147,40 @@ extension CTAP2 {
 // MARK: - Internal Types
 
 extension CTAP2.Config {
-    fileprivate enum Subcommand: UInt8, Sendable {
-        case enableEnterpriseAttestation = 0x01
-        case toggleAlwaysUV = 0x02
-        case setMinPINLength = 0x03
-        case vendorPrototype = 0xFF
+    /// Subcommands for the authenticatorConfig command.
+    ///
+    /// Authenticators report supported subcommands in ``CTAP2/GetInfo/Response/authenticatorConfigCommands``.
+    public enum Subcommand: RawRepresentable, Sendable, Equatable {
+        /// Enable enterprise attestation.
+        case enableEnterpriseAttestation
+        /// Toggle the alwaysUV setting.
+        case toggleAlwaysUV
+        /// Set minimum PIN length.
+        case setMinPINLength
+        /// Vendor-specific prototype command.
+        case vendorPrototype
+        /// Unknown or future subcommand.
+        case other(UInt8)
+
+        public var rawValue: UInt8 {
+            switch self {
+            case .enableEnterpriseAttestation: return 0x01
+            case .toggleAlwaysUV: return 0x02
+            case .setMinPINLength: return 0x03
+            case .vendorPrototype: return 0xFF
+            case .other(let value): return value
+            }
+        }
+
+        public init(rawValue: UInt8) {
+            switch rawValue {
+            case 0x01: self = .enableEnterpriseAttestation
+            case 0x02: self = .toggleAlwaysUV
+            case 0x03: self = .setMinPINLength
+            case 0xFF: self = .vendorPrototype
+            default: self = .other(rawValue)
+            }
+        }
     }
 
     fileprivate enum Parameter: UInt8, Sendable {

--- a/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse+CBOR.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse+CBOR.swift
@@ -63,11 +63,17 @@ extension CTAP2.GetInfo.Response: CBOR.Decodable {
             attestationFormats: map[.int(0x16)]?.cborDecoded() ?? [],
             uvCountSinceLastPinEntry: map[.int(0x17)]?.cborDecoded(),
             longTouchForReset: map[.int(0x18)]?.cborDecoded(),
-            encIdentifier: map[.int(0x19)]?.cborDecoded(),
+            encIdentifier: map[.int(0x19)]?.dataValue.map {
+                CTAP2.GetInfo.Encrypted(encryptedData: $0)
+            },
             transportsForReset: map[.int(0x1A)]?.cborDecoded() ?? [],
             pinComplexityPolicy: map[.int(0x1B)]?.cborDecoded(),
             pinComplexityPolicyURL: map[.int(0x1C)]?.cborDecoded(),
-            maxPINLength: map[.int(0x1D)]?.cborDecoded()
+            maxPINLength: map[.int(0x1D)]?.cborDecoded(),
+            encCredStoreState: map[.int(0x1E)]?.dataValue.map {
+                CTAP2.GetInfo.Encrypted(encryptedData: $0)
+            },
+            authenticatorConfigCommands: map[.int(0x1F)]?.cborDecoded()
         )
     }
 }

--- a/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse+CBOR.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse+CBOR.swift
@@ -115,3 +115,10 @@ extension URL: CBOR.Decodable {
         self = url
     }
 }
+
+extension CTAP2.Config.Subcommand: CBOR.Decodable {
+    init?(cbor: CBOR.Value) {
+        guard let rawValue: UInt8 = cbor.cborDecoded() else { return nil }
+        self.init(rawValue: rawValue)
+    }
+}

--- a/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse+CBOR.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse+CBOR.swift
@@ -64,14 +64,14 @@ extension CTAP2.GetInfo.Response: CBOR.Decodable {
             uvCountSinceLastPinEntry: map[.int(0x17)]?.cborDecoded(),
             longTouchForReset: map[.int(0x18)]?.cborDecoded(),
             encIdentifier: map[.int(0x19)]?.dataValue.map {
-                CTAP2.GetInfo.Encrypted(encryptedData: $0)
+                CTAP2.GetInfo.Encrypted(encryptedData: $0, hkdfInfo: "encIdentifier")
             },
             transportsForReset: map[.int(0x1A)]?.cborDecoded() ?? [],
             pinComplexityPolicy: map[.int(0x1B)]?.cborDecoded(),
             pinComplexityPolicyURL: map[.int(0x1C)]?.cborDecoded(),
             maxPINLength: map[.int(0x1D)]?.cborDecoded(),
             encCredStoreState: map[.int(0x1E)]?.dataValue.map {
-                CTAP2.GetInfo.Encrypted(encryptedData: $0)
+                CTAP2.GetInfo.Encrypted(encryptedData: $0, hkdfInfo: "encCredStoreState")
             },
             authenticatorConfigCommands: map[.int(0x1F)]?.cborDecoded()
         )

--- a/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse.swift
@@ -244,7 +244,7 @@ extension CTAP2.GetInfo.Encrypted {
     /// Decrypts an encrypted field using HKDF-SHA256 and AES-128-CBC.
     fileprivate func decryptRaw(
         info: String,
-        using persistentPinUvAuthToken: Data
+        using token: CTAP2.ClientPin.Token
     ) throws(CryptoError) -> Data {
         let ivSize = Crypto.AES.blockSize
         guard encryptedData.count > ivSize else {
@@ -253,14 +253,7 @@ extension CTAP2.GetInfo.Encrypted {
 
         let iv = encryptedData.prefix(ivSize)
         let ciphertext = encryptedData.dropFirst(ivSize)
-
-        // Derive AES key per spec: HKDF-SHA-256(salt = 32 zero bytes, IKM = token, L = 16, info = info)
-        let aesKey = Crypto.KDF.hkdf(
-            persistentPinUvAuthToken,
-            salt: Data(count: 32),
-            info: info,
-            outputLength: 16
-        )
+        let aesKey = token.deriveKey(info: info)
 
         return try Crypto.AES.decrypt(Data(ciphertext), key: aesKey, mode: .cbc(iv: Data(iv)))
     }
@@ -274,7 +267,7 @@ extension CTAP2.GetInfo.Encrypted where Value == UUID {
     /// - Returns: The decrypted 16-byte device identifier.
     /// - Throws: `CryptoError` if decryption fails.
     public func decrypt(using token: CTAP2.ClientPin.Token) throws(CryptoError) -> Data {
-        try decryptRaw(info: "encIdentifier", using: token.token)
+        try decryptRaw(info: "encIdentifier", using: token)
     }
 
     /// Decrypts the device identifier using a persistent pinUvAuthToken.
@@ -298,7 +291,7 @@ extension CTAP2.GetInfo.Encrypted where Value == CTAP2.GetInfo.CredStoreState {
     /// - Returns: The decrypted 16-byte credential store state.
     /// - Throws: `CryptoError` if decryption fails.
     public func decrypt(using token: CTAP2.ClientPin.Token) throws(CryptoError) -> Data {
-        try decryptRaw(info: "encCredStoreState", using: token.token)
+        try decryptRaw(info: "encCredStoreState", using: token)
     }
 
     /// Decrypts the credential store state using a persistent pinUvAuthToken.

--- a/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse.swift
@@ -213,7 +213,7 @@ extension CTAP2.GetInfo {
         public let encCredStoreState: Encrypted<CredStoreState>?
 
         /// List of supported authenticatorConfig subcommands.
-        public let authenticatorConfigCommands: [UInt]?
+        public let authenticatorConfigCommands: [CTAP2.Config.Subcommand]?
 
     }
 

--- a/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse.swift
@@ -267,6 +267,16 @@ extension CTAP2.GetInfo.Encrypted {
 }
 
 extension CTAP2.GetInfo.Encrypted where Value == UUID {
+    /// Decrypts the device identifier to raw bytes using a persistent pinUvAuthToken.
+    ///
+    /// - Parameter token: A persistent pinUvAuthToken obtained with
+    ///   the `.persistentCredentialManagement` permission.
+    /// - Returns: The decrypted 16-byte device identifier.
+    /// - Throws: `CryptoError` if decryption fails.
+    public func decrypt(using token: CTAP2.ClientPin.Token) throws(CryptoError) -> Data {
+        try decryptRaw(info: "encIdentifier", using: token.token)
+    }
+
     /// Decrypts the device identifier using a persistent pinUvAuthToken.
     ///
     /// - Parameter token: A persistent pinUvAuthToken obtained with
@@ -274,13 +284,23 @@ extension CTAP2.GetInfo.Encrypted where Value == UUID {
     /// - Returns: The decrypted 128-bit device identifier.
     /// - Throws: `CryptoError` if decryption fails.
     public func decrypt(using token: CTAP2.ClientPin.Token) throws(CryptoError) -> UUID {
-        let data = try decryptRaw(info: "encIdentifier", using: token.token)
+        let data: Data = try decrypt(using: token)
         guard data.count == 16 else { throw .missingData }
         return data.withUnsafeBytes { UUID(uuid: $0.load(as: uuid_t.self)) }
     }
 }
 
 extension CTAP2.GetInfo.Encrypted where Value == CTAP2.GetInfo.CredStoreState {
+    /// Decrypts the credential store state to raw bytes using a persistent pinUvAuthToken.
+    ///
+    /// - Parameter token: A persistent pinUvAuthToken obtained with
+    ///   the `.persistentCredentialManagement` permission.
+    /// - Returns: The decrypted 16-byte credential store state.
+    /// - Throws: `CryptoError` if decryption fails.
+    public func decrypt(using token: CTAP2.ClientPin.Token) throws(CryptoError) -> Data {
+        try decryptRaw(info: "encCredStoreState", using: token.token)
+    }
+
     /// Decrypts the credential store state using a persistent pinUvAuthToken.
     ///
     /// - Parameter token: A persistent pinUvAuthToken obtained with
@@ -290,7 +310,7 @@ extension CTAP2.GetInfo.Encrypted where Value == CTAP2.GetInfo.CredStoreState {
     public func decrypt(
         using token: CTAP2.ClientPin.Token
     ) throws(CryptoError) -> CTAP2.GetInfo.CredStoreState {
-        let data = try decryptRaw(info: "encCredStoreState", using: token.token)
+        let data: Data = try decrypt(using: token)
         guard data.count == 16 else { throw .missingData }
         return data.withUnsafeBytes {
             CTAP2.GetInfo.CredStoreState(

--- a/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse.swift
@@ -269,12 +269,12 @@ extension CTAP2.GetInfo.Encrypted {
 extension CTAP2.GetInfo.Encrypted where Value == UUID {
     /// Decrypts the device identifier using a persistent pinUvAuthToken.
     ///
-    /// - Parameter persistentPinUvAuthToken: A persistent pinUvAuthToken obtained with
+    /// - Parameter token: A persistent pinUvAuthToken obtained with
     ///   the `.persistentCredentialManagement` permission.
     /// - Returns: The decrypted 128-bit device identifier.
     /// - Throws: `CryptoError` if decryption fails.
-    public func decrypt(using persistentPinUvAuthToken: Data) throws(CryptoError) -> UUID {
-        let data = try decryptRaw(info: "encIdentifier", using: persistentPinUvAuthToken)
+    public func decrypt(using token: CTAP2.ClientPin.Token) throws(CryptoError) -> UUID {
+        let data = try decryptRaw(info: "encIdentifier", using: token.token)
         guard data.count == 16 else { throw .missingData }
         return data.withUnsafeBytes { UUID(uuid: $0.load(as: uuid_t.self)) }
     }
@@ -283,14 +283,14 @@ extension CTAP2.GetInfo.Encrypted where Value == UUID {
 extension CTAP2.GetInfo.Encrypted where Value == CTAP2.GetInfo.CredStoreState {
     /// Decrypts the credential store state using a persistent pinUvAuthToken.
     ///
-    /// - Parameter persistentPinUvAuthToken: A persistent pinUvAuthToken obtained with
+    /// - Parameter token: A persistent pinUvAuthToken obtained with
     ///   the `.persistentCredentialManagement` permission.
     /// - Returns: The decrypted 128-bit credential store state.
     /// - Throws: `CryptoError` if decryption fails.
     public func decrypt(
-        using persistentPinUvAuthToken: Data
+        using token: CTAP2.ClientPin.Token
     ) throws(CryptoError) -> CTAP2.GetInfo.CredStoreState {
-        let data = try decryptRaw(info: "encCredStoreState", using: persistentPinUvAuthToken)
+        let data = try decryptRaw(info: "encCredStoreState", using: token.token)
         guard data.count == 16 else { throw .missingData }
         return data.withUnsafeBytes {
             CTAP2.GetInfo.CredStoreState(

--- a/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse.swift
@@ -254,7 +254,7 @@ extension CTAP2.GetInfo.Encrypted {
         let iv = encryptedData.prefix(ivSize)
         let ciphertext = encryptedData.dropFirst(ivSize)
 
-        // Derive AES key: HKDF-SHA-256(salt = 32 zero bytes, IKM = token, L = 16, info = info)
+        // Derive AES key per spec: HKDF-SHA-256(salt = 32 zero bytes, IKM = token, L = 16, info = info)
         let aesKey = Crypto.KDF.hkdf(
             persistentPinUvAuthToken,
             salt: Data(count: 32),

--- a/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse.swift
@@ -222,7 +222,7 @@ extension CTAP2.GetInfo {
     /// Opaque 128-bit credential store state used for cache invalidation.
     ///
     /// Compare values to detect if the credential store has changed since last cached.
-    public struct CredStoreState: Sendable, Equatable {
+    public struct CredStoreState: Sendable, Equatable, Hashable {
         // When the SDK's minimum deployment target is raised to macOS 15 / iOS 18,
         // this struct can be replaced with a typealias to UInt128.
         public let high: UInt64
@@ -231,10 +231,10 @@ extension CTAP2.GetInfo {
 
     /// An encrypted GetInfo field, decryptable with a persistent pinUvAuthToken.
     ///
-    /// The encrypted data contains `iv || ct` where `ct` is the AES-128-CBC encryption
-    /// of the underlying value.
-    public struct Encrypted<Value: Sendable>: Sendable {
-        let encryptedData: Data
+    /// - SeeAlso: [CTAP 2.3 Section 6.4](https://fidoalliance.org/specs/fido-v2.3-rd-20251023/fido-client-to-authenticator-protocol-v2.3-rd-20251023.html#authenticatorGetInfo)
+    public struct Encrypted<Value: Sendable>: Sendable, Hashable, Equatable {
+        /// The raw encrypted data.
+        public let encryptedData: Data
     }
 }
 

--- a/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse.swift
@@ -190,7 +190,7 @@ extension CTAP2.GetInfo {
         public let longTouchForReset: Bool?
 
         /// Encrypted device identifier, decryptable with a persistent pinUvAuthToken.
-        public let encIdentifier: Encrypted<UUID>?
+        public let encIdentifier: Encrypted<Opaque128>?
 
         /// Transports that support the reset command.
         public let transportsForReset: [WebAuthn.Transport]
@@ -210,7 +210,7 @@ extension CTAP2.GetInfo {
         /// Encrypted credential store state, decryptable with a persistent pinUvAuthToken.
         ///
         /// Platforms can use this to detect if the credential store has changed since last cached.
-        public let encCredStoreState: Encrypted<CredStoreState>?
+        public let encCredStoreState: Encrypted<Opaque128>?
 
         /// List of supported authenticatorConfig subcommands.
         public let authenticatorConfigCommands: [CTAP2.Config.Subcommand]?
@@ -219,14 +219,21 @@ extension CTAP2.GetInfo {
 
     // MARK: - Encrypted Fields
 
-    /// Opaque 128-bit credential store state used for cache invalidation.
+    /// An opaque 128-bit value used for encrypted GetInfo fields.
     ///
-    /// Compare values to detect if the credential store has changed since last cached.
-    public struct CredStoreState: Sendable, Equatable, Hashable {
-        // When the SDK's minimum deployment target is raised to macOS 15 / iOS 18,
-        // this struct can be replaced with a typealias to UInt128.
-        public let high: UInt64
-        public let low: UInt64
+    /// Both `encIdentifier` and `encCredStoreState` decrypt to this type.
+    /// Values should be compared for equality, not interpreted.
+    public struct Opaque128: RawRepresentable, Sendable, Equatable, Hashable {
+        public let rawValue: Data
+
+        init?(_ data: Data) {
+            guard data.count == 16 else { return nil }
+            self.rawValue = data
+        }
+
+        public init?(rawValue: Data) {
+            self.init(rawValue)
+        }
     }
 
     /// An encrypted GetInfo field, decryptable with a persistent pinUvAuthToken.
@@ -235,17 +242,21 @@ extension CTAP2.GetInfo {
     public struct Encrypted<Value: Sendable>: Sendable, Hashable, Equatable {
         /// The raw encrypted data.
         public let encryptedData: Data
+        /// The HKDF info string used for key derivation.
+        internal let hkdfInfo: String
     }
 }
 
 // MARK: - Encrypted Field Decryption
 
-extension CTAP2.GetInfo.Encrypted {
-    /// Decrypts an encrypted field using HKDF-SHA256 and AES-128-CBC.
-    fileprivate func decryptRaw(
-        info: String,
-        using token: CTAP2.ClientPin.Token
-    ) throws(CryptoError) -> Data {
+extension CTAP2.GetInfo.Encrypted where Value == CTAP2.GetInfo.Opaque128 {
+    /// Decrypts the encrypted field to raw bytes using a persistent pinUvAuthToken.
+    ///
+    /// - Parameter token: A persistent pinUvAuthToken obtained with
+    ///   the `.persistentCredentialManagement` permission.
+    /// - Returns: The decrypted 16-byte value.
+    /// - Throws: `CryptoError` if decryption fails.
+    public func decryptedData(using token: CTAP2.ClientPin.Token) throws(CryptoError) -> Data {
         let ivSize = Crypto.AES.blockSize
         guard encryptedData.count > ivSize else {
             throw .missingData
@@ -253,63 +264,22 @@ extension CTAP2.GetInfo.Encrypted {
 
         let iv = encryptedData.prefix(ivSize)
         let ciphertext = encryptedData.dropFirst(ivSize)
-        let aesKey = token.deriveKey(info: info)
+        let aesKey = token.deriveKey(info: hkdfInfo)
 
         return try Crypto.AES.decrypt(Data(ciphertext), key: aesKey, mode: .cbc(iv: Data(iv)))
     }
-}
 
-extension CTAP2.GetInfo.Encrypted where Value == UUID {
-    /// Decrypts the device identifier to raw bytes using a persistent pinUvAuthToken.
+    /// Decrypts the encrypted field using a persistent pinUvAuthToken.
     ///
     /// - Parameter token: A persistent pinUvAuthToken obtained with
     ///   the `.persistentCredentialManagement` permission.
-    /// - Returns: The decrypted 16-byte device identifier.
-    /// - Throws: `CryptoError` if decryption fails.
-    public func decryptedData(using token: CTAP2.ClientPin.Token) throws(CryptoError) -> Data {
-        try decryptRaw(info: "encIdentifier", using: token)
-    }
-
-    /// Decrypts the device identifier using a persistent pinUvAuthToken.
-    ///
-    /// - Parameter token: A persistent pinUvAuthToken obtained with
-    ///   the `.persistentCredentialManagement` permission.
-    /// - Returns: The decrypted 128-bit device identifier.
-    /// - Throws: `CryptoError` if decryption fails.
-    public func decrypted(using token: CTAP2.ClientPin.Token) throws(CryptoError) -> UUID {
-        let data = try decryptedData(using: token)
-        guard data.count == 16 else { throw .missingData }
-        return data.withUnsafeBytes { UUID(uuid: $0.load(as: uuid_t.self)) }
-    }
-}
-
-extension CTAP2.GetInfo.Encrypted where Value == CTAP2.GetInfo.CredStoreState {
-    /// Decrypts the credential store state to raw bytes using a persistent pinUvAuthToken.
-    ///
-    /// - Parameter token: A persistent pinUvAuthToken obtained with
-    ///   the `.persistentCredentialManagement` permission.
-    /// - Returns: The decrypted 16-byte credential store state.
-    /// - Throws: `CryptoError` if decryption fails.
-    public func decryptedData(using token: CTAP2.ClientPin.Token) throws(CryptoError) -> Data {
-        try decryptRaw(info: "encCredStoreState", using: token)
-    }
-
-    /// Decrypts the credential store state using a persistent pinUvAuthToken.
-    ///
-    /// - Parameter token: A persistent pinUvAuthToken obtained with
-    ///   the `.persistentCredentialManagement` permission.
-    /// - Returns: The decrypted 128-bit credential store state.
+    /// - Returns: The decrypted 128-bit value.
     /// - Throws: `CryptoError` if decryption fails.
     public func decrypted(
         using token: CTAP2.ClientPin.Token
-    ) throws(CryptoError) -> CTAP2.GetInfo.CredStoreState {
+    ) throws(CryptoError) -> CTAP2.GetInfo.Opaque128 {
         let data = try decryptedData(using: token)
-        guard data.count == 16 else { throw .missingData }
-        return data.withUnsafeBytes {
-            CTAP2.GetInfo.CredStoreState(
-                high: $0.load(fromByteOffset: 0, as: UInt64.self),
-                low: $0.load(fromByteOffset: 8, as: UInt64.self)
-            )
-        }
+        guard let value = CTAP2.GetInfo.Opaque128(data) else { throw .missingData }
+        return value
     }
 }

--- a/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse.swift
@@ -266,7 +266,7 @@ extension CTAP2.GetInfo.Encrypted where Value == UUID {
     ///   the `.persistentCredentialManagement` permission.
     /// - Returns: The decrypted 16-byte device identifier.
     /// - Throws: `CryptoError` if decryption fails.
-    public func decrypt(using token: CTAP2.ClientPin.Token) throws(CryptoError) -> Data {
+    public func decryptedData(using token: CTAP2.ClientPin.Token) throws(CryptoError) -> Data {
         try decryptRaw(info: "encIdentifier", using: token)
     }
 
@@ -276,8 +276,8 @@ extension CTAP2.GetInfo.Encrypted where Value == UUID {
     ///   the `.persistentCredentialManagement` permission.
     /// - Returns: The decrypted 128-bit device identifier.
     /// - Throws: `CryptoError` if decryption fails.
-    public func decrypt(using token: CTAP2.ClientPin.Token) throws(CryptoError) -> UUID {
-        let data: Data = try decrypt(using: token)
+    public func decrypted(using token: CTAP2.ClientPin.Token) throws(CryptoError) -> UUID {
+        let data = try decryptedData(using: token)
         guard data.count == 16 else { throw .missingData }
         return data.withUnsafeBytes { UUID(uuid: $0.load(as: uuid_t.self)) }
     }
@@ -290,7 +290,7 @@ extension CTAP2.GetInfo.Encrypted where Value == CTAP2.GetInfo.CredStoreState {
     ///   the `.persistentCredentialManagement` permission.
     /// - Returns: The decrypted 16-byte credential store state.
     /// - Throws: `CryptoError` if decryption fails.
-    public func decrypt(using token: CTAP2.ClientPin.Token) throws(CryptoError) -> Data {
+    public func decryptedData(using token: CTAP2.ClientPin.Token) throws(CryptoError) -> Data {
         try decryptRaw(info: "encCredStoreState", using: token)
     }
 
@@ -300,10 +300,10 @@ extension CTAP2.GetInfo.Encrypted where Value == CTAP2.GetInfo.CredStoreState {
     ///   the `.persistentCredentialManagement` permission.
     /// - Returns: The decrypted 128-bit credential store state.
     /// - Throws: `CryptoError` if decryption fails.
-    public func decrypt(
+    public func decrypted(
         using token: CTAP2.ClientPin.Token
     ) throws(CryptoError) -> CTAP2.GetInfo.CredStoreState {
-        let data: Data = try decrypt(using: token)
+        let data = try decryptedData(using: token)
         guard data.count == 16 else { throw .missingData }
         return data.withUnsafeBytes {
             CTAP2.GetInfo.CredStoreState(

--- a/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse.swift
@@ -189,11 +189,8 @@ extension CTAP2.GetInfo {
         /// Whether the authenticator requires a 10-second touch for reset.
         public let longTouchForReset: Bool?
 
-        /// Encrypted device identifier (decryptable with a persistent PUAT).
-        ///
-        /// The value contains `iv || ct` where `ct` is the AES-128-CBC encryption
-        /// of a 128-bit device identifier.
-        public let encIdentifier: Data?
+        /// Encrypted device identifier, decryptable with a persistent pinUvAuthToken.
+        public let encIdentifier: Encrypted<UUID>?
 
         /// Transports that support the reset command.
         public let transportsForReset: [WebAuthn.Transport]
@@ -210,5 +207,96 @@ extension CTAP2.GetInfo {
         /// Maximum PIN length supported by the authenticator.
         public let maxPINLength: UInt?
 
+        /// Encrypted credential store state, decryptable with a persistent pinUvAuthToken.
+        ///
+        /// Platforms can use this to detect if the credential store has changed since last cached.
+        public let encCredStoreState: Encrypted<CredStoreState>?
+
+        /// List of supported authenticatorConfig subcommands.
+        public let authenticatorConfigCommands: [UInt]?
+
+    }
+
+    // MARK: - Encrypted Fields
+
+    /// Opaque 128-bit credential store state used for cache invalidation.
+    ///
+    /// Compare values to detect if the credential store has changed since last cached.
+    public struct CredStoreState: Sendable, Equatable {
+        // When the SDK's minimum deployment target is raised to macOS 15 / iOS 18,
+        // this struct can be replaced with a typealias to UInt128.
+        public let high: UInt64
+        public let low: UInt64
+    }
+
+    /// An encrypted GetInfo field, decryptable with a persistent pinUvAuthToken.
+    ///
+    /// The encrypted data contains `iv || ct` where `ct` is the AES-128-CBC encryption
+    /// of the underlying value.
+    public struct Encrypted<Value: Sendable>: Sendable {
+        let encryptedData: Data
+    }
+}
+
+// MARK: - Encrypted Field Decryption
+
+extension CTAP2.GetInfo.Encrypted {
+    /// Decrypts an encrypted field using HKDF-SHA256 and AES-128-CBC.
+    fileprivate func decryptRaw(
+        info: String,
+        using persistentPinUvAuthToken: Data
+    ) throws(CryptoError) -> Data {
+        let ivSize = Crypto.AES.blockSize
+        guard encryptedData.count > ivSize else {
+            throw .missingData
+        }
+
+        let iv = encryptedData.prefix(ivSize)
+        let ciphertext = encryptedData.dropFirst(ivSize)
+
+        // Derive AES key: HKDF-SHA-256(salt = 32 zero bytes, IKM = token, L = 16, info = info)
+        let aesKey = Crypto.KDF.hkdf(
+            persistentPinUvAuthToken,
+            salt: Data(count: 32),
+            info: info,
+            outputLength: 16
+        )
+
+        return try Crypto.AES.decrypt(Data(ciphertext), key: aesKey, mode: .cbc(iv: Data(iv)))
+    }
+}
+
+extension CTAP2.GetInfo.Encrypted where Value == UUID {
+    /// Decrypts the device identifier using a persistent pinUvAuthToken.
+    ///
+    /// - Parameter persistentPinUvAuthToken: A persistent pinUvAuthToken obtained with
+    ///   the `.persistentCredentialManagement` permission.
+    /// - Returns: The decrypted 128-bit device identifier.
+    /// - Throws: `CryptoError` if decryption fails.
+    public func decrypt(using persistentPinUvAuthToken: Data) throws(CryptoError) -> UUID {
+        let data = try decryptRaw(info: "encIdentifier", using: persistentPinUvAuthToken)
+        guard data.count == 16 else { throw .missingData }
+        return data.withUnsafeBytes { UUID(uuid: $0.load(as: uuid_t.self)) }
+    }
+}
+
+extension CTAP2.GetInfo.Encrypted where Value == CTAP2.GetInfo.CredStoreState {
+    /// Decrypts the credential store state using a persistent pinUvAuthToken.
+    ///
+    /// - Parameter persistentPinUvAuthToken: A persistent pinUvAuthToken obtained with
+    ///   the `.persistentCredentialManagement` permission.
+    /// - Returns: The decrypted 128-bit credential store state.
+    /// - Throws: `CryptoError` if decryption fails.
+    public func decrypt(
+        using persistentPinUvAuthToken: Data
+    ) throws(CryptoError) -> CTAP2.GetInfo.CredStoreState {
+        let data = try decryptRaw(info: "encCredStoreState", using: persistentPinUvAuthToken)
+        guard data.count == 16 else { throw .missingData }
+        return data.withUnsafeBytes {
+            CTAP2.GetInfo.CredStoreState(
+                high: $0.load(fromByteOffset: 0, as: UInt64.self),
+                low: $0.load(fromByteOffset: 8, as: UInt64.self)
+            )
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds support for CTAP 2.3 encrypted GetInfo fields:
- `encIdentifier` (0x19) - Now wrapped in `Encrypted<UUID>` with decryption support
- `encCredStoreState` (0x1E) - Encrypted credential store state for cache invalidation
- `authenticatorConfigCommands` (0x1F) - List of supported authenticatorConfig subcommands

Introduces a type-safe `Encrypted<Value>` wrapper that encapsulates encrypted field decryption using a PPUAT.

Also makes `CTAP2.Config.Subcommand` public with `.other(UInt8)` for forward compatibility.