### PR TITLE
CTAP2 Credential Management

### DIFF
--- a/FullStackTests/FullStackTests.xcodeproj/project.pbxproj
+++ b/FullStackTests/FullStackTests.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		6CCREDBLOB2F1115000000001 /* CredBlobTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CCREDBLOB2F1115000000000 /* CredBlobTests.swift */; };
 		6CMINPINLEN2F1116000000001 /* MinPinLengthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CMINPINLEN2F1116000000000 /* MinPinLengthTests.swift */; };
 		B2A73E5DE80348329B8FA710 /* EncryptedFieldsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E3FD736FBE49ECAAAFA28E /* EncryptedFieldsTests.swift */; };
+		583058DA680743A1B11C558F /* CredentialManagementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA359818D52447249DB07BD1 /* CredentialManagementTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -80,6 +81,7 @@
 		6CCREDBLOB2F1115000000000 /* CredBlobTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredBlobTests.swift; sourceTree = "<group>"; };
 		6CMINPINLEN2F1116000000000 /* MinPinLengthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinPinLengthTests.swift; sourceTree = "<group>"; };
 		59E3FD736FBE49ECAAAFA28E /* EncryptedFieldsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptedFieldsTests.swift; sourceTree = "<group>"; };
+		FA359818D52447249DB07BD1 /* CredentialManagementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialManagementTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -169,6 +171,7 @@
 			children = (
 				CD75D32D2F1114C8000624CB /* Extensions */,
 				CD89AB9B1BB24FA6B5FD79D3 /* ConfigTests.swift */,
+				FA359818D52447249DB07BD1 /* CredentialManagementTests.swift */,
 				6C734BB42EE860E100972E2A /* CredentialTests.swift */,
 				59E3FD736FBE49ECAAAFA28E /* EncryptedFieldsTests.swift */,
 				6C734BAA2EE860AF00972E2A /* HIDTransportTests.swift */,
@@ -346,6 +349,7 @@
 				6C2B14552DC8CF4C00B5C482 /* XCTestCase+SCP.swift in Sources */,
 				6CDATAHEX2EF1234500000001 /* Data+Hex.swift in Sources */,
 				B2A73E5DE80348329B8FA710 /* EncryptedFieldsTests.swift in Sources */,
+				583058DA680743A1B11C558F /* CredentialManagementTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FullStackTests/Tests/CTAP2/CredentialManagementTests.swift
+++ b/FullStackTests/Tests/CTAP2/CredentialManagementTests.swift
@@ -19,10 +19,8 @@ import YubiKit
 // MARK: - Test Constants
 
 private let testClientDataHash = Data(repeating: 0xCD, count: 32)
-
 private let testRpId = "test.example.com"
 private let testRp = WebAuthn.PublicKeyCredential.RPEntity(id: testRpId, name: "Test RP")
-
 private let testUserId = Data([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08])
 private let testUserName = "testuser@example.com"
 private let testUserDisplayName = "Test User"
@@ -32,453 +30,278 @@ private let testUser = WebAuthn.PublicKeyCredential.UserEntity(
     displayName: testUserDisplayName
 )
 
-// MARK: - Test Tags
-
-extension Tag {
-    @Tag static var credentialManagement: Tag
-}
-
 // MARK: - Tests
 
-@Suite("Credential Management Full Stack Tests", .tags(.credentialManagement), .serialized)
-struct CredentialManagementFullStackTests {
+@Suite("Credential Management", .serialized)
+struct CredentialManagementTests {
 
-    // MARK: - Read Metadata Tests
+    // MARK: - Empty State
 
-    @Test("Read credential metadata with no credentials")
-    func testReadMetadataEmpty() async throws {
-        try await withCTAP2Session { session in
-            guard try await requireCredentialManagementSupport(session) else { return }
-            guard try await requirePinSet(session) else { return }
-            try await deleteAllCredentials(session)
-
-            let pinToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
-                permissions: [.credentialManagement]
-            )
-            let credMgmt = try await session.credentialManagement(pinToken: pinToken)
-
+    @Test("Operations return empty results when no credentials exist")
+    func testEmptyState() async throws {
+        try await withCredentialManagement(createCredential: false) { credMgmt, _ in
             let metadata = try await credMgmt.getMetadata()
-
             #expect(metadata.existingCredentialsCount == 0)
             #expect(metadata.maxRemainingCredentialsCount > 0)
-        }
-    }
-
-    @Test("Read credential metadata with one credential")
-    func testReadMetadataWithCredential() async throws {
-        try await withReconnectableCTAP2Session { session, reconnectWhenOverNFC in
-            var session = session
-            guard try await requireCredentialManagementSupport(session) else { return }
-            guard try await requirePinSet(session) else { return }
-            try await deleteAllCredentials(session)
-
-            // Create a test credential (requires UP)
-            session = try await reconnectWhenOverNFC()
-            try await createTestCredential(session)
-
-            // Get fresh token for credential management
-            let pinToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
-                permissions: [.credentialManagement]
-            )
-            let credMgmt = try await session.credentialManagement(pinToken: pinToken)
-
-            let metadata = try await credMgmt.getMetadata()
-
-            #expect(metadata.existingCredentialsCount == 1)
-            #expect(metadata.maxRemainingCredentialsCount > 0)
-
-            // Cleanup
-            try await deleteAllCredentials(session)
-        }
-    }
-
-    // MARK: - Enumerate RPs Tests
-
-    @Test("Enumerate RPs returns empty when no credentials")
-    func testEnumerateRPsEmpty() async throws {
-        try await withCTAP2Session { session in
-            guard try await requireCredentialManagementSupport(session) else { return }
-            guard try await requirePinSet(session) else { return }
-            try await deleteAllCredentials(session)
-
-            let pinToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
-                permissions: [.credentialManagement]
-            )
-            let credMgmt = try await session.credentialManagement(pinToken: pinToken)
 
             let rps = try await credMgmt.enumerateRPs()
-
             #expect(rps.isEmpty)
-        }
-    }
 
-    @Test("Enumerate RPs returns RP after credential creation")
-    func testEnumerateRPs() async throws {
-        try await withReconnectableCTAP2Session { session, reconnectWhenOverNFC in
-            var session = session
-            guard try await requireCredentialManagementSupport(session) else { return }
-            guard try await requirePinSet(session) else { return }
-            try await deleteAllCredentials(session)
-
-            // Create test credential (requires UP)
-            session = try await reconnectWhenOverNFC()
-            try await createTestCredential(session)
-
-            // Get fresh token for credential management
-            let pinToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
-                permissions: [.credentialManagement]
-            )
-            let credMgmt = try await session.credentialManagement(pinToken: pinToken)
-
-            let rps = try await credMgmt.enumerateRPs()
-
-            #expect(rps.count == 1)
-            #expect(rps[0].rp.id == testRpId)
-            #expect(rps[0].rpIdHash.count == 32)  // SHA-256 hash
-
-            // Cleanup
-            try await deleteAllCredentials(session)
-        }
-    }
-
-    // MARK: - AsyncSequence Tests
-
-    @Test("Enumerate RPs using AsyncSequence")
-    func testEnumerateRPsAsyncSequence() async throws {
-        try await withReconnectableCTAP2Session { session, reconnectWhenOverNFC in
-            var session = session
-            guard try await requireCredentialManagementSupport(session) else { return }
-            guard try await requirePinSet(session) else { return }
-            try await deleteAllCredentials(session)
-
-            // Create test credential (requires UP)
-            session = try await reconnectWhenOverNFC()
-            try await createTestCredential(session)
-
-            // Get fresh token for credential management
-            let pinToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
-                permissions: [.credentialManagement]
-            )
-            let credMgmt = try await session.credentialManagement(pinToken: pinToken)
-
-            // Use AsyncSequence to iterate RPs
-            var rpCount = 0
-            for try await rp in credMgmt.rps {
-                #expect(rp.rp.id == testRpId)
-                #expect(rp.rpIdHash.count == 32)
-                rpCount += 1
-            }
-
-            #expect(rpCount == 1)
-
-            // Cleanup
-            try await deleteAllCredentials(session)
-        }
-    }
-
-    @Test("Enumerate credentials using AsyncSequence")
-    func testEnumerateCredentialsAsyncSequence() async throws {
-        try await withReconnectableCTAP2Session { session, reconnectWhenOverNFC in
-            var session = session
-            guard try await requireCredentialManagementSupport(session) else { return }
-            guard try await requirePinSet(session) else { return }
-            try await deleteAllCredentials(session)
-
-            // Create test credential (requires UP)
-            session = try await reconnectWhenOverNFC()
-            try await createTestCredential(session)
-
-            // Get fresh token for credential management
-            let pinToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
-                permissions: [.credentialManagement]
-            )
-            let credMgmt = try await session.credentialManagement(pinToken: pinToken)
-
-            // Get the RP first
-            let rps = try await credMgmt.enumerateRPs()
-            #expect(rps.count == 1)
-
-            // Use AsyncSequence to iterate credentials
-            var credCount = 0
-            for try await cred in credMgmt.credentials(for: rps[0].rpIdHash) {
-                #expect(cred.user.id == testUserId)
-                #expect(cred.user.name == testUserName)
-                #expect(cred.user.displayName == testUserDisplayName)
-                credCount += 1
-            }
-
-            #expect(credCount == 1)
-
-            // Cleanup
-            try await deleteAllCredentials(session)
-        }
-    }
-
-    @Test("AsyncSequence returns empty for no credentials")
-    func testAsyncSequenceEmpty() async throws {
-        try await withCTAP2Session { session in
-            guard try await requireCredentialManagementSupport(session) else { return }
-            guard try await requirePinSet(session) else { return }
-            try await deleteAllCredentials(session)
-
-            let pinToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
-                permissions: [.credentialManagement]
-            )
-            let credMgmt = try await session.credentialManagement(pinToken: pinToken)
-
-            // Verify empty iteration
             var rpCount = 0
             for try await _ in credMgmt.rps {
                 rpCount += 1
             }
-
             #expect(rpCount == 0)
         }
     }
 
-    // MARK: - Enumerate Credentials Tests
+    // MARK: - Metadata
 
-    @Test("Enumerate credentials for RP")
-    func testEnumerateCredentials() async throws {
-        try await withReconnectableCTAP2Session { session, reconnectWhenOverNFC in
-            var session = session
-            guard try await requireCredentialManagementSupport(session) else { return }
-            guard try await requirePinSet(session) else { return }
-            try await deleteAllCredentials(session)
+    @Test("Get credential metadata")
+    func testMetadata() async throws {
+        try await withCredentialManagement { credMgmt, _ in
+            let metadata = try await credMgmt.getMetadata()
+            #expect(metadata.existingCredentialsCount == 1)
+            #expect(metadata.maxRemainingCredentialsCount > 0)
+        }
+    }
 
-            // Create test credential (requires UP)
-            session = try await reconnectWhenOverNFC()
-            try await createTestCredential(session)
+    // MARK: - Enumerate
 
-            // Get fresh token for credential management
-            let pinToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
-                permissions: [.credentialManagement]
-            )
-            let credMgmt = try await session.credentialManagement(pinToken: pinToken)
-
-            // First get the RP
+    @Test("Enumerate RPs and credentials")
+    func testEnumerate() async throws {
+        try await withCredentialManagement { credMgmt, _ in
             let rps = try await credMgmt.enumerateRPs()
             #expect(rps.count == 1)
+            #expect(rps[0].rp.id == testRpId)
+            #expect(rps[0].rpIdHash.count == 32)
 
-            // Enumerate credentials for the RP
             let credentials = try await credMgmt.enumerateCredentials(rpIdHash: rps[0].rpIdHash)
-
             #expect(credentials.count == 1)
             #expect(credentials[0].user.id == testUserId)
             #expect(credentials[0].user.name == testUserName)
             #expect(credentials[0].user.displayName == testUserDisplayName)
             #expect(credentials[0].credentialId.id.count > 0)
-
-            // Cleanup
-            try await deleteAllCredentials(session)
         }
     }
 
-    // MARK: - Delete Credential Tests
+    @Test("Enumerate using AsyncSequence")
+    func testEnumerateAsyncSequence() async throws {
+        try await withCredentialManagement { credMgmt, _ in
+            var rpCount = 0
+            var rpIdHash: Data?
+            for try await rp in credMgmt.rps {
+                #expect(rp.rp.id == testRpId)
+                #expect(rp.rpIdHash.count == 32)
+                rpIdHash = rp.rpIdHash
+                rpCount += 1
+            }
+            #expect(rpCount == 1)
 
-    @Test("Delete credential removes it from authenticator")
-    func testDeleteCredential() async throws {
-        try await withReconnectableCTAP2Session { session, reconnectWhenOverNFC in
-            var session = session
-            guard try await requireCredentialManagementSupport(session) else { return }
-            guard try await requirePinSet(session) else { return }
-            try await deleteAllCredentials(session)
+            var credCount = 0
+            for try await cred in credMgmt.credentials(for: rpIdHash!) {
+                #expect(cred.user.id == testUserId)
+                #expect(cred.user.name == testUserName)
+                #expect(cred.user.displayName == testUserDisplayName)
+                credCount += 1
+            }
+            #expect(credCount == 1)
+        }
+    }
 
-            // Create test credential (requires UP)
-            session = try await reconnectWhenOverNFC()
-            try await createTestCredential(session)
+    // MARK: - Delete
 
-            // Get fresh token for credential management
-            var pinToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
-                permissions: [.credentialManagement]
-            )
-            var credMgmt = try await session.credentialManagement(pinToken: pinToken)
-
+    @Test("Delete credential")
+    func testDelete() async throws {
+        try await withCredentialManagement { credMgmt, session in
             // Verify credential exists
             var metadata = try await credMgmt.getMetadata()
             #expect(metadata.existingCredentialsCount == 1)
 
-            // Get the credential to delete
+            // Get and delete the credential
             let rps = try await credMgmt.enumerateRPs()
             let credentials = try await credMgmt.enumerateCredentials(rpIdHash: rps[0].rpIdHash)
-            let credentialToDelete = credentials[0]
+            try await credMgmt.deleteCredential(credentials[0].credentialId)
 
-            // Delete the credential
-            try await credMgmt.deleteCredential(credentialToDelete.credentialId)
-
-            // Get new token and verify credential is gone
-            pinToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
-                permissions: [.credentialManagement]
-            )
-            credMgmt = try await session.credentialManagement(pinToken: pinToken)
-
-            metadata = try await credMgmt.getMetadata()
+            // Verify deletion (need fresh token)
+            let newCredMgmt = try await getCredentialManagement(session)
+            metadata = try await newCredMgmt.getMetadata()
             #expect(metadata.existingCredentialsCount == 0)
         }
     }
 
-    // MARK: - Update User Information Tests
+    // MARK: - Update User Information
 
-    @Test("Update user information changes display name")
-    func testUpdateUserInformation() async throws {
-        try await withReconnectableCTAP2Session { session, reconnectWhenOverNFC in
-            var session = session
-            guard try await requireCredentialManagementSupport(session) else { return }
-
-            // Check if update is supported
+    @Test("Update user information")
+    func testUpdateUserInfo() async throws {
+        try await withCredentialManagement { credMgmt, session in
             guard try await CTAP2.CredentialManagement.isUpdateSupported(by: session) else {
                 print("Update user information not supported - skipping")
                 return
             }
 
-            guard try await requirePinSet(session) else { return }
-            try await deleteAllCredentials(session)
-
-            // Create test credential (requires UP)
-            session = try await reconnectWhenOverNFC()
-            try await createTestCredential(session)
-
-            // Get fresh token for credential management
-            var pinToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
-                permissions: [.credentialManagement]
-            )
-            var credMgmt = try await session.credentialManagement(pinToken: pinToken)
-
             // Get the credential
             let rps = try await credMgmt.enumerateRPs()
             let credentials = try await credMgmt.enumerateCredentials(rpIdHash: rps[0].rpIdHash)
-            let credentialToUpdate = credentials[0]
+            let credentialId = credentials[0].credentialId
 
-            // Create updated user info
+            // Update user info
             let updatedUser = WebAuthn.PublicKeyCredential.UserEntity(
                 id: testUserId,
                 name: "UPDATED NAME",
                 displayName: "UPDATED DISPLAY NAME"
             )
+            try await credMgmt.updateUserInformation(credentialId: credentialId, user: updatedUser)
 
-            // Update user information
-            try await credMgmt.updateUserInformation(
-                credentialId: credentialToUpdate.credentialId,
-                user: updatedUser
-            )
+            // Verify update (need fresh token)
+            let newCredMgmt = try await getCredentialManagement(session)
+            let rpsAfter = try await newCredMgmt.enumerateRPs()
+            let updated = try await newCredMgmt.enumerateCredentials(rpIdHash: rpsAfter[0].rpIdHash)
 
-            // Get new token and verify update
-            pinToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
-                permissions: [.credentialManagement]
-            )
-            credMgmt = try await session.credentialManagement(pinToken: pinToken)
-
-            let rpsAfter = try await credMgmt.enumerateRPs()
-            let updatedCredentials = try await credMgmt.enumerateCredentials(rpIdHash: rpsAfter[0].rpIdHash)
-
-            #expect(updatedCredentials[0].user.id == testUserId)
-            #expect(updatedCredentials[0].user.name == "UPDATED NAME")
-            #expect(updatedCredentials[0].user.displayName == "UPDATED DISPLAY NAME")
-
-            // Cleanup
-            try await deleteAllCredentials(session)
+            #expect(updated[0].user.id == testUserId)
+            #expect(updated[0].user.name == "UPDATED NAME")
+            #expect(updated[0].user.displayName == "UPDATED DISPLAY NAME")
         }
     }
 
-    // MARK: - Full Management Flow Test
+    // MARK: - Persistent Token (PPUAT)
 
-    @Test("Full credential management workflow")
-    func testFullManagementWorkflow() async throws {
-        try await withReconnectableCTAP2Session { session, reconnectWhenOverNFC in
-            var session = session
-            guard try await requireCredentialManagementSupport(session) else { return }
-            guard try await requirePinSet(session) else { return }
-            try await deleteAllCredentials(session)
-
-            // 1. Verify no credentials exist
-            var pinToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
-                permissions: [.credentialManagement]
-            )
-            var credMgmt = try await session.credentialManagement(pinToken: pinToken)
-            var rps = try await credMgmt.enumerateRPs()
-            #expect(rps.isEmpty)
-
-            // 2. Create first credential (requires UP)
-            session = try await reconnectWhenOverNFC()
-            try await createTestCredential(session)
-
-            // 3. Verify credential was created
-            pinToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
-                permissions: [.credentialManagement]
-            )
-            credMgmt = try await session.credentialManagement(pinToken: pinToken)
-
-            rps = try await credMgmt.enumerateRPs()
-            #expect(rps.count == 1)
-            #expect(rps[0].rp.id == testRpId)
-
-            let credentials = try await credMgmt.enumerateCredentials(rpIdHash: rps[0].rpIdHash)
-            #expect(credentials.count == 1)
-
-            let metadata = try await credMgmt.getMetadata()
-            #expect(metadata.existingCredentialsCount == 1)
-
-            // 4. Delete the credential
-            try await credMgmt.deleteCredential(credentials[0].credentialId)
-
-            // 5. Verify credential was deleted
-            pinToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
-                permissions: [.credentialManagement]
-            )
-            credMgmt = try await session.credentialManagement(pinToken: pinToken)
-
-            rps = try await credMgmt.enumerateRPs()
-            #expect(rps.isEmpty)
-
-            let finalMetadata = try await credMgmt.getMetadata()
-            #expect(finalMetadata.existingCredentialsCount == 0)
+    @Test("Read-only management with persistent token")
+    func testReadOnlyWithPPUAT() async throws {
+        // Check prerequisites first
+        let supported = try await withCTAP2Session { session -> Bool in
+            guard try await isSupported(session) else { return false }
+            guard try await CTAP2.CredentialManagement.isReadOnlySupported(by: session) else {
+                print("Persistent PUAT not supported - skipping")
+                return false
+            }
+            return true
         }
+        guard supported else { return }
+
+        typealias Opaque128 = CTAP2.GetInfo.Opaque128
+
+        // First session: setup and get PPUAT
+        let testData:
+            (
+                ppuat: CTAP2.ClientPin.Token,
+                credentialId: WebAuthn.PublicKeyCredential.Descriptor,
+                rpIdHash: Data,
+                identifier: Opaque128?,
+                credStoreState: Opaque128?
+            ) = try await withReconnectableCTAP2Session { session, reconnect in
+                var session = session
+                try await deleteAllCredentials(session)
+
+                // Create test credential
+                session = try await reconnect()
+                try await createTestCredential(session)
+
+                // Get credential info
+                let credMgmt = try await getCredentialManagement(session)
+                let rps = try await credMgmt.enumerateRPs()
+                let credentials = try await credMgmt.enumerateCredentials(rpIdHash: rps[0].rpIdHash)
+
+                // Get PPUAT
+                let ppuat = try await session.getPinUVToken(
+                    using: .pin(defaultTestPin),
+                    permissions: [.persistentCredentialManagement]
+                )
+
+                // Get encrypted fields
+                let info = try await session.getInfo()
+                let identifier = try info.encIdentifier.map { try $0.decrypted(using: ppuat) }
+                let credStoreState = try info.encCredStoreState.map { try $0.decrypted(using: ppuat) }
+
+                // Verify before reconnect
+                try await verifyReadOnlyOperations(session: session, ppuat: ppuat, rpIdHash: rps[0].rpIdHash)
+
+                return (ppuat, credentials[0].credentialId, rps[0].rpIdHash, identifier, credStoreState)
+            }
+
+        // Second session: verify PPUAT works after reconnect
+        try await withCTAP2Session { session in
+            try await verifyReadOnlyOperations(
+                session: session,
+                ppuat: testData.ppuat,
+                rpIdHash: testData.rpIdHash
+            )
+
+            // Verify encrypted fields are consistent
+            let info = try await session.getInfo()
+            if let expected = testData.identifier {
+                let identifier = try info.encIdentifier!.decrypted(using: testData.ppuat)
+                #expect(identifier == expected)
+            }
+            if let expected = testData.credStoreState {
+                let credStoreState = try info.encCredStoreState!.decrypted(using: testData.ppuat)
+                #expect(credStoreState == expected)
+            }
+        }
+
+        // Third session: cleanup and verify credStoreState changes
+        try await withCTAP2Session { session in
+            let credMgmt = try await getCredentialManagement(session)
+            try await credMgmt.deleteCredential(testData.credentialId)
+
+            if let original = testData.credStoreState {
+                let info = try await session.getInfo()
+                let newState = try info.encCredStoreState!.decrypted(using: testData.ppuat)
+                #expect(newState != original)
+            }
+        }
+    }
+}
+
+// MARK: - Test Fixture
+
+private func withCredentialManagement(
+    createCredential: Bool = true,
+    _ body: (CTAP2.CredentialManagement, CTAP2.Session) async throws -> Void
+) async throws {
+    try await withReconnectableCTAP2Session { session, reconnect in
+        var session = session
+        guard try await isSupported(session) else { return }
+        try await deleteAllCredentials(session)
+
+        if createCredential {
+            session = try await reconnect()
+            try await createTestCredential(session)
+        }
+
+        let credMgmt = try await getCredentialManagement(session)
+        try await body(credMgmt, session)
+
+        try await deleteAllCredentials(session)
     }
 }
 
 // MARK: - Helpers
 
-private func requireCredentialManagementSupport(_ session: CTAP2.Session) async throws -> Bool {
+private func isSupported(_ session: CTAP2.Session) async throws -> Bool {
     guard try await CTAP2.CredentialManagement.isSupported(by: session) else {
         print("Credential management not supported - skipping")
         return false
     }
+    let info = try await session.getInfo()
+    try #require(info.options.clientPin == true, "PIN not set")
     return true
 }
 
-private func requirePinSet(_ session: CTAP2.Session) async throws -> Bool {
-    let info = try await session.getInfo()
-    guard info.options.clientPin == true else {
-        print("PIN not set - skipping (run testClientPinSetup first)")
-        return false
-    }
-    return true
+private func getCredentialManagement(_ session: CTAP2.Session) async throws -> CTAP2.CredentialManagement {
+    let token = try await session.getPinUVToken(
+        using: .pin(defaultTestPin),
+        permissions: [.credentialManagement]
+    )
+    return try await session.credentialManagement(pinToken: token)
 }
 
 private func createTestCredential(_ session: CTAP2.Session) async throws {
-    // Get PIN token for makeCredential
     let pinToken = try await session.getPinUVToken(
         using: .pin(defaultTestPin),
         permissions: [.makeCredential],
         rpId: testRpId
     )
-
-    // Create a discoverable (resident) credential
     let params = CTAP2.MakeCredential.Parameters(
         clientDataHash: testClientDataHash,
         rp: testRp,
@@ -486,23 +309,61 @@ private func createTestCredential(_ session: CTAP2.Session) async throws {
         pubKeyCredParams: [.es256],
         options: .init(rk: true)
     )
-
     print("👆 Touch YubiKey: creating test credential...")
     _ = try await session.makeCredential(parameters: params, pinToken: pinToken).value
-    print("✅ Test credential created")
 }
 
 private func deleteAllCredentials(_ session: CTAP2.Session) async throws {
-    let pinToken = try await session.getPinUVToken(
-        using: .pin(defaultTestPin),
-        permissions: .credentialManagement
-    )
-    let credMgmt = try await session.credentialManagement(pinToken: pinToken)
-
-    // Use AsyncSequence to enumerate and delete all credentials
+    let credMgmt = try await getCredentialManagement(session)
     for try await rp in credMgmt.rps {
         for try await credential in credMgmt.credentials(for: rp.rpIdHash) {
             try await credMgmt.deleteCredential(credential.credentialId)
+        }
+    }
+}
+
+private func verifyReadOnlyOperations(
+    session: CTAP2.Session,
+    ppuat: CTAP2.ClientPin.Token,
+    rpIdHash: Data
+) async throws {
+    let credMgmt = try await session.credentialManagement(pinToken: ppuat)
+
+    // Read operations should work
+    let metadata = try await credMgmt.getMetadata()
+    #expect(metadata.existingCredentialsCount == 1)
+
+    let rps = try await credMgmt.enumerateRPs()
+    #expect(rps.count == 1)
+
+    let credentials = try await credMgmt.enumerateCredentials(rpIdHash: rpIdHash)
+    #expect(credentials.count == 1)
+
+    let credentialId = credentials[0].credentialId
+
+    // Write operations should fail with pinAuthInvalid
+    do {
+        let user = WebAuthn.PublicKeyCredential.UserEntity(
+            id: Data([0x01, 0x02, 0x03]),
+            name: "X",
+            displayName: "X"
+        )
+        try await credMgmt.updateUserInformation(credentialId: credentialId, user: user)
+        Issue.record("updateUserInformation should fail with PPUAT")
+    } catch let error as CTAP2.SessionError {
+        guard case .ctapError(.pinAuthInvalid, _) = error else {
+            Issue.record("Expected pinAuthInvalid, got \(error)")
+            throw error
+        }
+    }
+
+    do {
+        try await credMgmt.deleteCredential(credentialId)
+        Issue.record("deleteCredential should fail with PPUAT")
+    } catch let error as CTAP2.SessionError {
+        guard case .ctapError(.pinAuthInvalid, _) = error else {
+            Issue.record("Expected pinAuthInvalid, got \(error)")
+            throw error
         }
     }
 }

--- a/FullStackTests/Tests/CTAP2/CredentialManagementTests.swift
+++ b/FullStackTests/Tests/CTAP2/CredentialManagementTests.swift
@@ -123,9 +123,8 @@ struct CredentialManagementTests {
             let credentials = try await credMgmt.enumerateCredentials(rpIdHash: rps[0].rpIdHash)
             try await credMgmt.deleteCredential(credentials[0].credentialId)
 
-            // Verify deletion (need fresh token)
-            let newCredMgmt = try await getCredentialManagement(session)
-            metadata = try await newCredMgmt.getMetadata()
+            // Verify deletion
+            metadata = try await credMgmt.getMetadata()
             #expect(metadata.existingCredentialsCount == 0)
         }
     }
@@ -153,10 +152,9 @@ struct CredentialManagementTests {
             )
             try await credMgmt.updateUserInformation(credentialId: credentialId, user: updatedUser)
 
-            // Verify update (need fresh token)
-            let newCredMgmt = try await getCredentialManagement(session)
-            let rpsAfter = try await newCredMgmt.enumerateRPs()
-            let updated = try await newCredMgmt.enumerateCredentials(rpIdHash: rpsAfter[0].rpIdHash)
+            // Verify update
+            let rpsAfter = try await credMgmt.enumerateRPs()
+            let updated = try await credMgmt.enumerateCredentials(rpIdHash: rpsAfter[0].rpIdHash)
 
             #expect(updated[0].user.id == testUserId)
             #expect(updated[0].user.name == "UPDATED NAME")
@@ -189,12 +187,12 @@ struct CredentialManagementTests {
                 rpIdHash: Data,
                 identifier: Opaque128?,
                 credStoreState: Opaque128?
-            ) = try await withReconnectableCTAP2Session { session, reconnect in
+            ) = try await withReconnectableCTAP2Session { session, reconnectWhenOverNFC in
                 var session = session
                 try await deleteAllCredentials(session)
 
                 // Create test credential
-                session = try await reconnect()
+                session = try await reconnectWhenOverNFC()
                 try await createTestCredential(session)
 
                 // Get credential info
@@ -259,13 +257,13 @@ private func withCredentialManagement(
     createCredential: Bool,
     _ body: (CTAP2.CredentialManagement, CTAP2.Session) async throws -> Void
 ) async throws {
-    try await withReconnectableCTAP2Session { session, reconnect in
+    try await withReconnectableCTAP2Session { session, reconnectWhenOverNFC in
         var session = session
         guard try await isSupported(session) else { return }
         try await deleteAllCredentials(session)
 
         if createCredential {
-            session = try await reconnect()
+            session = try await reconnectWhenOverNFC()
             try await createTestCredential(session)
         }
 

--- a/FullStackTests/Tests/CTAP2/CredentialManagementTests.swift
+++ b/FullStackTests/Tests/CTAP2/CredentialManagementTests.swift
@@ -1,0 +1,508 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Testing
+import YubiKit
+
+// MARK: - Test Constants
+
+private let testClientDataHash = Data(repeating: 0xCD, count: 32)
+
+private let testRpId = "test.example.com"
+private let testRp = WebAuthn.PublicKeyCredential.RPEntity(id: testRpId, name: "Test RP")
+
+private let testUserId = Data([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08])
+private let testUserName = "testuser@example.com"
+private let testUserDisplayName = "Test User"
+private let testUser = WebAuthn.PublicKeyCredential.UserEntity(
+    id: testUserId,
+    name: testUserName,
+    displayName: testUserDisplayName
+)
+
+// MARK: - Test Tags
+
+extension Tag {
+    @Tag static var credentialManagement: Tag
+}
+
+// MARK: - Tests
+
+@Suite("Credential Management Full Stack Tests", .tags(.credentialManagement), .serialized)
+struct CredentialManagementFullStackTests {
+
+    // MARK: - Read Metadata Tests
+
+    @Test("Read credential metadata with no credentials")
+    func testReadMetadataEmpty() async throws {
+        try await withCTAP2Session { session in
+            guard try await requireCredentialManagementSupport(session) else { return }
+            guard try await requirePinSet(session) else { return }
+            try await deleteAllCredentials(session)
+
+            let pinToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.credentialManagement]
+            )
+            let credMgmt = try await session.credentialManagement(pinToken: pinToken)
+
+            let metadata = try await credMgmt.getMetadata()
+
+            #expect(metadata.existingCredentialsCount == 0)
+            #expect(metadata.maxRemainingCredentialsCount > 0)
+        }
+    }
+
+    @Test("Read credential metadata with one credential")
+    func testReadMetadataWithCredential() async throws {
+        try await withReconnectableCTAP2Session { session, reconnectWhenOverNFC in
+            var session = session
+            guard try await requireCredentialManagementSupport(session) else { return }
+            guard try await requirePinSet(session) else { return }
+            try await deleteAllCredentials(session)
+
+            // Create a test credential (requires UP)
+            session = try await reconnectWhenOverNFC()
+            try await createTestCredential(session)
+
+            // Get fresh token for credential management
+            let pinToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.credentialManagement]
+            )
+            let credMgmt = try await session.credentialManagement(pinToken: pinToken)
+
+            let metadata = try await credMgmt.getMetadata()
+
+            #expect(metadata.existingCredentialsCount == 1)
+            #expect(metadata.maxRemainingCredentialsCount > 0)
+
+            // Cleanup
+            try await deleteAllCredentials(session)
+        }
+    }
+
+    // MARK: - Enumerate RPs Tests
+
+    @Test("Enumerate RPs returns empty when no credentials")
+    func testEnumerateRPsEmpty() async throws {
+        try await withCTAP2Session { session in
+            guard try await requireCredentialManagementSupport(session) else { return }
+            guard try await requirePinSet(session) else { return }
+            try await deleteAllCredentials(session)
+
+            let pinToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.credentialManagement]
+            )
+            let credMgmt = try await session.credentialManagement(pinToken: pinToken)
+
+            let rps = try await credMgmt.enumerateRPs()
+
+            #expect(rps.isEmpty)
+        }
+    }
+
+    @Test("Enumerate RPs returns RP after credential creation")
+    func testEnumerateRPs() async throws {
+        try await withReconnectableCTAP2Session { session, reconnectWhenOverNFC in
+            var session = session
+            guard try await requireCredentialManagementSupport(session) else { return }
+            guard try await requirePinSet(session) else { return }
+            try await deleteAllCredentials(session)
+
+            // Create test credential (requires UP)
+            session = try await reconnectWhenOverNFC()
+            try await createTestCredential(session)
+
+            // Get fresh token for credential management
+            let pinToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.credentialManagement]
+            )
+            let credMgmt = try await session.credentialManagement(pinToken: pinToken)
+
+            let rps = try await credMgmt.enumerateRPs()
+
+            #expect(rps.count == 1)
+            #expect(rps[0].rp.id == testRpId)
+            #expect(rps[0].rpIdHash.count == 32)  // SHA-256 hash
+
+            // Cleanup
+            try await deleteAllCredentials(session)
+        }
+    }
+
+    // MARK: - AsyncSequence Tests
+
+    @Test("Enumerate RPs using AsyncSequence")
+    func testEnumerateRPsAsyncSequence() async throws {
+        try await withReconnectableCTAP2Session { session, reconnectWhenOverNFC in
+            var session = session
+            guard try await requireCredentialManagementSupport(session) else { return }
+            guard try await requirePinSet(session) else { return }
+            try await deleteAllCredentials(session)
+
+            // Create test credential (requires UP)
+            session = try await reconnectWhenOverNFC()
+            try await createTestCredential(session)
+
+            // Get fresh token for credential management
+            let pinToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.credentialManagement]
+            )
+            let credMgmt = try await session.credentialManagement(pinToken: pinToken)
+
+            // Use AsyncSequence to iterate RPs
+            var rpCount = 0
+            for try await rp in credMgmt.rps {
+                #expect(rp.rp.id == testRpId)
+                #expect(rp.rpIdHash.count == 32)
+                rpCount += 1
+            }
+
+            #expect(rpCount == 1)
+
+            // Cleanup
+            try await deleteAllCredentials(session)
+        }
+    }
+
+    @Test("Enumerate credentials using AsyncSequence")
+    func testEnumerateCredentialsAsyncSequence() async throws {
+        try await withReconnectableCTAP2Session { session, reconnectWhenOverNFC in
+            var session = session
+            guard try await requireCredentialManagementSupport(session) else { return }
+            guard try await requirePinSet(session) else { return }
+            try await deleteAllCredentials(session)
+
+            // Create test credential (requires UP)
+            session = try await reconnectWhenOverNFC()
+            try await createTestCredential(session)
+
+            // Get fresh token for credential management
+            let pinToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.credentialManagement]
+            )
+            let credMgmt = try await session.credentialManagement(pinToken: pinToken)
+
+            // Get the RP first
+            let rps = try await credMgmt.enumerateRPs()
+            #expect(rps.count == 1)
+
+            // Use AsyncSequence to iterate credentials
+            var credCount = 0
+            for try await cred in credMgmt.credentials(for: rps[0].rpIdHash) {
+                #expect(cred.user.id == testUserId)
+                #expect(cred.user.name == testUserName)
+                #expect(cred.user.displayName == testUserDisplayName)
+                credCount += 1
+            }
+
+            #expect(credCount == 1)
+
+            // Cleanup
+            try await deleteAllCredentials(session)
+        }
+    }
+
+    @Test("AsyncSequence returns empty for no credentials")
+    func testAsyncSequenceEmpty() async throws {
+        try await withCTAP2Session { session in
+            guard try await requireCredentialManagementSupport(session) else { return }
+            guard try await requirePinSet(session) else { return }
+            try await deleteAllCredentials(session)
+
+            let pinToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.credentialManagement]
+            )
+            let credMgmt = try await session.credentialManagement(pinToken: pinToken)
+
+            // Verify empty iteration
+            var rpCount = 0
+            for try await _ in credMgmt.rps {
+                rpCount += 1
+            }
+
+            #expect(rpCount == 0)
+        }
+    }
+
+    // MARK: - Enumerate Credentials Tests
+
+    @Test("Enumerate credentials for RP")
+    func testEnumerateCredentials() async throws {
+        try await withReconnectableCTAP2Session { session, reconnectWhenOverNFC in
+            var session = session
+            guard try await requireCredentialManagementSupport(session) else { return }
+            guard try await requirePinSet(session) else { return }
+            try await deleteAllCredentials(session)
+
+            // Create test credential (requires UP)
+            session = try await reconnectWhenOverNFC()
+            try await createTestCredential(session)
+
+            // Get fresh token for credential management
+            let pinToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.credentialManagement]
+            )
+            let credMgmt = try await session.credentialManagement(pinToken: pinToken)
+
+            // First get the RP
+            let rps = try await credMgmt.enumerateRPs()
+            #expect(rps.count == 1)
+
+            // Enumerate credentials for the RP
+            let credentials = try await credMgmt.enumerateCredentials(rpIdHash: rps[0].rpIdHash)
+
+            #expect(credentials.count == 1)
+            #expect(credentials[0].user.id == testUserId)
+            #expect(credentials[0].user.name == testUserName)
+            #expect(credentials[0].user.displayName == testUserDisplayName)
+            #expect(credentials[0].credentialId.id.count > 0)
+
+            // Cleanup
+            try await deleteAllCredentials(session)
+        }
+    }
+
+    // MARK: - Delete Credential Tests
+
+    @Test("Delete credential removes it from authenticator")
+    func testDeleteCredential() async throws {
+        try await withReconnectableCTAP2Session { session, reconnectWhenOverNFC in
+            var session = session
+            guard try await requireCredentialManagementSupport(session) else { return }
+            guard try await requirePinSet(session) else { return }
+            try await deleteAllCredentials(session)
+
+            // Create test credential (requires UP)
+            session = try await reconnectWhenOverNFC()
+            try await createTestCredential(session)
+
+            // Get fresh token for credential management
+            var pinToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.credentialManagement]
+            )
+            var credMgmt = try await session.credentialManagement(pinToken: pinToken)
+
+            // Verify credential exists
+            var metadata = try await credMgmt.getMetadata()
+            #expect(metadata.existingCredentialsCount == 1)
+
+            // Get the credential to delete
+            let rps = try await credMgmt.enumerateRPs()
+            let credentials = try await credMgmt.enumerateCredentials(rpIdHash: rps[0].rpIdHash)
+            let credentialToDelete = credentials[0]
+
+            // Delete the credential
+            try await credMgmt.deleteCredential(credentialToDelete.credentialId)
+
+            // Get new token and verify credential is gone
+            pinToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.credentialManagement]
+            )
+            credMgmt = try await session.credentialManagement(pinToken: pinToken)
+
+            metadata = try await credMgmt.getMetadata()
+            #expect(metadata.existingCredentialsCount == 0)
+        }
+    }
+
+    // MARK: - Update User Information Tests
+
+    @Test("Update user information changes display name")
+    func testUpdateUserInformation() async throws {
+        try await withReconnectableCTAP2Session { session, reconnectWhenOverNFC in
+            var session = session
+            guard try await requireCredentialManagementSupport(session) else { return }
+
+            // Check if update is supported
+            guard try await CTAP2.CredentialManagement.isUpdateSupported(by: session) else {
+                print("Update user information not supported - skipping")
+                return
+            }
+
+            guard try await requirePinSet(session) else { return }
+            try await deleteAllCredentials(session)
+
+            // Create test credential (requires UP)
+            session = try await reconnectWhenOverNFC()
+            try await createTestCredential(session)
+
+            // Get fresh token for credential management
+            var pinToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.credentialManagement]
+            )
+            var credMgmt = try await session.credentialManagement(pinToken: pinToken)
+
+            // Get the credential
+            let rps = try await credMgmt.enumerateRPs()
+            let credentials = try await credMgmt.enumerateCredentials(rpIdHash: rps[0].rpIdHash)
+            let credentialToUpdate = credentials[0]
+
+            // Create updated user info
+            let updatedUser = WebAuthn.PublicKeyCredential.UserEntity(
+                id: testUserId,
+                name: "UPDATED NAME",
+                displayName: "UPDATED DISPLAY NAME"
+            )
+
+            // Update user information
+            try await credMgmt.updateUserInformation(
+                credentialId: credentialToUpdate.credentialId,
+                user: updatedUser
+            )
+
+            // Get new token and verify update
+            pinToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.credentialManagement]
+            )
+            credMgmt = try await session.credentialManagement(pinToken: pinToken)
+
+            let rpsAfter = try await credMgmt.enumerateRPs()
+            let updatedCredentials = try await credMgmt.enumerateCredentials(rpIdHash: rpsAfter[0].rpIdHash)
+
+            #expect(updatedCredentials[0].user.id == testUserId)
+            #expect(updatedCredentials[0].user.name == "UPDATED NAME")
+            #expect(updatedCredentials[0].user.displayName == "UPDATED DISPLAY NAME")
+
+            // Cleanup
+            try await deleteAllCredentials(session)
+        }
+    }
+
+    // MARK: - Full Management Flow Test
+
+    @Test("Full credential management workflow")
+    func testFullManagementWorkflow() async throws {
+        try await withReconnectableCTAP2Session { session, reconnectWhenOverNFC in
+            var session = session
+            guard try await requireCredentialManagementSupport(session) else { return }
+            guard try await requirePinSet(session) else { return }
+            try await deleteAllCredentials(session)
+
+            // 1. Verify no credentials exist
+            var pinToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.credentialManagement]
+            )
+            var credMgmt = try await session.credentialManagement(pinToken: pinToken)
+            var rps = try await credMgmt.enumerateRPs()
+            #expect(rps.isEmpty)
+
+            // 2. Create first credential (requires UP)
+            session = try await reconnectWhenOverNFC()
+            try await createTestCredential(session)
+
+            // 3. Verify credential was created
+            pinToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.credentialManagement]
+            )
+            credMgmt = try await session.credentialManagement(pinToken: pinToken)
+
+            rps = try await credMgmt.enumerateRPs()
+            #expect(rps.count == 1)
+            #expect(rps[0].rp.id == testRpId)
+
+            let credentials = try await credMgmt.enumerateCredentials(rpIdHash: rps[0].rpIdHash)
+            #expect(credentials.count == 1)
+
+            let metadata = try await credMgmt.getMetadata()
+            #expect(metadata.existingCredentialsCount == 1)
+
+            // 4. Delete the credential
+            try await credMgmt.deleteCredential(credentials[0].credentialId)
+
+            // 5. Verify credential was deleted
+            pinToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.credentialManagement]
+            )
+            credMgmt = try await session.credentialManagement(pinToken: pinToken)
+
+            rps = try await credMgmt.enumerateRPs()
+            #expect(rps.isEmpty)
+
+            let finalMetadata = try await credMgmt.getMetadata()
+            #expect(finalMetadata.existingCredentialsCount == 0)
+        }
+    }
+}
+
+// MARK: - Helpers
+
+private func requireCredentialManagementSupport(_ session: CTAP2.Session) async throws -> Bool {
+    guard try await CTAP2.CredentialManagement.isSupported(by: session) else {
+        print("Credential management not supported - skipping")
+        return false
+    }
+    return true
+}
+
+private func requirePinSet(_ session: CTAP2.Session) async throws -> Bool {
+    let info = try await session.getInfo()
+    guard info.options.clientPin == true else {
+        print("PIN not set - skipping (run testClientPinSetup first)")
+        return false
+    }
+    return true
+}
+
+private func createTestCredential(_ session: CTAP2.Session) async throws {
+    // Get PIN token for makeCredential
+    let pinToken = try await session.getPinUVToken(
+        using: .pin(defaultTestPin),
+        permissions: [.makeCredential],
+        rpId: testRpId
+    )
+
+    // Create a discoverable (resident) credential
+    let params = CTAP2.MakeCredential.Parameters(
+        clientDataHash: testClientDataHash,
+        rp: testRp,
+        user: testUser,
+        pubKeyCredParams: [.es256],
+        options: .init(rk: true)
+    )
+
+    print("👆 Touch YubiKey: creating test credential...")
+    _ = try await session.makeCredential(parameters: params, pinToken: pinToken).value
+    print("✅ Test credential created")
+}
+
+private func deleteAllCredentials(_ session: CTAP2.Session) async throws {
+    let pinToken = try await session.getPinUVToken(
+        using: .pin(defaultTestPin),
+        permissions: .credentialManagement
+    )
+    let credMgmt = try await session.credentialManagement(pinToken: pinToken)
+
+    // Use AsyncSequence to enumerate and delete all credentials
+    for try await rp in credMgmt.rps {
+        for try await credential in credMgmt.credentials(for: rp.rpIdHash) {
+            try await credMgmt.deleteCredential(credential.credentialId)
+        }
+    }
+}

--- a/FullStackTests/Tests/CTAP2/CredentialManagementTests.swift
+++ b/FullStackTests/Tests/CTAP2/CredentialManagementTests.swift
@@ -59,7 +59,7 @@ struct CredentialManagementTests {
 
     @Test("Get credential metadata")
     func testMetadata() async throws {
-        try await withCredentialManagement { credMgmt, _ in
+        try await withCredentialManagement(createCredential: true) { credMgmt, _ in
             let metadata = try await credMgmt.getMetadata()
             #expect(metadata.existingCredentialsCount == 1)
             #expect(metadata.maxRemainingCredentialsCount > 0)
@@ -70,7 +70,7 @@ struct CredentialManagementTests {
 
     @Test("Enumerate RPs and credentials")
     func testEnumerate() async throws {
-        try await withCredentialManagement { credMgmt, _ in
+        try await withCredentialManagement(createCredential: true) { credMgmt, _ in
             let rps = try await credMgmt.enumerateRPs()
             #expect(rps.count == 1)
             #expect(rps[0].rp.id == testRpId)
@@ -87,7 +87,7 @@ struct CredentialManagementTests {
 
     @Test("Enumerate using AsyncSequence")
     func testEnumerateAsyncSequence() async throws {
-        try await withCredentialManagement { credMgmt, _ in
+        try await withCredentialManagement(createCredential: true) { credMgmt, _ in
             var rpCount = 0
             var rpIdHash: Data?
             for try await rp in credMgmt.rps {
@@ -113,7 +113,7 @@ struct CredentialManagementTests {
 
     @Test("Delete credential")
     func testDelete() async throws {
-        try await withCredentialManagement { credMgmt, session in
+        try await withCredentialManagement(createCredential: true) { credMgmt, session in
             // Verify credential exists
             var metadata = try await credMgmt.getMetadata()
             #expect(metadata.existingCredentialsCount == 1)
@@ -134,7 +134,7 @@ struct CredentialManagementTests {
 
     @Test("Update user information")
     func testUpdateUserInfo() async throws {
-        try await withCredentialManagement { credMgmt, session in
+        try await withCredentialManagement(createCredential: true) { credMgmt, session in
             guard try await CTAP2.CredentialManagement.isUpdateSupported(by: session) else {
                 print("Update user information not supported - skipping")
                 return
@@ -256,7 +256,7 @@ struct CredentialManagementTests {
 // MARK: - Test Fixture
 
 private func withCredentialManagement(
-    createCredential: Bool = true,
+    createCredential: Bool,
     _ body: (CTAP2.CredentialManagement, CTAP2.Session) async throws -> Void
 ) async throws {
     try await withReconnectableCTAP2Session { session, reconnect in
@@ -350,7 +350,7 @@ private func verifyReadOnlyOperations(
         )
         try await credMgmt.updateUserInformation(credentialId: credentialId, user: user)
         Issue.record("updateUserInformation should fail with PPUAT")
-    } catch let error as CTAP2.SessionError {
+    } catch {
         guard case .ctapError(.pinAuthInvalid, _) = error else {
             Issue.record("Expected pinAuthInvalid, got \(error)")
             throw error
@@ -360,7 +360,7 @@ private func verifyReadOnlyOperations(
     do {
         try await credMgmt.deleteCredential(credentialId)
         Issue.record("deleteCredential should fail with PPUAT")
-    } catch let error as CTAP2.SessionError {
+    } catch {
         guard case .ctapError(.pinAuthInvalid, _) = error else {
             Issue.record("Expected pinAuthInvalid, got \(error)")
             throw error

--- a/FullStackTests/Tests/CTAP2/CredentialManagementTests.swift
+++ b/FullStackTests/Tests/CTAP2/CredentialManagementTests.swift
@@ -44,14 +44,8 @@ struct CredentialManagementTests {
             #expect(metadata.existingCredentialsCount == 0)
             #expect(metadata.maxRemainingCredentialsCount > 0)
 
-            let rps = try await credMgmt.enumerateRPs()
+            let rps = try await credMgmt.rps.enumerate()
             #expect(rps.isEmpty)
-
-            var rpCount = 0
-            for try await _ in credMgmt.rps {
-                rpCount += 1
-            }
-            #expect(rpCount == 0)
         }
     }
 
@@ -71,23 +65,6 @@ struct CredentialManagementTests {
     @Test("Enumerate RPs and credentials")
     func testEnumerate() async throws {
         try await withCredentialManagement(createCredential: true) { credMgmt, _ in
-            let rps = try await credMgmt.enumerateRPs()
-            #expect(rps.count == 1)
-            #expect(rps[0].rp.id == testRpId)
-            #expect(rps[0].rpIdHash.count == 32)
-
-            let credentials = try await credMgmt.enumerateCredentials(rpIdHash: rps[0].rpIdHash)
-            #expect(credentials.count == 1)
-            #expect(credentials[0].user.id == testUserId)
-            #expect(credentials[0].user.name == testUserName)
-            #expect(credentials[0].user.displayName == testUserDisplayName)
-            #expect(credentials[0].credentialId.id.count > 0)
-        }
-    }
-
-    @Test("Enumerate using AsyncSequence")
-    func testEnumerateAsyncSequence() async throws {
-        try await withCredentialManagement(createCredential: true) { credMgmt, _ in
             var rpCount = 0
             var rpIdHash: Data?
             for try await rp in credMgmt.rps {
@@ -103,6 +80,7 @@ struct CredentialManagementTests {
                 #expect(cred.user.id == testUserId)
                 #expect(cred.user.name == testUserName)
                 #expect(cred.user.displayName == testUserDisplayName)
+                #expect(cred.credentialId.id.count > 0)
                 credCount += 1
             }
             #expect(credCount == 1)
@@ -119,8 +97,8 @@ struct CredentialManagementTests {
             #expect(metadata.existingCredentialsCount == 1)
 
             // Get and delete the credential
-            let rps = try await credMgmt.enumerateRPs()
-            let credentials = try await credMgmt.enumerateCredentials(rpIdHash: rps[0].rpIdHash)
+            let rps = try await credMgmt.rps.enumerate()
+            let credentials = try await credMgmt.credentials(for: rps[0].rpIdHash).enumerate()
             try await credMgmt.deleteCredential(credentials[0].credentialId)
 
             // Verify deletion
@@ -140,8 +118,8 @@ struct CredentialManagementTests {
             }
 
             // Get the credential
-            let rps = try await credMgmt.enumerateRPs()
-            let credentials = try await credMgmt.enumerateCredentials(rpIdHash: rps[0].rpIdHash)
+            let rps = try await credMgmt.rps.enumerate()
+            let credentials = try await credMgmt.credentials(for: rps[0].rpIdHash).enumerate()
             let credentialId = credentials[0].credentialId
 
             // Update user info
@@ -153,8 +131,8 @@ struct CredentialManagementTests {
             try await credMgmt.updateUserInformation(credentialId: credentialId, user: updatedUser)
 
             // Verify update
-            let rpsAfter = try await credMgmt.enumerateRPs()
-            let updated = try await credMgmt.enumerateCredentials(rpIdHash: rpsAfter[0].rpIdHash)
+            let rpsAfter = try await credMgmt.rps.enumerate()
+            let updated = try await credMgmt.credentials(for: rpsAfter[0].rpIdHash).enumerate()
 
             #expect(updated[0].user.id == testUserId)
             #expect(updated[0].user.name == "UPDATED NAME")
@@ -197,8 +175,8 @@ struct CredentialManagementTests {
 
                 // Get credential info
                 let credMgmt = try await getCredentialManagement(session)
-                let rps = try await credMgmt.enumerateRPs()
-                let credentials = try await credMgmt.enumerateCredentials(rpIdHash: rps[0].rpIdHash)
+                let rps = try await credMgmt.rps.enumerate()
+                let credentials = try await credMgmt.credentials(for: rps[0].rpIdHash).enumerate()
 
                 // Get PPUAT
                 let ppuat = try await session.getPinUVToken(
@@ -331,10 +309,10 @@ private func verifyReadOnlyOperations(
     let metadata = try await credMgmt.getMetadata()
     #expect(metadata.existingCredentialsCount == 1)
 
-    let rps = try await credMgmt.enumerateRPs()
+    let rps = try await credMgmt.rps.enumerate()
     #expect(rps.count == 1)
 
-    let credentials = try await credMgmt.enumerateCredentials(rpIdHash: rpIdHash)
+    let credentials = try await credMgmt.credentials(for: rpIdHash).enumerate()
     #expect(credentials.count == 1)
 
     let credentialId = credentials[0].credentialId

--- a/FullStackTests/Tests/CTAP2/EncryptedFieldsTests.swift
+++ b/FullStackTests/Tests/CTAP2/EncryptedFieldsTests.swift
@@ -184,8 +184,8 @@ struct EncryptedFieldsTests {
                 permissions: [.credentialManagement]
             )
             let credMgmt2 = try await session.credentialManagement(pinToken: deleteToken)
-            let rps = try await credMgmt2.enumerateRPs()
-            let creds = try await credMgmt2.enumerateCredentials(rpIdHash: rps[0].rpIdHash)
+            let rps = try await credMgmt2.rps.enumerate()
+            let creds = try await credMgmt2.credentials(for: rps[0].rpIdHash).enumerate()
             try await credMgmt2.deleteCredential(creds[0].credentialId)
 
             // Verify state changed after credential deletion

--- a/FullStackTests/Tests/CTAP2/EncryptedFieldsTests.swift
+++ b/FullStackTests/Tests/CTAP2/EncryptedFieldsTests.swift
@@ -113,9 +113,86 @@ struct EncryptedFieldsTests {
 
     @Test("credStoreState changes when credentials are added or deleted")
     func testCredStoreStateChangesOnCredentialLifecycle() async throws {
-        // TODO: Implement when CredentialManagement API is added
-        // 1. Get PPUAT and initial credStoreState
-        // 2. Create discoverable credential -> verify state changes
-        // 3. Delete credential via CredentialManagement -> verify state changes again
+        try await withReconnectableCTAP2Session { session, reconnectWhenOverNFC in
+            var session = session
+            let info = try await session.getInfo()
+            try #require(info.encCredStoreState != nil, "encCredStoreState not supported")
+
+            guard try await CTAP2.CredentialManagement.isSupported(by: session) else {
+                print("Credential management not supported - skipping")
+                return
+            }
+            guard try await CTAP2.CredentialManagement.isReadOnlySupported(by: session) else {
+                print("Persistent PUAT not supported - skipping")
+                return
+            }
+            try #require(info.options.clientPin == true, "PIN not set")
+
+            // Get PPUAT for decrypting credStoreState
+            let ppuat = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.persistentCredentialManagement]
+            )
+
+            // Clean up any existing credentials
+            let cmToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.credentialManagement]
+            )
+            let credMgmt = try await session.credentialManagement(pinToken: cmToken)
+            for try await rp in credMgmt.rps {
+                for try await cred in credMgmt.credentials(for: rp.rpIdHash) {
+                    try await credMgmt.deleteCredential(cred.credentialId)
+                }
+            }
+
+            // 1. Get initial credStoreState
+            let info1 = try await session.getInfo()
+            let state1 = try info1.encCredStoreState!.decrypted(using: ppuat)
+            print("✅ Initial credStoreState: \(state1)")
+
+            // 2. Create discoverable credential (requires UP)
+            session = try await reconnectWhenOverNFC()
+            let makeCredToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.makeCredential],
+                rpId: "test.example.com"
+            )
+            let params = CTAP2.MakeCredential.Parameters(
+                clientDataHash: Data(repeating: 0xCD, count: 32),
+                rp: WebAuthn.PublicKeyCredential.RPEntity(id: "test.example.com", name: "Test"),
+                user: WebAuthn.PublicKeyCredential.UserEntity(
+                    id: Data([0x01, 0x02, 0x03]),
+                    name: "test",
+                    displayName: "Test"
+                ),
+                pubKeyCredParams: [.es256],
+                options: .init(rk: true)
+            )
+            print("👆 Touch YubiKey: creating credential...")
+            _ = try await session.makeCredential(parameters: params, pinToken: makeCredToken).value
+
+            // Verify state changed after credential creation
+            let info2 = try await session.getInfo()
+            let state2 = try info2.encCredStoreState!.decrypted(using: ppuat)
+            #expect(state2 != state1)
+            print("✅ credStoreState changed after credential creation: \(state2)")
+
+            // 3. Delete credential via CredentialManagement
+            let cmToken2 = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.credentialManagement]
+            )
+            let credMgmt2 = try await session.credentialManagement(pinToken: cmToken2)
+            let rps = try await credMgmt2.enumerateRPs()
+            let creds = try await credMgmt2.enumerateCredentials(rpIdHash: rps[0].rpIdHash)
+            try await credMgmt2.deleteCredential(creds[0].credentialId)
+
+            // Verify state changed after credential deletion
+            let info3 = try await session.getInfo()
+            let state3 = try info3.encCredStoreState!.decrypted(using: ppuat)
+            #expect(state3 != state2)
+            print("✅ credStoreState changed after credential deletion: \(state3)")
+        }
     }
 }

--- a/FullStackTests/Tests/CTAP2/EncryptedFieldsTests.swift
+++ b/FullStackTests/Tests/CTAP2/EncryptedFieldsTests.swift
@@ -178,12 +178,12 @@ struct EncryptedFieldsTests {
             #expect(state2 != state1)
             print("✅ credStoreState changed after credential creation: \(state2)")
 
-            // 3. Delete credential via CredentialManagement
-            let cmToken2 = try await session.getPinUVToken(
+            // 3. Delete credential via CredentialManagement (re-create after potential NFC reconnect)
+            let deleteToken = try await session.getPinUVToken(
                 using: .pin(defaultTestPin),
                 permissions: [.credentialManagement]
             )
-            let credMgmt2 = try await session.credentialManagement(pinToken: cmToken2)
+            let credMgmt2 = try await session.credentialManagement(pinToken: deleteToken)
             let rps = try await credMgmt2.enumerateRPs()
             let creds = try await credMgmt2.enumerateCredentials(rpIdHash: rps[0].rpIdHash)
             try await credMgmt2.deleteCredential(creds[0].credentialId)

--- a/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement+AsyncSequence.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement+AsyncSequence.swift
@@ -28,7 +28,7 @@ extension CTAP2.CredentialManagement {
     /// }
     /// ```
     ///
-    /// A lazy alternative to ``enumerateRPs()``.
+    /// To collect all RPs into an array, use ``RPSequence/enumerate()``.
     public var rps: RPSequence {
         RPSequence(credentialManagement: self)
     }
@@ -59,6 +59,15 @@ extension CTAP2.CredentialManagement {
 
         fileprivate let credentialManagement: CTAP2.CredentialManagement
 
+        /// Collects all relying parties into an array.
+        public func enumerate() async throws(CTAP2.SessionError) -> [RPData] {
+            var results = [RPData]()
+            for try await rp in self {
+                results.append(rp)
+            }
+            return results
+        }
+
         public func makeAsyncIterator() -> Iterator {
             Iterator(credentialManagement: credentialManagement)
         }
@@ -76,7 +85,7 @@ extension CTAP2.CredentialManagement {
                 self.credentialManagement = credentialManagement
             }
 
-            public func next() async throws -> RPData? {
+            public func next() async throws(CTAP2.SessionError) -> RPData? {
                 guard !finished else { return nil }
 
                 if fetched == 0 {
@@ -109,7 +118,7 @@ extension CTAP2.CredentialManagement {
                 return response.rpData
             }
 
-            private func beginEnumeration() async throws -> EnumerateRPsResponse? {
+            private func beginEnumeration() async throws(CTAP2.SessionError) -> EnumerateRPsResponse? {
                 do {
                     return try await credentialManagement.execute(subcommand: .enumerateRPsBegin)
                 } catch .ctapError(.noCredentials, _) {
@@ -131,6 +140,15 @@ extension CTAP2.CredentialManagement {
         fileprivate let credentialManagement: CTAP2.CredentialManagement
         fileprivate let rpIdHash: Data
 
+        /// Collects all credentials into an array.
+        public func enumerate() async throws(CTAP2.SessionError) -> [CredentialData] {
+            var results = [CredentialData]()
+            for try await cred in self {
+                results.append(cred)
+            }
+            return results
+        }
+
         public func makeAsyncIterator() -> Iterator {
             Iterator(credentialManagement: credentialManagement, rpIdHash: rpIdHash)
         }
@@ -150,7 +168,7 @@ extension CTAP2.CredentialManagement {
                 self.rpIdHash = rpIdHash
             }
 
-            public func next() async throws -> CredentialData? {
+            public func next() async throws(CTAP2.SessionError) -> CredentialData? {
                 guard !finished else { return nil }
 
                 if fetched == 0 {
@@ -183,7 +201,7 @@ extension CTAP2.CredentialManagement {
                 return response.credentialData
             }
 
-            private func beginEnumeration() async throws -> EnumerateCredentialsResponse? {
+            private func beginEnumeration() async throws(CTAP2.SessionError) -> EnumerateCredentialsResponse? {
                 let params: [UInt8: CBOR.Value] = [
                     Parameter.rpIdHash.rawValue: rpIdHash.cbor()
                 ]

--- a/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement+AsyncSequence.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement+AsyncSequence.swift
@@ -1,0 +1,202 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+// MARK: - AsyncSequence API
+
+extension CTAP2.CredentialManagement {
+
+    /// An async sequence of relying parties with stored credentials.
+    ///
+    /// Use this for lazy iteration over RPs, fetching each one on-demand:
+    /// ```swift
+    /// for try await rp in credMgmt.rps {
+    ///     print(rp.rp.id)
+    ///     if someCondition { break }  // Stops fetching early
+    /// }
+    /// ```
+    ///
+    /// This is more memory-efficient than `enumerateRPs()` when you may not
+    /// need all results, and supports early termination.
+    public var rps: RPSequence {
+        RPSequence(credentialManagement: self)
+    }
+
+    /// An async sequence of credentials for a specific relying party.
+    ///
+    /// Use this for lazy iteration over credentials, fetching each one on-demand:
+    /// ```swift
+    /// for try await cred in credMgmt.credentials(for: rpIdHash) {
+    ///     print(cred.user.name)
+    /// }
+    /// ```
+    ///
+    /// - Parameter rpIdHash: SHA-256 hash of the RP ID.
+    /// - Returns: An async sequence of credentials for the specified RP.
+    public func credentials(for rpIdHash: Data) -> CredentialSequence {
+        CredentialSequence(credentialManagement: self, rpIdHash: rpIdHash)
+    }
+}
+
+// MARK: - RP Sequence
+
+extension CTAP2.CredentialManagement {
+
+    /// An async sequence that lazily enumerates relying parties.
+    public struct RPSequence: AsyncSequence, Sendable {
+        public typealias Element = RPData
+
+        let credentialManagement: CTAP2.CredentialManagement
+
+        public func makeAsyncIterator() -> Iterator {
+            Iterator(credentialManagement: credentialManagement)
+        }
+
+        /// Iterator for lazily enumerating relying parties.
+        public actor Iterator: AsyncIteratorProtocol {
+            public typealias Element = RPData
+
+            let credentialManagement: CTAP2.CredentialManagement
+            var totalRPs: UInt = 0
+            var fetched: UInt = 0
+            var finished = false
+
+            init(credentialManagement: CTAP2.CredentialManagement) {
+                self.credentialManagement = credentialManagement
+            }
+
+            public func next() async throws -> RPData? {
+                guard !finished else { return nil }
+
+                if fetched == 0 {
+                    // First call - begin enumeration
+                    guard let response = try await beginEnumeration() else {
+                        finished = true
+                        return nil
+                    }
+                    totalRPs = response.totalRPs ?? 0
+                    guard totalRPs > 0 else {
+                        finished = true
+                        return nil
+                    }
+                    fetched = 1
+                    finished = fetched >= totalRPs
+                    return response.rpData
+                }
+
+                guard fetched < totalRPs else {
+                    finished = true
+                    return nil
+                }
+
+                // Subsequent calls - get next
+                let response: EnumerateRPsResponse = try await credentialManagement.executeNoAuth(
+                    subcommand: .enumerateRPsGetNextRP
+                )
+                fetched += 1
+                finished = fetched >= totalRPs
+                return response.rpData
+            }
+
+            private func beginEnumeration() async throws -> EnumerateRPsResponse? {
+                do {
+                    return try await credentialManagement.execute(subcommand: .enumerateRPsBegin)
+                } catch .ctapError(.noCredentials, _) {
+                    return nil
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Credential Sequence
+
+extension CTAP2.CredentialManagement {
+
+    /// An async sequence that lazily enumerates credentials for a relying party.
+    public struct CredentialSequence: AsyncSequence, Sendable {
+        public typealias Element = CredentialData
+
+        let credentialManagement: CTAP2.CredentialManagement
+        let rpIdHash: Data
+
+        public func makeAsyncIterator() -> Iterator {
+            Iterator(credentialManagement: credentialManagement, rpIdHash: rpIdHash)
+        }
+
+        /// Iterator for lazily enumerating credentials.
+        public actor Iterator: AsyncIteratorProtocol {
+            public typealias Element = CredentialData
+
+            let credentialManagement: CTAP2.CredentialManagement
+            let rpIdHash: Data
+            var totalCredentials: UInt = 0
+            var fetched: UInt = 0
+            var finished = false
+
+            init(credentialManagement: CTAP2.CredentialManagement, rpIdHash: Data) {
+                self.credentialManagement = credentialManagement
+                self.rpIdHash = rpIdHash
+            }
+
+            public func next() async throws -> CredentialData? {
+                guard !finished else { return nil }
+
+                if fetched == 0 {
+                    // First call - begin enumeration
+                    guard let response = try await beginEnumeration() else {
+                        finished = true
+                        return nil
+                    }
+                    totalCredentials = response.totalCredentials ?? 0
+                    guard totalCredentials > 0 else {
+                        finished = true
+                        return nil
+                    }
+                    fetched = 1
+                    finished = fetched >= totalCredentials
+                    return response.credentialData
+                }
+
+                guard fetched < totalCredentials else {
+                    finished = true
+                    return nil
+                }
+
+                // Subsequent calls - get next
+                let response: EnumerateCredentialsResponse = try await credentialManagement.executeNoAuth(
+                    subcommand: .enumerateCredentialsGetNextCredential
+                )
+                fetched += 1
+                finished = fetched >= totalCredentials
+                return response.credentialData
+            }
+
+            private func beginEnumeration() async throws -> EnumerateCredentialsResponse? {
+                let params: [UInt8: CBOR.Value] = [
+                    0x01: rpIdHash.cbor()  // PARAM_RP_ID_HASH
+                ]
+                do {
+                    return try await credentialManagement.execute(
+                        subcommand: .enumerateCredentialsBegin,
+                        params: params
+                    )
+                } catch .ctapError(.noCredentials, _) {
+                    return nil
+                }
+            }
+        }
+    }
+}

--- a/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement+AsyncSequence.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement+AsyncSequence.swift
@@ -28,8 +28,7 @@ extension CTAP2.CredentialManagement {
     /// }
     /// ```
     ///
-    /// This is more memory-efficient than `enumerateRPs()` when you may not
-    /// need all results, and supports early termination.
+    /// A lazy alternative to ``enumerateRPs()``.
     public var rps: RPSequence {
         RPSequence(credentialManagement: self)
     }
@@ -58,7 +57,7 @@ extension CTAP2.CredentialManagement {
     public struct RPSequence: AsyncSequence, Sendable {
         public typealias Element = RPData
 
-        let credentialManagement: CTAP2.CredentialManagement
+        fileprivate let credentialManagement: CTAP2.CredentialManagement
 
         public func makeAsyncIterator() -> Iterator {
             Iterator(credentialManagement: credentialManagement)
@@ -68,12 +67,12 @@ extension CTAP2.CredentialManagement {
         public actor Iterator: AsyncIteratorProtocol {
             public typealias Element = RPData
 
-            let credentialManagement: CTAP2.CredentialManagement
-            var totalRPs: UInt = 0
-            var fetched: UInt = 0
-            var finished = false
+            private let credentialManagement: CTAP2.CredentialManagement
+            private var totalRPs: UInt = 0
+            private var fetched: UInt = 0
+            private var finished = false
 
-            init(credentialManagement: CTAP2.CredentialManagement) {
+            fileprivate init(credentialManagement: CTAP2.CredentialManagement) {
                 self.credentialManagement = credentialManagement
             }
 
@@ -129,8 +128,8 @@ extension CTAP2.CredentialManagement {
     public struct CredentialSequence: AsyncSequence, Sendable {
         public typealias Element = CredentialData
 
-        let credentialManagement: CTAP2.CredentialManagement
-        let rpIdHash: Data
+        fileprivate let credentialManagement: CTAP2.CredentialManagement
+        fileprivate let rpIdHash: Data
 
         public func makeAsyncIterator() -> Iterator {
             Iterator(credentialManagement: credentialManagement, rpIdHash: rpIdHash)
@@ -140,13 +139,13 @@ extension CTAP2.CredentialManagement {
         public actor Iterator: AsyncIteratorProtocol {
             public typealias Element = CredentialData
 
-            let credentialManagement: CTAP2.CredentialManagement
-            let rpIdHash: Data
-            var totalCredentials: UInt = 0
-            var fetched: UInt = 0
-            var finished = false
+            private let credentialManagement: CTAP2.CredentialManagement
+            private let rpIdHash: Data
+            private var totalCredentials: UInt = 0
+            private var fetched: UInt = 0
+            private var finished = false
 
-            init(credentialManagement: CTAP2.CredentialManagement, rpIdHash: Data) {
+            fileprivate init(credentialManagement: CTAP2.CredentialManagement, rpIdHash: Data) {
                 self.credentialManagement = credentialManagement
                 self.rpIdHash = rpIdHash
             }

--- a/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement+AsyncSequence.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement+AsyncSequence.swift
@@ -186,7 +186,7 @@ extension CTAP2.CredentialManagement {
 
             private func beginEnumeration() async throws -> EnumerateCredentialsResponse? {
                 let params: [UInt8: CBOR.Value] = [
-                    0x01: rpIdHash.cbor()  // PARAM_RP_ID_HASH
+                    Parameter.rpIdHash.rawValue: rpIdHash.cbor()
                 ]
                 do {
                     return try await credentialManagement.execute(

--- a/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement+Types+CBOR.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement+Types+CBOR.swift
@@ -68,16 +68,14 @@ extension CTAP2.CredentialManagement.EnumerateRPsResponse: CBOR.Decodable {
 
         let totalRPs = map[.int(Key.totalRPs.rawValue)]?.uint64Value.map { UInt($0) }
 
-        let rpData: CTAP2.CredentialManagement.RPData?
-        if let rpCbor = map[.int(Key.rp.rawValue)],
+        guard let rpCbor = map[.int(Key.rp.rawValue)],
             let rp: WebAuthn.PublicKeyCredential.RPEntity = rpCbor.cborDecoded(),
             let rpIdHash = map[.int(Key.rpIdHash.rawValue)]?.dataValue
-        {
-            rpData = CTAP2.CredentialManagement.RPData(rp: rp, rpIdHash: rpIdHash)
-        } else {
-            rpData = nil
+        else {
+            return nil
         }
 
+        let rpData = CTAP2.CredentialManagement.RPData(rp: rp, rpIdHash: rpIdHash)
         self.init(rpData: rpData, totalRPs: totalRPs)
     }
 }
@@ -94,31 +92,29 @@ extension CTAP2.CredentialManagement.EnumerateCredentialsResponse: CBOR.Decodabl
 
         let totalCredentials = map[.int(Key.totalCredentials.rawValue)]?.uint64Value.map { UInt($0) }
 
-        let credentialData: CTAP2.CredentialManagement.CredentialData?
-        if let userCbor = map[.int(Key.user.rawValue)],
+        guard let userCbor = map[.int(Key.user.rawValue)],
             let user: WebAuthn.PublicKeyCredential.UserEntity = userCbor.cborDecoded(),
             let credIdCbor = map[.int(Key.credentialId.rawValue)],
             let credentialId: WebAuthn.PublicKeyCredential.Descriptor = credIdCbor.cborDecoded(),
             let publicKeyCbor = map[.int(Key.publicKey.rawValue)],
             let publicKey: COSE.Key = publicKeyCbor.cborDecoded()
-        {
-            let credProtect = map[.int(Key.credProtect.rawValue)]?.uint64Value
-                .flatMap { CTAP2.Extension.CredProtect.Level(rawValue: Int($0)) }
-            let largeBlobKey = map[.int(Key.largeBlobKey.rawValue)]?.dataValue
-            let thirdPartyPayment = map[.int(Key.thirdPartyPayment.rawValue)]?.boolValue
-
-            credentialData = CTAP2.CredentialManagement.CredentialData(
-                user: user,
-                credentialId: credentialId,
-                publicKey: publicKey,
-                credProtect: credProtect,
-                largeBlobKey: largeBlobKey,
-                thirdPartyPayment: thirdPartyPayment
-            )
-        } else {
-            credentialData = nil
+        else {
+            return nil
         }
 
+        let credProtect = map[.int(Key.credProtect.rawValue)]?.uint64Value
+            .flatMap { CTAP2.Extension.CredProtect.Level(rawValue: Int($0)) }
+        let largeBlobKey = map[.int(Key.largeBlobKey.rawValue)]?.dataValue
+        let thirdPartyPayment = map[.int(Key.thirdPartyPayment.rawValue)]?.boolValue
+
+        let credentialData = CTAP2.CredentialManagement.CredentialData(
+            user: user,
+            credentialId: credentialId,
+            publicKey: publicKey,
+            credProtect: credProtect,
+            largeBlobKey: largeBlobKey,
+            thirdPartyPayment: thirdPartyPayment
+        )
         self.init(credentialData: credentialData, totalCredentials: totalCredentials)
     }
 }

--- a/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement+Types+CBOR.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement+Types+CBOR.swift
@@ -1,0 +1,147 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+// MARK: - Response Keys
+
+extension CTAP2.CredentialManagement {
+    fileprivate enum ResponseKey: Int {
+        case existingResidentCredentialsCount = 0x01
+        case maxPossibleRemainingResidentCredentialsCount = 0x02
+        case rp = 0x03
+        case rpIdHash = 0x04
+        case totalRPs = 0x05
+        case user = 0x06
+        case credentialId = 0x07
+        case publicKey = 0x08
+        case totalCredentials = 0x09
+        case credProtect = 0x0A
+        case largeBlobKey = 0x0B
+        case thirdPartyPayment = 0x0C
+    }
+}
+
+// MARK: - Metadata + CBOR
+
+extension CTAP2.CredentialManagement.Metadata: CBOR.Decodable {
+    init?(cbor: CBOR.Value) {
+        guard let map = cbor.mapValue else {
+            return nil
+        }
+
+        typealias Key = CTAP2.CredentialManagement.ResponseKey
+
+        guard let existingCount = map[.int(Key.existingResidentCredentialsCount.rawValue)]?.uint64Value,
+            let maxRemaining = map[.int(Key.maxPossibleRemainingResidentCredentialsCount.rawValue)]?.uint64Value
+        else {
+            return nil
+        }
+
+        self.init(
+            existingCredentialsCount: UInt(existingCount),
+            maxRemainingCredentialsCount: UInt(maxRemaining)
+        )
+    }
+}
+
+// MARK: - EnumerateRPsResponse + CBOR
+
+extension CTAP2.CredentialManagement.EnumerateRPsResponse: CBOR.Decodable {
+    init?(cbor: CBOR.Value) {
+        guard let map = cbor.mapValue else {
+            return nil
+        }
+
+        typealias Key = CTAP2.CredentialManagement.ResponseKey
+
+        // totalRPs (0x05) - only in first response
+        let totalRPs: UInt?
+        if let count = map[.int(Key.totalRPs.rawValue)]?.uint64Value {
+            totalRPs = UInt(count)
+        } else {
+            totalRPs = nil
+        }
+
+        // rp (0x03) and rpIdHash (0x04)
+        let rpData: CTAP2.CredentialManagement.RPData?
+        if let rpCbor = map[.int(Key.rp.rawValue)],
+            let rp: WebAuthn.PublicKeyCredential.RPEntity = rpCbor.cborDecoded(),
+            let rpIdHash = map[.int(Key.rpIdHash.rawValue)]?.dataValue
+        {
+            rpData = CTAP2.CredentialManagement.RPData(rp: rp, rpIdHash: rpIdHash)
+        } else {
+            rpData = nil
+        }
+
+        self.init(rpData: rpData, totalRPs: totalRPs)
+    }
+}
+
+// MARK: - EnumerateCredentialsResponse + CBOR
+
+extension CTAP2.CredentialManagement.EnumerateCredentialsResponse: CBOR.Decodable {
+    init?(cbor: CBOR.Value) {
+        guard let map = cbor.mapValue else {
+            return nil
+        }
+
+        typealias Key = CTAP2.CredentialManagement.ResponseKey
+
+        // totalCredentials (0x09) - only in first response
+        let totalCredentials: UInt?
+        if let count = map[.int(Key.totalCredentials.rawValue)]?.uint64Value {
+            totalCredentials = UInt(count)
+        } else {
+            totalCredentials = nil
+        }
+
+        // Parse credential data
+        let credentialData: CTAP2.CredentialManagement.CredentialData?
+        if let userCbor = map[.int(Key.user.rawValue)],
+            let user: WebAuthn.PublicKeyCredential.UserEntity = userCbor.cborDecoded(),
+            let credIdCbor = map[.int(Key.credentialId.rawValue)],
+            let credentialId: WebAuthn.PublicKeyCredential.Descriptor = credIdCbor.cborDecoded(),
+            let publicKeyCbor = map[.int(Key.publicKey.rawValue)],
+            let publicKey: COSE.Key = publicKeyCbor.cborDecoded()
+        {
+            // Optional: credProtect (0x0A)
+            let credProtect: CTAP2.Extension.CredProtect.Level?
+            if let protectValue = map[.int(Key.credProtect.rawValue)]?.uint64Value {
+                credProtect = CTAP2.Extension.CredProtect.Level(rawValue: Int(protectValue))
+            } else {
+                credProtect = nil
+            }
+
+            // Optional: largeBlobKey (0x0B)
+            let largeBlobKey = map[.int(Key.largeBlobKey.rawValue)]?.dataValue
+
+            // Optional: thirdPartyPayment (0x0C)
+            let thirdPartyPayment = map[.int(Key.thirdPartyPayment.rawValue)]?.boolValue
+
+            credentialData = CTAP2.CredentialManagement.CredentialData(
+                user: user,
+                credentialId: credentialId,
+                publicKey: publicKey,
+                credProtect: credProtect,
+                largeBlobKey: largeBlobKey,
+                thirdPartyPayment: thirdPartyPayment
+            )
+        } else {
+            credentialData = nil
+        }
+
+        self.init(credentialData: credentialData, totalCredentials: totalCredentials)
+    }
+}

--- a/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement+Types+CBOR.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement+Types+CBOR.swift
@@ -66,15 +66,8 @@ extension CTAP2.CredentialManagement.EnumerateRPsResponse: CBOR.Decodable {
 
         typealias Key = CTAP2.CredentialManagement.ResponseKey
 
-        // totalRPs (0x05) - only in first response
-        let totalRPs: UInt?
-        if let count = map[.int(Key.totalRPs.rawValue)]?.uint64Value {
-            totalRPs = UInt(count)
-        } else {
-            totalRPs = nil
-        }
+        let totalRPs = map[.int(Key.totalRPs.rawValue)]?.uint64Value.map { UInt($0) }
 
-        // rp (0x03) and rpIdHash (0x04)
         let rpData: CTAP2.CredentialManagement.RPData?
         if let rpCbor = map[.int(Key.rp.rawValue)],
             let rp: WebAuthn.PublicKeyCredential.RPEntity = rpCbor.cborDecoded(),
@@ -99,15 +92,8 @@ extension CTAP2.CredentialManagement.EnumerateCredentialsResponse: CBOR.Decodabl
 
         typealias Key = CTAP2.CredentialManagement.ResponseKey
 
-        // totalCredentials (0x09) - only in first response
-        let totalCredentials: UInt?
-        if let count = map[.int(Key.totalCredentials.rawValue)]?.uint64Value {
-            totalCredentials = UInt(count)
-        } else {
-            totalCredentials = nil
-        }
+        let totalCredentials = map[.int(Key.totalCredentials.rawValue)]?.uint64Value.map { UInt($0) }
 
-        // Parse credential data
         let credentialData: CTAP2.CredentialManagement.CredentialData?
         if let userCbor = map[.int(Key.user.rawValue)],
             let user: WebAuthn.PublicKeyCredential.UserEntity = userCbor.cborDecoded(),
@@ -116,18 +102,9 @@ extension CTAP2.CredentialManagement.EnumerateCredentialsResponse: CBOR.Decodabl
             let publicKeyCbor = map[.int(Key.publicKey.rawValue)],
             let publicKey: COSE.Key = publicKeyCbor.cborDecoded()
         {
-            // Optional: credProtect (0x0A)
-            let credProtect: CTAP2.Extension.CredProtect.Level?
-            if let protectValue = map[.int(Key.credProtect.rawValue)]?.uint64Value {
-                credProtect = CTAP2.Extension.CredProtect.Level(rawValue: Int(protectValue))
-            } else {
-                credProtect = nil
-            }
-
-            // Optional: largeBlobKey (0x0B)
+            let credProtect = map[.int(Key.credProtect.rawValue)]?.uint64Value
+                .flatMap { CTAP2.Extension.CredProtect.Level(rawValue: Int($0)) }
             let largeBlobKey = map[.int(Key.largeBlobKey.rawValue)]?.dataValue
-
-            // Optional: thirdPartyPayment (0x0C)
             let thirdPartyPayment = map[.int(Key.thirdPartyPayment.rawValue)]?.boolValue
 
             credentialData = CTAP2.CredentialManagement.CredentialData(

--- a/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement+Types.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement+Types.swift
@@ -1,0 +1,107 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+// MARK: - Public Types
+
+extension CTAP2.CredentialManagement {
+
+    /// Metadata about stored credentials on the authenticator.
+    public struct Metadata: Sendable {
+        /// Total number of discoverable credentials currently stored.
+        public let existingCredentialsCount: UInt
+
+        /// Maximum number of additional discoverable credentials that can be stored.
+        ///
+        /// This is an estimate as actual space depends on algorithm choice,
+        /// user entity information size, etc.
+        public let maxRemainingCredentialsCount: UInt
+
+        internal init(existingCredentialsCount: UInt, maxRemainingCredentialsCount: UInt) {
+            self.existingCredentialsCount = existingCredentialsCount
+            self.maxRemainingCredentialsCount = maxRemainingCredentialsCount
+        }
+    }
+
+    /// Information about a relying party with stored credentials.
+    public struct RPData: Sendable {
+        /// The relying party entity.
+        public let rp: WebAuthn.PublicKeyCredential.RPEntity
+
+        /// SHA-256 hash of the RP ID.
+        public let rpIdHash: Data
+
+        internal init(rp: WebAuthn.PublicKeyCredential.RPEntity, rpIdHash: Data) {
+            self.rp = rp
+            self.rpIdHash = rpIdHash
+        }
+    }
+
+    /// Information about a stored credential.
+    public struct CredentialData: Sendable {
+        /// The user entity associated with this credential.
+        public let user: WebAuthn.PublicKeyCredential.UserEntity
+
+        /// The credential identifier.
+        public let credentialId: WebAuthn.PublicKeyCredential.Descriptor
+
+        /// The credential's public key.
+        public let publicKey: COSE.Key
+
+        /// Credential protection level, if set.
+        public let credProtect: CTAP2.Extension.CredProtect.Level?
+
+        /// Large blob key for this credential, if available.
+        ///
+        /// This is a 32-byte key that can be used to encrypt/decrypt
+        /// data in the authenticator's large blob storage.
+        public let largeBlobKey: Data?
+
+        /// Whether this credential supports third-party payment.
+        public let thirdPartyPayment: Bool?
+
+        internal init(
+            user: WebAuthn.PublicKeyCredential.UserEntity,
+            credentialId: WebAuthn.PublicKeyCredential.Descriptor,
+            publicKey: COSE.Key,
+            credProtect: CTAP2.Extension.CredProtect.Level?,
+            largeBlobKey: Data?,
+            thirdPartyPayment: Bool?
+        ) {
+            self.user = user
+            self.credentialId = credentialId
+            self.publicKey = publicKey
+            self.credProtect = credProtect
+            self.largeBlobKey = largeBlobKey
+            self.thirdPartyPayment = thirdPartyPayment
+        }
+    }
+}
+
+// MARK: - Internal Response Types
+
+extension CTAP2.CredentialManagement {
+    /// Internal response from enumerateRPsBegin/enumerateRPsGetNextRP
+    struct EnumerateRPsResponse: Sendable {
+        let rpData: RPData?
+        let totalRPs: UInt?
+    }
+
+    /// Internal response from enumerateCredentialsBegin/enumerateCredentialsGetNextCredential
+    struct EnumerateCredentialsResponse: Sendable {
+        let credentialData: CredentialData?
+        let totalCredentials: UInt?
+    }
+}

--- a/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement+Types.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement+Types.swift
@@ -95,13 +95,13 @@ extension CTAP2.CredentialManagement {
 extension CTAP2.CredentialManagement {
     /// Internal response from enumerateRPsBegin/enumerateRPsGetNextRP
     struct EnumerateRPsResponse: Sendable {
-        let rpData: RPData?
+        let rpData: RPData
         let totalRPs: UInt?
     }
 
     /// Internal response from enumerateCredentialsBegin/enumerateCredentialsGetNextCredential
     struct EnumerateCredentialsResponse: Sendable {
-        let credentialData: CredentialData?
+        let credentialData: CredentialData
         let totalCredentials: UInt?
     }
 }

--- a/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement.swift
@@ -129,21 +129,13 @@ extension CTAP2 {
                 return []
             }
 
-            var results: [RPData] = []
-
-            // First RP is in the initial response
-            if let rpData = response.rpData {
-                results.append(rpData)
-            }
-
-            // Get remaining RPs
+            var results = [response.rpData].compactMap { $0 }
             for _ in 1..<totalRPs {
-                let nextResponse: EnumerateRPsResponse = try await executeNoAuth(subcommand: .enumerateRPsGetNextRP)
-                if let rpData = nextResponse.rpData {
+                let next: EnumerateRPsResponse = try await executeNoAuth(subcommand: .enumerateRPsGetNextRP)
+                if let rpData = next.rpData {
                     results.append(rpData)
                 }
             }
-
             return results
         }
 
@@ -168,23 +160,15 @@ extension CTAP2 {
                 return []
             }
 
-            var results: [CredentialData] = []
-
-            // First credential is in the initial response
-            if let credData = response.credentialData {
-                results.append(credData)
-            }
-
-            // Get remaining credentials
+            var results = [response.credentialData].compactMap { $0 }
             for _ in 1..<totalCredentials {
-                let nextResponse: EnumerateCredentialsResponse = try await executeNoAuth(
+                let next: EnumerateCredentialsResponse = try await executeNoAuth(
                     subcommand: .enumerateCredentialsGetNextCredential
                 )
-                if let credData = nextResponse.credentialData {
+                if let credData = next.credentialData {
                     results.append(credData)
                 }
             }
-
             return results
         }
 
@@ -234,72 +218,52 @@ extension CTAP2 {
             subcommand: Subcommand,
             params: [UInt8: CBOR.Value]? = nil
         ) async throws(CTAP2.SessionError) -> R {
-            let message = authMessage(subcommand: subcommand, params: params)
-            let pinUVAuthParam = pinToken.authenticate(message: message)
-
-            let parameters = RequestParameters(
-                subCommand: subcommand,
-                subCommandParams: params,
-                pinUVAuthProtocol: pinToken.protocolVersion,
-                pinUVAuthParam: pinUVAuthParam
-            )
-
+            let parameters = authParameters(subcommand: subcommand, params: params)
             let command = try await commandCode()
-            return try await session.interface.send(
-                command: command,
-                payload: parameters
-            ).value
+            return try await session.interface.send(command: command, payload: parameters).value
         }
 
         func execute(
             subcommand: Subcommand,
             params: [UInt8: CBOR.Value]? = nil
         ) async throws(CTAP2.SessionError) {
-            let message = authMessage(subcommand: subcommand, params: params)
-            let pinUVAuthParam = pinToken.authenticate(message: message)
-
-            let parameters = RequestParameters(
-                subCommand: subcommand,
-                subCommandParams: params,
-                pinUVAuthProtocol: pinToken.protocolVersion,
-                pinUVAuthParam: pinUVAuthParam
-            )
-
+            let parameters = authParameters(subcommand: subcommand, params: params)
             let command = try await commandCode()
-            try await session.interface.send(
-                command: command,
-                payload: parameters
-            ).value
+            try await session.interface.send(command: command, payload: parameters).value
         }
 
         func executeNoAuth<R: CBOR.Decodable & Sendable>(
             subcommand: Subcommand
         ) async throws(CTAP2.SessionError) -> R {
-            let parameters = RequestParametersNoAuth(subCommand: subcommand)
-
             let command = try await commandCode()
             return try await session.interface.send(
                 command: command,
-                payload: parameters
+                payload: RequestParametersNoAuth(subCommand: subcommand)
             ).value
+        }
+
+        private func authParameters(
+            subcommand: Subcommand,
+            params: [UInt8: CBOR.Value]?
+        ) -> RequestParameters {
+            // Auth message format: subCommand || CBOR(params)
+            var message = Data([subcommand.rawValue])
+            if let params {
+                message.append(params.cbor().encode())
+            }
+            return RequestParameters(
+                subCommand: subcommand,
+                subCommandParams: params,
+                pinUVAuthProtocol: pinToken.protocolVersion,
+                pinUVAuthParam: pinToken.authenticate(message: message)
+            )
         }
 
         private func commandCode() async throws(CTAP2.SessionError) -> CTAP2.Command {
             let info = try await session.getInfo()
-            if info.options.credentialManagement == true {
-                return .credentialManagement
-            }
-            return .credentialManagementPreview
-        }
-
-        // Format: subCommand || CBOR(params)
-        private func authMessage(subcommand: Subcommand, params: [UInt8: CBOR.Value]?) -> Data {
-            var message = Data([subcommand.rawValue])
-            if let params {
-                let cborParams = params.cbor()
-                message.append(cborParams.encode())
-            }
-            return message
+            return info.options.credentialManagement == true
+                ? .credentialManagement
+                : .credentialManagementPreview
         }
     }
 }
@@ -323,7 +287,7 @@ extension CTAP2.CredentialManagement {
         case user = 0x03
     }
 
-    fileprivate struct RequestParameters: Sendable, CBOR.Encodable {
+    struct RequestParameters: Sendable, CBOR.Encodable {
         let subCommand: Subcommand
         let subCommandParams: [UInt8: CBOR.Value]?
         let pinUVAuthProtocol: CTAP2.ClientPin.ProtocolVersion
@@ -345,7 +309,7 @@ extension CTAP2.CredentialManagement {
         }
     }
 
-    fileprivate struct RequestParametersNoAuth: Sendable, CBOR.Encodable {
+    struct RequestParametersNoAuth: Sendable, CBOR.Encodable {
         let subCommand: Subcommand
 
         func cbor() -> CBOR.Value {

--- a/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement.swift
@@ -1,0 +1,356 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+// MARK: - Session CredentialManagement Accessor
+
+extension CTAP2.Session {
+    /// Returns credential management operations bound to a PIN/UV auth token.
+    ///
+    /// ```swift
+    /// let pinToken = try await session.getPinUVToken(
+    ///     using: .pin("123456"),
+    ///     permissions: [.credentialManagement]
+    /// )
+    /// let credMgmt = try await session.credentialManagement(pinToken: pinToken)
+    /// let metadata = try await credMgmt.getMetadata()
+    /// let rps = try await credMgmt.enumerateRPs()
+    /// ```
+    ///
+    /// - Parameter pinToken: PIN/UV auth token with `credentialManagement` permission.
+    /// - Returns: CredentialManagement operations bound to the token.
+    /// - Throws: `CTAP2.SessionError.featureNotSupported` if credential management is not supported.
+    /// - SeeAlso: [CTAP2 authenticatorCredentialManagement](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorCredentialManagement)
+    public func credentialManagement(
+        pinToken: CTAP2.ClientPin.Token
+    ) async throws(CTAP2.SessionError) -> CTAP2.CredentialManagement {
+        guard try await CTAP2.CredentialManagement.isSupported(by: self) else {
+            throw .featureNotSupported(source: .here())
+        }
+        return CTAP2.CredentialManagement(session: self, pinToken: pinToken)
+    }
+}
+
+// MARK: - CredentialManagement
+
+extension CTAP2 {
+    /// Credential management operations bound to a PIN/UV auth token.
+    ///
+    /// Allows managing discoverable (resident) credentials stored on the authenticator.
+    ///
+    /// - SeeAlso: [CTAP2 authenticatorCredentialManagement](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorCredentialManagement)
+    public struct CredentialManagement: Sendable {
+        private let session: CTAP2.Session
+        private let pinToken: CTAP2.ClientPin.Token
+
+        fileprivate init(session: CTAP2.Session, pinToken: CTAP2.ClientPin.Token) {
+            self.session = session
+            self.pinToken = pinToken
+        }
+
+        // MARK: - Feature Detection
+
+        /// Checks if the authenticator supports credential management.
+        ///
+        /// - Parameter session: The CTAP2 session to check.
+        /// - Returns: `true` if the authenticator supports credential management.
+        public static func isSupported(by session: CTAP2.Session) async throws(CTAP2.SessionError) -> Bool {
+            let info = try await session.getInfo()
+            // Check for CTAP 2.1+ credMgmt or FIDO_2_1_PRE credentialMgmtPreview
+            return info.options.credentialManagement == true
+                || (info.versions.contains(.fido2_1Pre) && info.options.credentialMgmtPreview == true)
+        }
+
+        /// Checks if the authenticator supports updating user information.
+        ///
+        /// Update user information is only available with full CTAP 2.1+ credential management,
+        /// not with the FIDO_2_1_PRE prototype command.
+        ///
+        /// - Parameter session: The CTAP2 session to check.
+        /// - Returns: `true` if the authenticator supports updating user information.
+        public static func isUpdateSupported(by session: CTAP2.Session) async throws(CTAP2.SessionError) -> Bool {
+            let info = try await session.getInfo()
+            return info.options.credentialManagement == true
+        }
+
+        /// Checks if the authenticator supports read-only credential management with a persistent token.
+        ///
+        /// When supported, read-only operations (enumerate RPs, enumerate credentials, get metadata)
+        /// can use a persistent PIN/UV auth token without requiring re-authentication each time.
+        ///
+        /// - Parameter session: The CTAP2 session to check.
+        /// - Returns: `true` if the authenticator supports read-only credential management.
+        public static func isReadOnlySupported(by session: CTAP2.Session) async throws(CTAP2.SessionError) -> Bool {
+            let info = try await session.getInfo()
+            return info.options.perCredMgmtRO == true
+        }
+
+        // MARK: - Operations
+
+        /// Gets metadata about stored credentials.
+        ///
+        /// Returns the total number of discoverable credentials and the maximum
+        /// number of additional credentials that can be stored.
+        ///
+        /// - Returns: Metadata containing credential counts.
+        /// - SeeAlso: [Getting Credentials Metadata](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#getCredsMetadata)
+        public func getMetadata() async throws(CTAP2.SessionError) -> Metadata {
+            try await execute(subcommand: .getCredsMetadata)
+        }
+
+        /// Enumerates all relying parties with stored credentials.
+        ///
+        /// Returns a list of all RPs that have discoverable credentials stored
+        /// on the authenticator.
+        ///
+        /// - Returns: Array of RP data, or empty array if no credentials exist.
+        /// - SeeAlso: [Enumerating RPs](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#enumeratingRPs)
+        public func enumerateRPs() async throws(CTAP2.SessionError) -> [RPData] {
+            let response: EnumerateRPsResponse
+            do {
+                response = try await execute(subcommand: .enumerateRPsBegin)
+            } catch .ctapError(.noCredentials, _) {
+                return []
+            }
+
+            guard let totalRPs = response.totalRPs, totalRPs > 0 else {
+                return []
+            }
+
+            var results: [RPData] = []
+
+            // First RP is in the initial response
+            if let rpData = response.rpData {
+                results.append(rpData)
+            }
+
+            // Get remaining RPs
+            for _ in 1..<totalRPs {
+                let nextResponse: EnumerateRPsResponse = try await executeNoAuth(subcommand: .enumerateRPsGetNextRP)
+                if let rpData = nextResponse.rpData {
+                    results.append(rpData)
+                }
+            }
+
+            return results
+        }
+
+        /// Enumerates all credentials for a specific relying party.
+        ///
+        /// - Parameter rpIdHash: SHA-256 hash of the RP ID.
+        /// - Returns: Array of credential data, or empty array if no credentials exist.
+        /// - SeeAlso: [Enumerating Credentials](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#enumeratingCredentials)
+        public func enumerateCredentials(rpIdHash: Data) async throws(CTAP2.SessionError) -> [CredentialData] {
+            let params: [UInt8: CBOR.Value] = [
+                Parameter.rpIdHash.rawValue: rpIdHash.cbor()
+            ]
+
+            let response: EnumerateCredentialsResponse
+            do {
+                response = try await execute(subcommand: .enumerateCredentialsBegin, params: params)
+            } catch .ctapError(.noCredentials, _) {
+                return []
+            }
+
+            guard let totalCredentials = response.totalCredentials, totalCredentials > 0 else {
+                return []
+            }
+
+            var results: [CredentialData] = []
+
+            // First credential is in the initial response
+            if let credData = response.credentialData {
+                results.append(credData)
+            }
+
+            // Get remaining credentials
+            for _ in 1..<totalCredentials {
+                let nextResponse: EnumerateCredentialsResponse = try await executeNoAuth(
+                    subcommand: .enumerateCredentialsGetNextCredential
+                )
+                if let credData = nextResponse.credentialData {
+                    results.append(credData)
+                }
+            }
+
+            return results
+        }
+
+        /// Deletes a credential from the authenticator.
+        ///
+        /// - Parameter credentialId: The credential descriptor identifying the credential to delete.
+        /// - SeeAlso: [DeleteCredential](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#deleteCredential)
+        public func deleteCredential(
+            _ credentialId: WebAuthn.PublicKeyCredential.Descriptor
+        ) async throws(CTAP2.SessionError) {
+            let params: [UInt8: CBOR.Value] = [
+                Parameter.credentialId.rawValue: credentialId.cbor()
+            ]
+
+            try await execute(subcommand: .deleteCredential, params: params) as Void
+        }
+
+        /// Updates user information for a credential.
+        ///
+        /// This operation is only available on authenticators with full CTAP 2.1+
+        /// credential management support (not FIDO_2_1_PRE prototype).
+        ///
+        /// - Parameters:
+        ///   - credentialId: The credential descriptor identifying the credential to update.
+        ///   - user: The updated user entity information.
+        /// - Throws: `CTAP2.SessionError.featureNotSupported` if update is not supported.
+        /// - SeeAlso: [Updating user information](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#updateUserInformation)
+        public func updateUserInformation(
+            credentialId: WebAuthn.PublicKeyCredential.Descriptor,
+            user: WebAuthn.PublicKeyCredential.UserEntity
+        ) async throws(CTAP2.SessionError) {
+            guard try await Self.isUpdateSupported(by: session) else {
+                throw .featureNotSupported(source: .here())
+            }
+
+            let params: [UInt8: CBOR.Value] = [
+                Parameter.credentialId.rawValue: credentialId.cbor(),
+                Parameter.user.rawValue: user.cbor(),
+            ]
+
+            try await execute(subcommand: .updateUserInformation, params: params) as Void
+        }
+
+        // MARK: - Internal
+
+        func execute<R: CBOR.Decodable & Sendable>(
+            subcommand: Subcommand,
+            params: [UInt8: CBOR.Value]? = nil
+        ) async throws(CTAP2.SessionError) -> R {
+            let message = authMessage(subcommand: subcommand, params: params)
+            let pinUVAuthParam = pinToken.authenticate(message: message)
+
+            let parameters = RequestParameters(
+                subCommand: subcommand,
+                subCommandParams: params,
+                pinUVAuthProtocol: pinToken.protocolVersion,
+                pinUVAuthParam: pinUVAuthParam
+            )
+
+            let command = try await commandCode()
+            return try await session.interface.send(
+                command: command,
+                payload: parameters
+            ).value
+        }
+
+        func execute(
+            subcommand: Subcommand,
+            params: [UInt8: CBOR.Value]? = nil
+        ) async throws(CTAP2.SessionError) {
+            let message = authMessage(subcommand: subcommand, params: params)
+            let pinUVAuthParam = pinToken.authenticate(message: message)
+
+            let parameters = RequestParameters(
+                subCommand: subcommand,
+                subCommandParams: params,
+                pinUVAuthProtocol: pinToken.protocolVersion,
+                pinUVAuthParam: pinUVAuthParam
+            )
+
+            let command = try await commandCode()
+            try await session.interface.send(
+                command: command,
+                payload: parameters
+            ).value
+        }
+
+        func executeNoAuth<R: CBOR.Decodable & Sendable>(
+            subcommand: Subcommand
+        ) async throws(CTAP2.SessionError) -> R {
+            let parameters = RequestParametersNoAuth(subCommand: subcommand)
+
+            let command = try await commandCode()
+            return try await session.interface.send(
+                command: command,
+                payload: parameters
+            ).value
+        }
+
+        private func commandCode() async throws(CTAP2.SessionError) -> CTAP2.Command {
+            let info = try await session.getInfo()
+            if info.options.credentialManagement == true {
+                return .credentialManagement
+            }
+            return .credentialManagementPreview
+        }
+
+        // Format: subCommand || CBOR(params)
+        private func authMessage(subcommand: Subcommand, params: [UInt8: CBOR.Value]?) -> Data {
+            var message = Data([subcommand.rawValue])
+            if let params {
+                let cborParams = params.cbor()
+                message.append(cborParams.encode())
+            }
+            return message
+        }
+    }
+}
+
+// MARK: - Internal Types
+
+extension CTAP2.CredentialManagement {
+    enum Subcommand: UInt8, Sendable {
+        case getCredsMetadata = 0x01
+        case enumerateRPsBegin = 0x02
+        case enumerateRPsGetNextRP = 0x03
+        case enumerateCredentialsBegin = 0x04
+        case enumerateCredentialsGetNextCredential = 0x05
+        case deleteCredential = 0x06
+        case updateUserInformation = 0x07
+    }
+
+    fileprivate enum Parameter: UInt8, Sendable {
+        case rpIdHash = 0x01
+        case credentialId = 0x02
+        case user = 0x03
+    }
+
+    fileprivate struct RequestParameters: Sendable, CBOR.Encodable {
+        let subCommand: Subcommand
+        let subCommandParams: [UInt8: CBOR.Value]?
+        let pinUVAuthProtocol: CTAP2.ClientPin.ProtocolVersion
+        let pinUVAuthParam: Data
+
+        func cbor() -> CBOR.Value {
+            var map: [CBOR.Value: CBOR.Value] = [:]
+            map[.int(0x01)] = .int(Int(subCommand.rawValue))
+            if let params = subCommandParams, !params.isEmpty {
+                var paramsMap: [CBOR.Value: CBOR.Value] = [:]
+                for (key, value) in params {
+                    paramsMap[.int(Int(key))] = value
+                }
+                map[.int(0x02)] = .map(paramsMap)
+            }
+            map[.int(0x03)] = pinUVAuthProtocol.cbor()
+            map[.int(0x04)] = pinUVAuthParam.cbor()
+            return .map(map)
+        }
+    }
+
+    fileprivate struct RequestParametersNoAuth: Sendable, CBOR.Encodable {
+        let subCommand: Subcommand
+
+        func cbor() -> CBOR.Value {
+            let map: [CBOR.Value: CBOR.Value] = [.int(0x01): .int(Int(subCommand.rawValue))]
+            return .map(map)
+        }
+    }
+}

--- a/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement.swift
@@ -26,7 +26,7 @@ extension CTAP2.Session {
     /// )
     /// let credMgmt = try await session.credentialManagement(pinToken: pinToken)
     /// let metadata = try await credMgmt.getMetadata()
-    /// let rps = try await credMgmt.enumerateRPs()
+    /// let rps = try await credMgmt.rps.enumerate()
     /// ```
     ///
     /// - Parameter pinToken: PIN/UV auth token with `credentialManagement` permission.
@@ -108,68 +108,6 @@ extension CTAP2 {
         /// - SeeAlso: [Getting Credentials Metadata](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#getCredsMetadata)
         public func getMetadata() async throws(CTAP2.SessionError) -> Metadata {
             try await execute(subcommand: .getCredsMetadata)
-        }
-
-        /// Enumerates all relying parties with stored credentials.
-        ///
-        /// Returns a list of all RPs that have discoverable credentials stored
-        /// on the authenticator.
-        ///
-        /// - Returns: Array of RP data, or empty array if no credentials exist.
-        /// - SeeAlso: [Enumerating RPs](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#enumeratingRPs)
-        public func enumerateRPs() async throws(CTAP2.SessionError) -> [RPData] {
-            let response: EnumerateRPsResponse
-            do {
-                response = try await execute(subcommand: .enumerateRPsBegin)
-            } catch .ctapError(.noCredentials, _) {
-                return []
-            }
-
-            guard let totalRPs = response.totalRPs, totalRPs > 0 else {
-                return []
-            }
-
-            var results = [response.rpData].compactMap { $0 }
-            for _ in 1..<totalRPs {
-                let next: EnumerateRPsResponse = try await executeNoAuth(subcommand: .enumerateRPsGetNextRP)
-                if let rpData = next.rpData {
-                    results.append(rpData)
-                }
-            }
-            return results
-        }
-
-        /// Enumerates all credentials for a specific relying party.
-        ///
-        /// - Parameter rpIdHash: SHA-256 hash of the RP ID.
-        /// - Returns: Array of credential data, or empty array if no credentials exist.
-        /// - SeeAlso: [Enumerating Credentials](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#enumeratingCredentials)
-        public func enumerateCredentials(rpIdHash: Data) async throws(CTAP2.SessionError) -> [CredentialData] {
-            let params: [UInt8: CBOR.Value] = [
-                Parameter.rpIdHash.rawValue: rpIdHash.cbor()
-            ]
-
-            let response: EnumerateCredentialsResponse
-            do {
-                response = try await execute(subcommand: .enumerateCredentialsBegin, params: params)
-            } catch .ctapError(.noCredentials, _) {
-                return []
-            }
-
-            guard let totalCredentials = response.totalCredentials, totalCredentials > 0 else {
-                return []
-            }
-
-            var results = [response.credentialData].compactMap { $0 }
-            for _ in 1..<totalCredentials {
-                let next: EnumerateCredentialsResponse = try await executeNoAuth(
-                    subcommand: .enumerateCredentialsGetNextCredential
-                )
-                if let credData = next.credentialData {
-                    results.append(credData)
-                }
-            }
-            return results
         }
 
         /// Deletes a credential from the authenticator.

--- a/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement.swift
@@ -317,7 +317,7 @@ extension CTAP2.CredentialManagement {
         case updateUserInformation = 0x07
     }
 
-    fileprivate enum Parameter: UInt8, Sendable {
+    enum Parameter: UInt8, Sendable {
         case rpIdHash = 0x01
         case credentialId = 0x02
         case user = 0x03

--- a/YubiKit/YubiKit/FIDO/CTAP/GetAssertion/GetAssertionResponse+CBOR.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/GetAssertion/GetAssertionResponse+CBOR.swift
@@ -103,3 +103,18 @@ extension WebAuthn.PublicKeyCredential.UserEntity: CBOR.Decodable {
         self.init(id: id, name: name, displayName: displayName)
     }
 }
+
+// MARK: - WebAuthn.PublicKeyCredential.RPEntity + CBOR Decoding
+
+extension WebAuthn.PublicKeyCredential.RPEntity: CBOR.Decodable {
+    init?(cbor: CBOR.Value) {
+        guard let map = cbor.mapValue,
+            let id = map["id"]?.stringValue
+        else {
+            return nil
+        }
+
+        let name = map["name"]?.stringValue
+        self.init(id: id, name: name)
+    }
+}

--- a/YubiKit/YubiKit/FIDO/CTAP/GetInfo/AuthenticatorOptions.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/GetInfo/AuthenticatorOptions.swift
@@ -140,6 +140,14 @@ extension CTAP2.GetInfo {
         /// If `true`, `makeCredUVNotRequired` must be `false`.
         public var alwaysUV: Bool? { self["alwaysUv"] }
 
+        // MARK: - CTAP 2.2 Options
+
+        /// Read-only credential management support (CTAP 2.2).
+        ///
+        /// When `true`, the authenticator supports read-only credential management
+        /// operations using a persistent PIN/UV auth token with `persistentCredentialManagement` permission.
+        public var perCredMgmtRO: Bool? { self["perCredMgmtRO"] }
+
         // MARK: - Preview/Prototype Options
 
         /// Prototype biometric enrollment support (FIDO_2_1_PRE).


### PR DESCRIPTION
## Pull request overview

This PR implements CTAP2 Credential Management functionality for managing discoverable (resident) credentials stored on FIDO2 authenticators. The implementation provides both standard collection-based and streaming AsyncSequence-based APIs for efficient credential enumeration.

**Changes:**
- Added credential management operations (enumerate, delete, update) with support for both CTAP 2.1 and prototype versions
- Implemented AsyncSequence-based lazy iteration for memory-efficient credential enumeration
- Added comprehensive test coverage including persistent token (PPUAT) support