### PR TITLE
CTAP2 Improve `getInfo` caching in the CTAP2 session

### DIFF
--- a/FullStackTests/Tests/CTAP2/ConfigTests.swift
+++ b/FullStackTests/Tests/CTAP2/ConfigTests.swift
@@ -49,7 +49,7 @@ struct ConfigFullStackTests {
                 return
             }
 
-            guard info.options.alwaysUV != nil else {
+            guard info.options.supportsAlwaysUV else {
                 print("alwaysUV option not supported - skipping")
                 return
             }
@@ -90,7 +90,7 @@ struct ConfigFullStackTests {
                 return
             }
 
-            guard info.options.enterpriseAttestation != nil else {
+            guard info.options.supportsEnterpriseAttestation else {
                 print("Enterprise attestation not supported - skipping")
                 return
             }

--- a/FullStackTests/Tests/CTAP2/CredentialTests.swift
+++ b/FullStackTests/Tests/CTAP2/CredentialTests.swift
@@ -211,7 +211,7 @@ struct CTAP2FullStackTests {
             let info = try await session.getInfo()
 
             // Skip if device doesn't support clientPin
-            guard info.options.clientPin != nil else {
+            guard info.options.supportsClientPin else {
                 print("Device doesn't support clientPin - skipping")
                 return
             }

--- a/YubiKit/YubiKit/FIDO/CTAP/Config/Config.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/Config/Config.swift
@@ -34,7 +34,7 @@ extension CTAP2.Session {
     /// - Throws: `CTAP2.SessionError.featureNotSupported` if authenticatorConfig is not supported.
     /// - SeeAlso: [CTAP2 authenticatorConfig](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorConfig)
     public func config(pinToken: CTAP2.ClientPin.Token) async throws(CTAP2.SessionError) -> CTAP2.Config {
-        guard try await cachedInfo.options.authenticatorConfig == true else {
+        guard try await cachedInfo.options.authenticatorConfig else {
             throw .featureNotSupported(source: .here())
         }
         return CTAP2.Config(session: self, pinToken: pinToken)
@@ -62,7 +62,7 @@ extension CTAP2 {
         /// - Returns: `true` if the authenticator supports authenticatorConfig.
         public static func isSupported(by session: CTAP2.Session) async throws(CTAP2.SessionError) -> Bool {
             let info = try await session.cachedInfo
-            return info.options.authenticatorConfig == true
+            return info.options.authenticatorConfig
         }
 
         /// Enables enterprise attestation. If already enabled, this command is ignored.

--- a/YubiKit/YubiKit/FIDO/CTAP/Config/Config.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/Config/Config.swift
@@ -34,8 +34,7 @@ extension CTAP2.Session {
     /// - Throws: `CTAP2.SessionError.featureNotSupported` if authenticatorConfig is not supported.
     /// - SeeAlso: [CTAP2 authenticatorConfig](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorConfig)
     public func config(pinToken: CTAP2.ClientPin.Token) async throws(CTAP2.SessionError) -> CTAP2.Config {
-        let info = try await getInfo()
-        guard info.options.authenticatorConfig == true else {
+        guard try await cachedInfo.options.authenticatorConfig == true else {
             throw .featureNotSupported(source: .here())
         }
         return CTAP2.Config(session: self, pinToken: pinToken)
@@ -62,7 +61,7 @@ extension CTAP2 {
         /// - Parameter session: The CTAP2 session to check.
         /// - Returns: `true` if the authenticator supports authenticatorConfig.
         public static func isSupported(by session: CTAP2.Session) async throws(CTAP2.SessionError) -> Bool {
-            let info = try await session.getInfo()
+            let info = try await session.cachedInfo
             return info.options.authenticatorConfig == true
         }
 

--- a/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement.swift
@@ -69,8 +69,8 @@ extension CTAP2 {
         public static func isSupported(by session: CTAP2.Session) async throws(CTAP2.SessionError) -> Bool {
             let info = try await session.cachedInfo
             // Check for CTAP 2.1+ credMgmt or FIDO_2_1_PRE credentialMgmtPreview
-            return info.options.credentialManagement == true
-                || (info.versions.contains(.fido2_1Pre) && info.options.credentialMgmtPreview == true)
+            return info.options.credentialManagement
+                || (info.versions.contains(.fido2_1Pre) && info.options.credentialMgmtPreview)
         }
 
         /// Checks if the authenticator supports updating user information.
@@ -82,7 +82,7 @@ extension CTAP2 {
         /// - Returns: `true` if the authenticator supports updating user information.
         public static func isUpdateSupported(by session: CTAP2.Session) async throws(CTAP2.SessionError) -> Bool {
             let info = try await session.cachedInfo
-            return info.options.credentialManagement == true
+            return info.options.credentialManagement
         }
 
         /// Checks if the authenticator supports read-only credential management with a persistent token.
@@ -94,7 +94,7 @@ extension CTAP2 {
         /// - Returns: `true` if the authenticator supports read-only credential management.
         public static func isReadOnlySupported(by session: CTAP2.Session) async throws(CTAP2.SessionError) -> Bool {
             let info = try await session.cachedInfo
-            return info.options.perCredMgmtRO == true
+            return info.options.perCredMgmtRO
         }
 
         // MARK: - Operations
@@ -261,7 +261,7 @@ extension CTAP2 {
 
         private func commandCode() async throws(CTAP2.SessionError) -> CTAP2.Command {
             let info = try await session.cachedInfo
-            return info.options.credentialManagement == true
+            return info.options.credentialManagement
                 ? .credentialManagement
                 : .credentialManagementPreview
         }

--- a/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement.swift
@@ -67,7 +67,7 @@ extension CTAP2 {
         /// - Parameter session: The CTAP2 session to check.
         /// - Returns: `true` if the authenticator supports credential management.
         public static func isSupported(by session: CTAP2.Session) async throws(CTAP2.SessionError) -> Bool {
-            let info = try await session.getInfo()
+            let info = try await session.cachedInfo
             // Check for CTAP 2.1+ credMgmt or FIDO_2_1_PRE credentialMgmtPreview
             return info.options.credentialManagement == true
                 || (info.versions.contains(.fido2_1Pre) && info.options.credentialMgmtPreview == true)
@@ -81,7 +81,7 @@ extension CTAP2 {
         /// - Parameter session: The CTAP2 session to check.
         /// - Returns: `true` if the authenticator supports updating user information.
         public static func isUpdateSupported(by session: CTAP2.Session) async throws(CTAP2.SessionError) -> Bool {
-            let info = try await session.getInfo()
+            let info = try await session.cachedInfo
             return info.options.credentialManagement == true
         }
 
@@ -93,7 +93,7 @@ extension CTAP2 {
         /// - Parameter session: The CTAP2 session to check.
         /// - Returns: `true` if the authenticator supports read-only credential management.
         public static func isReadOnlySupported(by session: CTAP2.Session) async throws(CTAP2.SessionError) -> Bool {
-            let info = try await session.getInfo()
+            let info = try await session.cachedInfo
             return info.options.perCredMgmtRO == true
         }
 
@@ -260,7 +260,7 @@ extension CTAP2 {
         }
 
         private func commandCode() async throws(CTAP2.SessionError) -> CTAP2.Command {
-            let info = try await session.getInfo()
+            let info = try await session.cachedInfo
             return info.options.credentialManagement == true
                 ? .credentialManagement
                 : .credentialManagementPreview

--- a/YubiKit/YubiKit/FIDO/CTAP/Extensions/CredBlob.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/Extensions/CredBlob.swift
@@ -37,7 +37,7 @@ extension CTAP2.Extension {
         /// - Parameter session: The CTAP2 session to check for support.
         /// - Throws: `CTAP2.SessionError.extensionNotSupported` if credBlob is not supported.
         public init(session: CTAP2.Session) async throws(CTAP2.SessionError) {
-            let info = try await session.getInfo()
+            let info = try await session.cachedInfo
             guard info.extensions.contains(Self.identifier) else {
                 throw .extensionNotSupported(Self.identifier, source: .here())
             }
@@ -49,7 +49,7 @@ extension CTAP2.Extension {
         /// - Parameter session: The CTAP2 session to check.
         /// - Returns: `true` if the authenticator supports credBlob.
         public static func isSupported(by session: CTAP2.Session) async throws(CTAP2.SessionError) -> Bool {
-            let info = try await session.getInfo()
+            let info = try await session.cachedInfo
             return info.extensions.contains(identifier)
         }
 

--- a/YubiKit/YubiKit/FIDO/CTAP/Extensions/CredProtect.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/Extensions/CredProtect.swift
@@ -91,7 +91,7 @@ extension CTAP2.Extension {
         public static func isSupported(
             by session: CTAP2.Session
         ) async throws(CTAP2.SessionError) -> Bool {
-            let info = try await session.getInfo()
+            let info = try await session.cachedInfo
             return info.extensions.contains(identifier)
         }
 

--- a/YubiKit/YubiKit/FIDO/CTAP/Extensions/HmacSecret.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/Extensions/HmacSecret.swift
@@ -106,7 +106,7 @@ extension CTAP2.Extension {
             guard try await Self.isSupported(by: session) else {
                 throw .extensionNotSupported(Self.identifier, source: .here())
             }
-            let info = try await session.getInfo()
+            let info = try await session.cachedInfo
             self.supportsMC = info.extensions.contains(Self.mcIdentifier)
             self.sharedSecret = try await SharedSecret.create(session: session)
         }
@@ -115,7 +115,7 @@ extension CTAP2.Extension {
         public static func isSupported(
             by session: CTAP2.Session
         ) async throws(CTAP2.SessionError) -> Bool {
-            let info = try await session.getInfo()
+            let info = try await session.cachedInfo
             return info.extensions.contains(identifier)
         }
 

--- a/YubiKit/YubiKit/FIDO/CTAP/Extensions/LargeBlobKey.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/Extensions/LargeBlobKey.swift
@@ -48,7 +48,7 @@ extension CTAP2.Extension {
         /// - Returns: `true` if the authenticator supports largeBlobKey.
         public static func isSupported(by session: CTAP2.Session) async throws(CTAP2.SessionError) -> Bool {
             let info = try await session.cachedInfo
-            return info.extensions.contains(identifier) && info.options.largeBlobs == true
+            return info.extensions.contains(identifier) && info.options.largeBlobs
         }
 
         // MARK: - Operations

--- a/YubiKit/YubiKit/FIDO/CTAP/Extensions/LargeBlobKey.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/Extensions/LargeBlobKey.swift
@@ -47,7 +47,7 @@ extension CTAP2.Extension {
         /// - Parameter session: The CTAP2 session to check.
         /// - Returns: `true` if the authenticator supports largeBlobKey.
         public static func isSupported(by session: CTAP2.Session) async throws(CTAP2.SessionError) -> Bool {
-            let info = try await session.getInfo()
+            let info = try await session.cachedInfo
             return info.extensions.contains(identifier) && info.options.largeBlobs == true
         }
 

--- a/YubiKit/YubiKit/FIDO/CTAP/Extensions/MinPinLength.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/Extensions/MinPinLength.swift
@@ -45,7 +45,7 @@ extension CTAP2.Extension {
         /// - Parameter session: The CTAP2 session to check.
         /// - Returns: `true` if the authenticator supports minPinLength.
         public static func isSupported(by session: CTAP2.Session) async throws(CTAP2.SessionError) -> Bool {
-            let info = try await session.getInfo()
+            let info = try await session.cachedInfo
             return info.options.setMinPINLength != nil
         }
 

--- a/YubiKit/YubiKit/FIDO/CTAP/Extensions/MinPinLength.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/Extensions/MinPinLength.swift
@@ -46,7 +46,7 @@ extension CTAP2.Extension {
         /// - Returns: `true` if the authenticator supports minPinLength.
         public static func isSupported(by session: CTAP2.Session) async throws(CTAP2.SessionError) -> Bool {
             let info = try await session.cachedInfo
-            return info.options.setMinPINLength != nil
+            return info.options.setMinPINLength
         }
 
         // MARK: - Operations

--- a/YubiKit/YubiKit/FIDO/CTAP/Extensions/ThirdPartyPayment.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/Extensions/ThirdPartyPayment.swift
@@ -52,7 +52,7 @@ extension CTAP2.Extension {
         public static func isSupported(
             by session: CTAP2.Session
         ) async throws(CTAP2.SessionError) -> Bool {
-            let info = try await session.getInfo()
+            let info = try await session.cachedInfo
             return info.extensions.contains(identifier)
         }
 

--- a/YubiKit/YubiKit/FIDO/CTAP/GetInfo/AuthenticatorOptions.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/GetInfo/AuthenticatorOptions.swift
@@ -15,147 +15,112 @@
 import Foundation
 
 extension CTAP2.GetInfo {
-    /// Authenticator options returned by the `authenticatorGetInfo` command.
+    /// Authenticator options indicating capabilities and current configuration.
     ///
-    /// Options indicate the authenticator's capabilities and current configuration.
-    /// Some options are tri-state: `true` (enabled), `false` (supported but not configured),
-    /// or `nil` (not supported).
+    /// Options are either **tri-state** (nil/false/true) or **binary** (false/true):
+    /// - **Tri-state**: nil = not supported, false = supported but disabled, true = enabled
+    /// - **Binary**: false = not supported, true = supported
     ///
-    /// Use the typed properties for known options, or the subscript for custom/unknown options:
-    /// ```swift
-    /// let pinSet = options.clientPin      // Typed access
-    /// let custom = options["customOption"] // String subscript
-    /// ```
+    /// Use `supports*` properties to check tri-state feature support (immutable).
+    /// Access properties directly to read current state (may be mutable).
     public struct Options: Sendable, Equatable {
 
         private let values: [String: Bool]
 
         /// Access any option by its CTAP string key.
-        ///
-        /// Returns `nil` if the option is not present in the authenticator's response.
         public subscript(key: String) -> Bool? {
             values[key]
         }
 
-        // MARK: - CTAP 2.0 Options
+        // MARK: - Immutable Options
 
-        /// Indicates the device is attached to the client and cannot be removed.
-        ///
-        /// If `true`, the authenticator is a platform authenticator (built into the client device).
-        /// If `false` or absent, it's a roaming authenticator.
-        public var platformDevice: Bool { self["plat"] ?? false }
+        /// Platform authenticator (true) vs roaming authenticator (false).
+        public let platformDevice: Bool
 
-        /// Indicates the device supports resident keys (discoverable credentials).
-        ///
-        /// If `true`, the authenticator can store credentials on-device.
-        public var residentKey: Bool { self["rk"] ?? false }
+        /// Supports resident keys (discoverable credentials).
+        public let residentKey: Bool
 
-        /// Indicates the device is capable of testing user presence.
-        ///
-        /// Defaults to `true` if absent.
-        public var userPresence: Bool { self["up"] ?? true }
+        /// Capable of testing user presence.
+        public let userPresence: Bool
 
-        /// Client PIN support status.
-        ///
-        /// - `true`: PIN is supported and has been set
-        /// - `false`: PIN is supported but not yet set
-        /// - `nil`: PIN is not supported
-        public var clientPin: Bool? { self["clientPin"] }
+        // MARK: - Tri-State Options
 
-        /// Built-in user verification support status.
-        ///
-        /// - `true`: UV is supported and configured (e.g., biometric enrolled)
-        /// - `false`: UV is supported but not yet configured
-        /// - `nil`: UV is not supported (device can only do Client PIN)
-        public var userVerification: Bool? { self["uv"] }
+        /// Client PIN status: true = set, false = supported but not set, nil = not supported.
+        public let clientPin: Bool?
 
-        // MARK: - CTAP 2.1 Options
+        /// Built-in user verification status: true = configured, false = supported but not configured, nil = not supported.
+        public let userVerification: Bool?
 
-        /// Indicates support for `getPinUVAuthTokenUsingPinWithPermissions` and
-        /// `getPinUVAuthTokenUsingUVWithPermissions` subcommands.
-        ///
-        /// When `true`:
-        /// - If `clientPin` is `true`, supports `getPinUVAuthTokenUsingPinWithPermissions`
-        /// - If `userVerification` is `true`, supports `getPinUVAuthTokenUsingUVWithPermissions`
-        ///
-        /// When `false` or absent, only legacy `getPinToken` is supported.
+        /// Enterprise attestation status: true = enabled, false = disabled, nil = not supported.
+        public let enterpriseAttestation: Bool?
+
+        /// Biometric enrollment status: true = enrolled, false = supported but not enrolled, nil = not supported.
+        public let bioEnroll: Bool?
+
+        /// Always require UV: true = enabled, false = disabled, nil = not supported.
+        public let alwaysUV: Bool?
+
+        /// Prototype bio enrollment status (FIDO_2_1_PRE): true = enrolled, false = supported but not enrolled, nil = not supported.
+        public let userVerificationMgmtPreview: Bool?
+
+        // MARK: - Binary Options
+
+        /// Supports PIN/UV auth token with permissions (CTAP 2.1+). When false or absent, only legacy getPinToken is available.
         public var pinUVAuthToken: Bool? { self["pinUvAuthToken"] }
 
-        /// Indicates that tokens obtained via PIN cannot be used for MakeCredential/GetAssertion.
-        ///
-        /// When `true`, platforms should not attempt `getPinUVAuthTokenUsingPinWithPermissions`
-        /// if `getPinUVAuthTokenUsingUVWithPermissions` fails.
+        /// PIN tokens cannot be used for MakeCredential/GetAssertion.
         public var noMcGaPermissionsWithClientPin: Bool? { self["noMcGaPermissionsWithClientPin"] }
 
-        /// Indicates support for the `authenticatorLargeBlobs` command.
+        /// Supports `authenticatorLargeBlobs` command.
         public var largeBlobs: Bool? { self["largeBlobs"] }
 
-        /// Enterprise Attestation support status.
-        ///
-        /// - `true`: Supported and enabled
-        /// - `false`: Supported but disabled
-        /// - `nil`: Not supported
-        public var enterpriseAttestation: Bool? { self["ep"] }
-
-        /// Biometric enrollment support status.
-        ///
-        /// - `true`: Supported with at least one enrollment provisioned
-        /// - `false`: Supported but no enrollments yet
-        /// - `nil`: Not supported
-        public var bioEnroll: Bool? { self["bioEnroll"] }
-
-        /// Indicates support for requesting `be` permission via UV.
-        ///
-        /// Only present if `bioEnroll` is also present.
+        /// Supports requesting `be` (bioEnroll) permission via UV.
         public var uvBioEnroll: Bool? { self["uvBioEnroll"] }
 
-        /// Indicates support for the `authenticatorConfig` command.
+        /// Supports `authenticatorConfig` command.
         public var authenticatorConfig: Bool? { self["authnrCfg"] }
 
-        /// Indicates support for requesting `acfg` permission via UV.
-        ///
-        /// Only present if `authenticatorConfig` is also present.
+        /// Supports requesting `acfg` (authenticatorConfig) permission via UV.
         public var uvAuthenticatorConfig: Bool? { self["uvAcfg"] }
 
-        /// Indicates support for the `authenticatorCredentialManagement` command.
+        /// Supports `authenticatorCredentialManagement` command.
         public var credentialManagement: Bool? { self["credMgmt"] }
 
-        /// Indicates support for the `setMinPINLength` subcommand.
-        ///
-        /// Only present if `clientPin` is also present.
+        /// Supports `setMinPINLength` subcommand.
         public var setMinPINLength: Bool? { self["setMinPINLength"] }
 
-        /// Indicates non-discoverable credentials can be created without user verification.
-        ///
-        /// When `true`, the authenticator allows creating non-discoverable credentials
-        /// without requiring any form of user verification if the platform requests it.
+        /// Allows creating non-discoverable credentials without UV if requested by platform.
         public var makeCredUVNotRequired: Bool? { self["makeCredUvNotRqd"] }
 
-        /// Always Require User Verification feature status.
-        ///
-        /// - `true`: Supported and enabled
-        /// - `false`: Supported but disabled
-        /// - `nil`: Not supported
-        ///
-        /// If `true`, `makeCredUVNotRequired` must be `false`.
-        public var alwaysUV: Bool? { self["alwaysUv"] }
-
-        // MARK: - CTAP 2.2 Options
-
-        /// Read-only credential management support (CTAP 2.2).
-        ///
-        /// When `true`, the authenticator supports read-only credential management
-        /// operations using a persistent PIN/UV auth token with `persistentCredentialManagement` permission.
+        /// Supports read-only credential management with persistent token (CTAP 2.2).
         public var perCredMgmtRO: Bool? { self["perCredMgmtRO"] }
 
-        // MARK: - Preview/Prototype Options
-
-        /// Prototype biometric enrollment support (FIDO_2_1_PRE).
-        public var userVerificationMgmtPreview: Bool? { self["userVerificationMgmtPreview"] }
-
-        /// Prototype credential management support (FIDO_2_1_PRE).
+        /// Supports credential management preview (FIDO_2_1_PRE).
         public var credentialMgmtPreview: Bool? { self["credentialMgmtPreview"] }
     }
+}
+
+// MARK: - Tri-State Support Checking
+
+extension CTAP2.GetInfo.Options {
+    /// Protocol for checking tri-state option support.
+    public protocol SupportChecking {
+        var supportsClientPin: Bool { get }
+        var supportsUserVerification: Bool { get }
+        var supportsEnterpriseAttestation: Bool { get }
+        var supportsBioEnroll: Bool { get }
+        var supportsAlwaysUV: Bool { get }
+        var supportsUserVerificationMgmtPreview: Bool { get }
+    }
+}
+
+extension CTAP2.GetInfo.Options: CTAP2.GetInfo.Options.SupportChecking {
+    public var supportsClientPin: Bool { clientPin != nil }
+    public var supportsUserVerification: Bool { userVerification != nil }
+    public var supportsEnterpriseAttestation: Bool { enterpriseAttestation != nil }
+    public var supportsBioEnroll: Bool { bioEnroll != nil }
+    public var supportsAlwaysUV: Bool { alwaysUV != nil }
+    public var supportsUserVerificationMgmtPreview: Bool { userVerificationMgmtPreview != nil }
 }
 
 // MARK: - CBOR Decoding
@@ -164,5 +129,18 @@ extension CTAP2.GetInfo.Options: CBOR.Decodable {
     init?(cbor: CBOR.Value) {
         guard let values: [String: Bool] = cbor.cborDecoded() else { return nil }
         self.values = values
+
+        // Immutable
+        self.platformDevice = values["plat"] ?? false
+        self.residentKey = values["rk"] ?? false
+        self.userPresence = values["up"] ?? true
+
+        // Tri-state
+        self.clientPin = values["clientPin"]
+        self.userVerification = values["uv"]
+        self.enterpriseAttestation = values["ep"]
+        self.bioEnroll = values["bioEnroll"]
+        self.alwaysUV = values["alwaysUv"]
+        self.userVerificationMgmtPreview = values["userVerificationMgmtPreview"]
     }
 }

--- a/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoImmutableView.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoImmutableView.swift
@@ -16,12 +16,10 @@ import Foundation
 
 extension CTAP2.GetInfo {
 
-    /// A cached view of GetInfo fields that do not change during a ``CTAP2/Session``.
+    /// Cached view of immutable GetInfo fields (capabilities, limits, supported features).
     ///
-    /// These values describe fixed authenticator capabilities and limits.
-    /// Mutable state fields (e.g. `forcePinChange`,
-    /// `remainingDiscoverableCredentials`, `encIdentifier`) are excluded — use
-    /// ``CTAP2/Session/getInfo()`` to read current mutable state.
+    /// Mutable fields (forcePinChange, remainingDiscoverableCredentials, etc.) are excluded.
+    /// Use ``CTAP2/Session/getInfo()`` to read current mutable state.
     internal struct ImmutableView: Sendable {
 
         let versions: [AuthenticatorVersion]
@@ -49,8 +47,6 @@ extension CTAP2.GetInfo {
         let pinComplexityPolicyURL: URL?
         let maxPINLength: UInt?
         let authenticatorConfigCommands: [CTAP2.Config.Subcommand]?
-
-        // MARK: - Init
 
         init(_ response: Response) {
             self.versions = response.versions
@@ -81,41 +77,61 @@ extension CTAP2.GetInfo {
     }
 }
 
-// MARK: - Immutable Options View
+// MARK: - Immutable Options
 
 extension CTAP2.GetInfo.Options {
-    /// A view of authenticator options that do not change during a ``CTAP2/Session``.
+    /// Cached view of immutable options (always-constant values + feature support flags).
     ///
-    /// Mutable state flags (e.g. `clientPin`, `alwaysUV`, `bioEnroll`)
-    /// are excluded — use ``CTAP2/Session/getInfo()`` to read current mutable state.
-    internal struct ImmutableView: Sendable {
+    /// For current mutable option state, use ``CTAP2/Session/getInfo()``.
+    internal struct ImmutableView: Sendable, CTAP2.GetInfo.Options.SupportChecking {
 
+        // Immutable options
         let platformDevice: Bool
         let residentKey: Bool
         let userPresence: Bool
-        let pinUVAuthToken: Bool?
-        let noMcGaPermissionsWithClientPin: Bool?
-        let largeBlobs: Bool?
-        let authenticatorConfig: Bool?
-        let uvAuthenticatorConfig: Bool?
-        let credentialManagement: Bool?
-        let setMinPINLength: Bool?
-        let perCredMgmtRO: Bool?
-        let credentialMgmtPreview: Bool?
+
+        // Tri-state support flags
+        let supportsClientPin: Bool
+        let supportsUserVerification: Bool
+        let supportsEnterpriseAttestation: Bool
+        let supportsBioEnroll: Bool
+        let supportsAlwaysUV: Bool
+        let supportsUserVerificationMgmtPreview: Bool
+
+        // Binary options
+        let pinUVAuthToken: Bool
+        let noMcGaPermissionsWithClientPin: Bool
+        let largeBlobs: Bool
+        let uvBioEnroll: Bool
+        let authenticatorConfig: Bool
+        let uvAuthenticatorConfig: Bool
+        let credentialManagement: Bool
+        let setMinPINLength: Bool
+        let perCredMgmtRO: Bool
+        let credentialMgmtPreview: Bool
 
         init(_ options: CTAP2.GetInfo.Options) {
             self.platformDevice = options.platformDevice
             self.residentKey = options.residentKey
             self.userPresence = options.userPresence
-            self.pinUVAuthToken = options.pinUVAuthToken
-            self.noMcGaPermissionsWithClientPin = options.noMcGaPermissionsWithClientPin
-            self.largeBlobs = options.largeBlobs
-            self.authenticatorConfig = options.authenticatorConfig
-            self.uvAuthenticatorConfig = options.uvAuthenticatorConfig
-            self.credentialManagement = options.credentialManagement
-            self.setMinPINLength = options.setMinPINLength
-            self.perCredMgmtRO = options.perCredMgmtRO
-            self.credentialMgmtPreview = options.credentialMgmtPreview
+
+            self.supportsClientPin = options.supportsClientPin
+            self.supportsUserVerification = options.supportsUserVerification
+            self.supportsEnterpriseAttestation = options.supportsEnterpriseAttestation
+            self.supportsBioEnroll = options.supportsBioEnroll
+            self.supportsAlwaysUV = options.supportsAlwaysUV
+            self.supportsUserVerificationMgmtPreview = options.supportsUserVerificationMgmtPreview
+
+            self.pinUVAuthToken = options.pinUVAuthToken ?? false
+            self.noMcGaPermissionsWithClientPin = options.noMcGaPermissionsWithClientPin ?? false
+            self.largeBlobs = options.largeBlobs ?? false
+            self.uvBioEnroll = options.uvBioEnroll ?? false
+            self.authenticatorConfig = options.authenticatorConfig ?? false
+            self.uvAuthenticatorConfig = options.uvAuthenticatorConfig ?? false
+            self.credentialManagement = options.credentialManagement ?? false
+            self.setMinPINLength = options.setMinPINLength ?? false
+            self.perCredMgmtRO = options.perCredMgmtRO ?? false
+            self.credentialMgmtPreview = options.credentialMgmtPreview ?? false
         }
     }
 }

--- a/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoImmutableView.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoImmutableView.swift
@@ -1,0 +1,121 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+extension CTAP2.GetInfo {
+
+    /// A cached view of GetInfo fields that do not change during a ``CTAP2/Session``.
+    ///
+    /// These values describe fixed authenticator capabilities and limits.
+    /// Mutable state fields (e.g. `forcePinChange`,
+    /// `remainingDiscoverableCredentials`, `encIdentifier`) are excluded — use
+    /// ``CTAP2/Session/getInfo()`` to read current mutable state.
+    internal struct ImmutableView: Sendable {
+
+        let versions: [AuthenticatorVersion]
+        let aaguid: AAGUID
+        let extensions: [CTAP2.Extension.Identifier]
+        let options: Options.ImmutableView
+        let maxMsgSize: UInt
+        let pinUVAuthProtocols: [CTAP2.ClientPin.ProtocolVersion]
+
+        let maxCredentialCountInList: UInt?
+        let maxCredentialIdLength: UInt?
+        let transports: [WebAuthn.Transport]
+        let algorithms: [COSE.Algorithm]
+        let maxSerializedLargeBlobArray: UInt?
+        let firmwareVersion: UInt?
+        let maxCredBlobLength: UInt?
+        let maxRPIDsForSetMinPinLength: UInt?
+        let preferredPlatformUVAttempts: UInt?
+        let uvModality: UVModality?
+        let certifications: [String: UInt]
+        let vendorPrototypeConfigCommands: [UInt]?
+        let attestationFormats: [WebAuthn.AttestationFormat]
+        let longTouchForReset: Bool?
+        let transportsForReset: [WebAuthn.Transport]
+        let pinComplexityPolicyURL: URL?
+        let maxPINLength: UInt?
+        let authenticatorConfigCommands: [CTAP2.Config.Subcommand]?
+
+        // MARK: - Init
+
+        init(_ response: Response) {
+            self.versions = response.versions
+            self.aaguid = response.aaguid
+            self.extensions = response.extensions
+            self.options = Options.ImmutableView(response.options)
+            self.maxMsgSize = response.maxMsgSize
+            self.pinUVAuthProtocols = response.pinUVAuthProtocols
+            self.maxCredentialCountInList = response.maxCredentialCountInList
+            self.maxCredentialIdLength = response.maxCredentialIdLength
+            self.transports = response.transports
+            self.algorithms = response.algorithms
+            self.maxSerializedLargeBlobArray = response.maxSerializedLargeBlobArray
+            self.firmwareVersion = response.firmwareVersion
+            self.maxCredBlobLength = response.maxCredBlobLength
+            self.maxRPIDsForSetMinPinLength = response.maxRPIDsForSetMinPinLength
+            self.preferredPlatformUVAttempts = response.preferredPlatformUVAttempts
+            self.uvModality = response.uvModality
+            self.certifications = response.certifications
+            self.vendorPrototypeConfigCommands = response.vendorPrototypeConfigCommands
+            self.attestationFormats = response.attestationFormats
+            self.longTouchForReset = response.longTouchForReset
+            self.transportsForReset = response.transportsForReset
+            self.pinComplexityPolicyURL = response.pinComplexityPolicyURL
+            self.maxPINLength = response.maxPINLength
+            self.authenticatorConfigCommands = response.authenticatorConfigCommands
+        }
+    }
+}
+
+// MARK: - Immutable Options View
+
+extension CTAP2.GetInfo.Options {
+    /// A view of authenticator options that do not change during a ``CTAP2/Session``.
+    ///
+    /// Mutable state flags (e.g. `clientPin`, `alwaysUV`, `bioEnroll`)
+    /// are excluded — use ``CTAP2/Session/getInfo()`` to read current mutable state.
+    internal struct ImmutableView: Sendable {
+
+        let platformDevice: Bool
+        let residentKey: Bool
+        let userPresence: Bool
+        let pinUVAuthToken: Bool?
+        let noMcGaPermissionsWithClientPin: Bool?
+        let largeBlobs: Bool?
+        let authenticatorConfig: Bool?
+        let uvAuthenticatorConfig: Bool?
+        let credentialManagement: Bool?
+        let setMinPINLength: Bool?
+        let perCredMgmtRO: Bool?
+        let credentialMgmtPreview: Bool?
+
+        init(_ options: CTAP2.GetInfo.Options) {
+            self.platformDevice = options.platformDevice
+            self.residentKey = options.residentKey
+            self.userPresence = options.userPresence
+            self.pinUVAuthToken = options.pinUVAuthToken
+            self.noMcGaPermissionsWithClientPin = options.noMcGaPermissionsWithClientPin
+            self.largeBlobs = options.largeBlobs
+            self.authenticatorConfig = options.authenticatorConfig
+            self.uvAuthenticatorConfig = options.uvAuthenticatorConfig
+            self.credentialManagement = options.credentialManagement
+            self.setMinPINLength = options.setMinPINLength
+            self.perCredMgmtRO = options.perCredMgmtRO
+            self.credentialMgmtPreview = options.credentialMgmtPreview
+        }
+    }
+}

--- a/YubiKit/YubiKit/FIDO/CTAP/LargeBlobs/CTAPSession+LargeBlobs.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/LargeBlobs/CTAPSession+LargeBlobs.swift
@@ -29,7 +29,7 @@ extension CTAP2.Session {
     ///
     /// - Returns: `true` if the authenticator supports the `largeBlobs` option.
     public func supportsLargeBlobs() async throws(CTAP2.SessionError) -> Bool {
-        try await cachedInfo.options.largeBlobs == true
+        try await cachedInfo.options.largeBlobs
     }
 
     // MARK: - Credential Blob Operations

--- a/YubiKit/YubiKit/FIDO/CTAP/LargeBlobs/CTAPSession+LargeBlobs.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/LargeBlobs/CTAPSession+LargeBlobs.swift
@@ -29,8 +29,7 @@ extension CTAP2.Session {
     ///
     /// - Returns: `true` if the authenticator supports the `largeBlobs` option.
     public func supportsLargeBlobs() async throws(CTAP2.SessionError) -> Bool {
-        let info = try await getInfo()
-        return info.options.largeBlobs == true
+        try await cachedInfo.options.largeBlobs == true
     }
 
     // MARK: - Credential Blob Operations
@@ -113,7 +112,7 @@ extension CTAP2.Session {
 
     // Reads the entire large blob array with checksum validation.
     private func readBlobArray() async throws(CTAP2.SessionError) -> [CTAP2.LargeBlobs.Entry] {
-        let info = try await getInfo()
+        let info = try await cachedInfo
         let maxFragment = Int(info.maxMsgSize) - Self.maxFragmentLengthOverhead
 
         // Read all fragments
@@ -161,7 +160,7 @@ extension CTAP2.Session {
         _ entries: [CTAP2.LargeBlobs.Entry],
         pinToken: CTAP2.ClientPin.Token
     ) async throws(CTAP2.SessionError) {
-        let info = try await getInfo()
+        let info = try await cachedInfo
         let maxFragment = Int(info.maxMsgSize) - Self.maxFragmentLengthOverhead
 
         // Encode array and append checksum

--- a/YubiKit/YubiKit/FIDO/Interfaces/FIDOInterface/FIDOInterface.swift
+++ b/YubiKit/YubiKit/FIDO/Interfaces/FIDOInterface/FIDOInterface.swift
@@ -27,10 +27,12 @@ public final actor FIDOInterface<Error: FIDOSessionError>: HasFIDOLogger {
     // Internal (accessible to extensions)
     private(set) var capabilities: CTAP2.Capabilities = []
     private(set) var protocolVersion: UInt8 = 0
+    // NEXTMAJOR: Change type to UInt to match GetInfoResponse.maxMsgSize (CTAP spec defines this as unsigned)
     public private(set) var maxMsgSize: Int = 1024
 
     var channelId: UInt32 = CTAP2.CID_BROADCAST
 
+    // NEXTMAJOR: Change parameter type to UInt to match GetInfoResponse.maxMsgSize
     public func setMaxMsgSize(_ size: Int) {
         maxMsgSize = size
     }

--- a/YubiKit/YubiKit/FIDO/Session/CTAPSession.swift
+++ b/YubiKit/YubiKit/FIDO/Session/CTAPSession.swift
@@ -42,8 +42,9 @@ extension CTAP2 {
         public func getInfo() async throws(CTAP2.SessionError) -> CTAP2.GetInfo.Response {
             let stream: CTAP2.StatusStream<CTAP2.GetInfo.Response> = await interface.send(command: .getInfo)
             let response = try await stream.value
-            cachedInfo = response
-            await interface.setMaxMsgSize(Int(response.maxMsgSize))
+            let immutable = CTAP2.GetInfo.ImmutableView(response)
+            _cachedInfo = immutable
+            await interface.setMaxMsgSize(Int(immutable.maxMsgSize))
             return response
         }
 
@@ -84,14 +85,15 @@ extension CTAP2 {
 
         internal let interface: Interface
 
-        // Cached GetInfo.Response, populated after first getInfo() call.
-        fileprivate var cachedInfo: CTAP2.GetInfo.Response?
-
         internal init(interface: Interface) async {
             self.interface = interface
             self.version = await interface.version
         }
 
+        // MARK: - Private
+
+        // Private backing value for `cachedInfo`
+        private var _cachedInfo: CTAP2.GetInfo.ImmutableView?
     }
 }
 
@@ -119,23 +121,25 @@ extension CTAP2 {
     }
 }
 
-// MARK: - Internal helpers for ClientPin decision-making
+// MARK: - Cached immutable info
 extension CTAP2.Session {
 
-    private var getInfoResponse: CTAP2.GetInfo.Response {
+    /// Cached immutable authenticator info, lazily populated on first access.
+    var cachedInfo: CTAP2.GetInfo.ImmutableView {
         get async throws(CTAP2.SessionError) {
-            if let cachedInfo {
-                return cachedInfo
-            } else {
-                return try await getInfo()
+            if let _cachedInfo {
+                return _cachedInfo
             }
+            let response = try await getInfo()
+            // getInfo() populates _cachedInfo; fallback avoids force-unwrap.
+            return _cachedInfo ?? CTAP2.GetInfo.ImmutableView(response)
         }
     }
 
     // Prefer v2 when available
     var preferredClientPinProtocol: CTAP2.ClientPin.ProtocolVersion {
         get async throws(CTAP2.SessionError) {
-            if try await getInfoResponse.pinUVAuthProtocols.contains(.v2) {
+            if try await cachedInfo.pinUVAuthProtocols.contains(.v2) {
                 return .v2
             } else {
                 return .v1
@@ -146,7 +150,7 @@ extension CTAP2.Session {
     // Check if authenticator supports pinUVAuthToken (CTAP 2.1+)
     var supportsTokenPermissions: Bool {
         get async throws(CTAP2.SessionError) {
-            try await getInfoResponse.options.pinUVAuthToken == true
+            try await cachedInfo.options.pinUVAuthToken == true
         }
     }
 }

--- a/YubiKit/YubiKit/FIDO/Session/CTAPSession.swift
+++ b/YubiKit/YubiKit/FIDO/Session/CTAPSession.swift
@@ -131,12 +131,10 @@ extension CTAP2.Session {
                 return _cachedInfo
             }
             let response = try await getInfo()
-            // getInfo() populates _cachedInfo; fallback avoids force-unwrap.
             return _cachedInfo ?? CTAP2.GetInfo.ImmutableView(response)
         }
     }
 
-    // Prefer v2 when available
     var preferredClientPinProtocol: CTAP2.ClientPin.ProtocolVersion {
         get async throws(CTAP2.SessionError) {
             if try await cachedInfo.pinUVAuthProtocols.contains(.v2) {
@@ -147,10 +145,9 @@ extension CTAP2.Session {
         }
     }
 
-    // Check if authenticator supports pinUVAuthToken (CTAP 2.1+)
     var supportsTokenPermissions: Bool {
         get async throws(CTAP2.SessionError) {
-            try await cachedInfo.options.pinUVAuthToken == true
+            try await cachedInfo.options.pinUVAuthToken
         }
     }
 }

--- a/YubiKit/YubiKit/Session/SmartCard/SmartCardInterface.swift
+++ b/YubiKit/YubiKit/Session/SmartCard/SmartCardInterface.swift
@@ -29,8 +29,10 @@ public final actor SmartCardInterface<Error: SmartCardSessionError>: Sendable {
     internal var shouldCancelCTAP: Bool = false
 
     // Maximum message size for CTAP operations (CBORInterface)
+    // NEXTMAJOR: Change type to UInt to match GetInfoResponse.maxMsgSize (CTAP spec defines this as unsigned)
     public private(set) var maxMsgSize: Int = 1024
 
+    // NEXTMAJOR: Change parameter type to UInt to match GetInfoResponse.maxMsgSize
     public func setMaxMsgSize(_ size: Int) {
         maxMsgSize = size
     }


### PR DESCRIPTION
## Pull request overview

This PR introduces type-safe caching for `authenticatorGetInfo` by splitting the response into an ImmutableView that captures only the fields guaranteed not to change during a CTAP2 session (capabilities, limits, supported extensions/algorithms) and replacing all internal `getInfo()` calls that only checked immutable properties with the cached view, eliminating redundant round-trips to the authenticator while making it impossible to accidentally read stale mutable state from the cache.  
