### PR TITLE
CTAP2 Bio Enrolment /  UV tokens

### DIFF
--- a/FullStackTests/FullStackTests.xcodeproj/project.pbxproj
+++ b/FullStackTests/FullStackTests.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		6CMINPINLEN2F1116000000001 /* MinPinLengthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CMINPINLEN2F1116000000000 /* MinPinLengthTests.swift */; };
 		B2A73E5DE80348329B8FA710 /* EncryptedFieldsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E3FD736FBE49ECAAAFA28E /* EncryptedFieldsTests.swift */; };
 		583058DA680743A1B11C558F /* CredentialManagementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA359818D52447249DB07BD1 /* CredentialManagementTests.swift */; };
+		13BE63C7192C4B728038C6A1 /* BioEnrollmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72D7C4A8CBA8427693C73A4D /* BioEnrollmentTests.swift */; };
+		39665FDAD3234C40B63D96C652AF6BDC /* BioUVTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D791282CF7244B319C15DAB12BE8C426 /* BioUVTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -82,6 +84,8 @@
 		6CMINPINLEN2F1116000000000 /* MinPinLengthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinPinLengthTests.swift; sourceTree = "<group>"; };
 		59E3FD736FBE49ECAAAFA28E /* EncryptedFieldsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptedFieldsTests.swift; sourceTree = "<group>"; };
 		FA359818D52447249DB07BD1 /* CredentialManagementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialManagementTests.swift; sourceTree = "<group>"; };
+		72D7C4A8CBA8427693C73A4D /* BioEnrollmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BioEnrollmentTests.swift; sourceTree = "<group>"; };
+		D791282CF7244B319C15DAB12BE8C426 /* BioUVTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BioUVTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -170,6 +174,8 @@
 			isa = PBXGroup;
 			children = (
 				CD75D32D2F1114C8000624CB /* Extensions */,
+				72D7C4A8CBA8427693C73A4D /* BioEnrollmentTests.swift */,
+				D791282CF7244B319C15DAB12BE8C426 /* BioUVTests.swift */,
 				CD89AB9B1BB24FA6B5FD79D3 /* ConfigTests.swift */,
 				FA359818D52447249DB07BD1 /* CredentialManagementTests.swift */,
 				6C734BB42EE860E100972E2A /* CredentialTests.swift */,
@@ -350,6 +356,8 @@
 				6CDATAHEX2EF1234500000001 /* Data+Hex.swift in Sources */,
 				B2A73E5DE80348329B8FA710 /* EncryptedFieldsTests.swift in Sources */,
 				583058DA680743A1B11C558F /* CredentialManagementTests.swift in Sources */,
+				13BE63C7192C4B728038C6A1 /* BioEnrollmentTests.swift in Sources */,
+				39665FDAD3234C40B63D96C652AF6BDC /* BioUVTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FullStackTests/Tests/CTAP2/BioEnrollmentTests.swift
+++ b/FullStackTests/Tests/CTAP2/BioEnrollmentTests.swift
@@ -23,7 +23,7 @@ struct BioEnrollmentTests {
 
     @Test("Get fingerprint sensor info")
     func testGetSensorInfo() async throws {
-        try await withBioEnrollment { bio, _ in
+        try await withBioEnrollment { bio in
             let info = try await bio.getFingerprintSensorInfo()
             // fingerprintKind should be touch (1) or swipe (2)
             #expect([.touch, .swipe].contains(info.fingerprintKind))
@@ -38,7 +38,7 @@ struct BioEnrollmentTests {
 
     @Test("Enroll, rename, and delete fingerprint")
     func testEnrollRenameDelete() async throws {
-        try await withBioEnrollment { bio, _ in
+        try await withBioEnrollment { bio in
             // Remove all existing enrollments
             let existing = try await bio.enrollments.enumerate()
             for template in existing {
@@ -113,13 +113,10 @@ struct BioEnrollmentTests {
 // MARK: - Test Fixture
 
 private func withBioEnrollment(
-    _ body: (CTAP2.BioEnrollment, CTAP2.Session) async throws -> Void
+    _ body: (CTAP2.BioEnrollment) async throws -> Void
 ) async throws {
     try await withCTAP2Session { session in
-        guard try await CTAP2.BioEnrollment.isSupported(by: session) else {
-            print("Bio enrollment not supported - skipping")
-            return
-        }
+        try #require(await CTAP2.BioEnrollment.isSupported(by: session), "Bio enrollment not supported")
 
         let info = try await session.getInfo()
         try #require(info.options.clientPin == true, "PIN not set")
@@ -131,6 +128,6 @@ private func withBioEnrollment(
 
         let bio = try await session.bioEnrollment(pinToken: pinToken)
 
-        try await body(bio, session)
+        try await body(bio)
     }
 }

--- a/FullStackTests/Tests/CTAP2/BioEnrollmentTests.swift
+++ b/FullStackTests/Tests/CTAP2/BioEnrollmentTests.swift
@@ -1,0 +1,136 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Testing
+import YubiKit
+
+// MARK: - Bio Enrollment Tests
+
+@Suite("Bio Enrollment", .serialized)
+struct BioEnrollmentTests {
+
+    @Test("Get fingerprint sensor info")
+    func testGetSensorInfo() async throws {
+        try await withBioEnrollment { bio, _ in
+            let info = try await bio.getFingerprintSensorInfo()
+            // fingerprintKind should be touch (1) or swipe (2)
+            #expect([.touch, .swipe].contains(info.fingerprintKind))
+            // maxCaptureSamplesRequired should be > 0
+            #expect(info.maxCaptureSamplesRequired > 0)
+            // maxTemplateFriendlyName should be > 0 if present
+            if let maxName = info.maxTemplateFriendlyName {
+                #expect(maxName > 0)
+            }
+        }
+    }
+
+    @Test("Enroll, rename, and delete fingerprint")
+    func testEnrollRenameDelete() async throws {
+        try await withBioEnrollment { bio, _ in
+            // Remove all existing enrollments
+            let existing = try await bio.enrollments.enumerate()
+            for template in existing {
+                try await bio.removeEnrollment(template.templateId)
+            }
+
+            // Verify we start with no enrollments
+            #expect(try await bio.enrollments.enumerate().isEmpty)
+
+            // Enroll fingerprint
+            var templateId: Data?
+            print("👆 Press your fingerprint against the sensor now...")
+            for try await sample in bio.enroll() {
+                switch sample {
+                case .waitingForUser:
+                    print("👆 Touch the sensor...")
+                case .sample(let status, let remaining):
+                    if status == .good {
+                        print("✅ \(remaining) more scans needed")
+                    } else {
+                        print("⚠️  \(status)")
+                    }
+                case .completed(let id, _):
+                    templateId = id
+                }
+            }
+
+            #expect(templateId != nil)
+
+            // Check enrollment exists with no name
+            var enrollments = try await bio.enrollments.enumerate()
+            #expect(enrollments.count == 1)
+            #expect(enrollments[0].templateId == templateId)
+            #expect(enrollments[0].friendlyName == nil || enrollments[0].friendlyName == "")
+
+            // Set name
+            try await bio.setFriendlyName("Test 1", for: templateId!)
+            enrollments = try await bio.enrollments.enumerate()
+            #expect(enrollments.count == 1)
+            #expect(enrollments[0].friendlyName == "Test 1")
+
+            // Set name to max length
+            let sensorInfo = try await bio.getFingerprintSensorInfo()
+            if let maxLen = sensorInfo.maxTemplateFriendlyName {
+                let maxName = "Test" + String(repeating: "!", count: Int(maxLen) - 4)
+                try await bio.setFriendlyName(maxName, for: templateId!)
+                enrollments = try await bio.enrollments.enumerate()
+                #expect(enrollments.count == 1)
+                #expect(enrollments[0].friendlyName == maxName)
+
+                // Test max length + 1 error (matches Java test)
+                let tooLongName = "Test" + String(repeating: "!", count: Int(maxLen) - 3)
+                do {
+                    try await bio.setFriendlyName(tooLongName, for: templateId!)
+                    Issue.record("Should have thrown error for name exceeding max length")
+                } catch let error as CTAP2.SessionError {
+                    guard case .ctapError(.invalidLength, _) = error else {
+                        Issue.record("Expected invalidLength error, got: \(error)")
+                        return
+                    }
+                    print("✅ Correctly rejected name exceeding max length with invalidLength error")
+                }
+            }
+
+            // Delete fingerprint
+            try await bio.removeEnrollment(templateId!)
+            #expect(try await bio.enrollments.enumerate().isEmpty)
+        }
+    }
+}
+
+// MARK: - Test Fixture
+
+private func withBioEnrollment(
+    _ body: (CTAP2.BioEnrollment, CTAP2.Session) async throws -> Void
+) async throws {
+    try await withCTAP2Session { session in
+        guard try await CTAP2.BioEnrollment.isSupported(by: session) else {
+            print("Bio enrollment not supported - skipping")
+            return
+        }
+
+        let info = try await session.getInfo()
+        try #require(info.options.clientPin == true, "PIN not set")
+
+        let pinToken = try await session.getPinToken(
+            defaultTestPin,
+            permissions: [.bioEnrollment]
+        )
+
+        let bio = try await session.bioEnrollment(pinToken: pinToken)
+
+        try await body(bio, session)
+    }
+}

--- a/FullStackTests/Tests/CTAP2/BioUVTests.swift
+++ b/FullStackTests/Tests/CTAP2/BioUVTests.swift
@@ -59,13 +59,16 @@ struct BioUVTests {
     @Test("UV blocking after wrong fingerprint attempts")
     func testUVBlocking() async throws {
         try await withEnrolledFingerprint { session, templateId in
-            // Attempt to get UV token 3 times with WRONG fingerprint
-            // This should cause UV_BLOCKED error
-            print("\n⚠️  Next 3 attempts: Use a DIFFERENT fingerprint (not the enrolled one)")
+            // Attempt UV with wrong fingerprint until the authenticator blocks UV.
+            // The retry threshold is authenticator-specific (typically 3–5).
+            let maxAttempts = 10
+            print("\n⚠️  Use a DIFFERENT fingerprint (not the enrolled one) until UV is blocked")
 
-            for attempt in 1...3 {
+            var attempt = 0
+            while attempt < maxAttempts {
+                attempt += 1
                 do {
-                    print("👆 Attempt \(attempt)/3: Touch WRONG fingerprint...")
+                    print("👆 Attempt \(attempt): Touch WRONG fingerprint...")
                     _ = try await session.getUVToken(
                         permissions: [.makeCredential],
                         rpId: "example.com"
@@ -73,18 +76,18 @@ struct BioUVTests {
                     Issue.record("Wrong fingerprint should have been rejected")
                 } catch let error as CTAP2.SessionError {
                     if case .ctapError(let code, _) = error {
-                        if attempt < 3 {
-                            #expect(code == .uvInvalid, "Expected uvInvalid on attempt \(attempt), got: \(code)")
-                            print("✅ Received UV_INVALID (\(attempt)/3)")
-                        } else {
-                            #expect(code == .uvBlocked, "Expected uvBlocked on attempt 3, got: \(code)")
-                            print("✅ Received UV_BLOCKED after 3 failed attempts")
+                        if code == .uvBlocked {
+                            print("✅ UV_BLOCKED after \(attempt) failed attempts")
+                            break
                         }
+                        #expect(code == .uvInvalid, "Expected uvInvalid on attempt \(attempt), got: \(code)")
+                        print("✅ UV_INVALID (\(attempt))")
                     } else {
                         Issue.record("Expected CTAP error, got: \(error)")
                     }
                 }
             }
+            #expect(attempt <= maxAttempts, "UV was not blocked after \(maxAttempts) attempts")
 
             // Now verify that PIN still works even though UV is blocked
             print("\n👆 Touch sensor for user presence (PIN will be used, not UV)...")
@@ -111,10 +114,10 @@ struct BioUVTests {
                 pinToken: pinToken
             ).value
 
-            // PIN token with uv: nil → authenticator sets UP but not UV
+            // Per CTAP 2.2 §6.1.1: valid pinUvAuthParam sets UV flag regardless of token type
             #expect(credential.authenticatorData.flags.contains(.userPresent))
-            #expect(!credential.authenticatorData.flags.contains(.userVerified))
-            print("✅ PIN works even with UV blocked (UP set, UV not set)")
+            #expect(credential.authenticatorData.flags.contains(.userVerified))
+            print("✅ PIN works even with UV blocked (UP + UV flags set)")
         }
     }
 }
@@ -126,16 +129,10 @@ private func withEnrolledFingerprint(
     _ body: (CTAP2.Session, Data) async throws -> Void
 ) async throws {
     try await withCTAP2Session { session in
-        guard try await CTAP2.BioEnrollment.isSupported(by: session) else {
-            print("Bio enrollment not supported - skipping")
-            return
-        }
+        try #require(await CTAP2.BioEnrollment.isSupported(by: session), "Bio enrollment not supported")
 
         let info = try await session.getInfo()
-        guard info.options.clientPin == true else {
-            print("PIN not set - skipping")
-            return
-        }
+        try #require(info.options.clientPin == true, "PIN not set")
 
         // Get PIN token for bio enrollment management
         let pinToken = try await session.getPinToken(
@@ -168,10 +165,7 @@ private func withEnrolledFingerprint(
             }
         }
 
-        guard let enrolledTemplateId = templateId else {
-            Issue.record("Failed to enroll fingerprint")
-            return
-        }
+        let enrolledTemplateId = try #require(templateId, "Failed to enroll fingerprint")
 
         #expect(try await bio.enrollments.enumerate().count == 1)
         print("✅ Fingerprint enrolled successfully")
@@ -179,9 +173,16 @@ private func withEnrolledFingerprint(
         // Run the test body
         try await body(session, enrolledTemplateId)
 
+        // Re-obtain PIN token for cleanup (test body may have invalidated the original token)
+        let cleanupToken = try await session.getPinToken(
+            defaultTestPin,
+            permissions: [.bioEnrollment]
+        )
+        let cleanupBio = try await session.bioEnrollment(pinToken: cleanupToken)
+
         // Clean up
-        try await bio.removeEnrollment(enrolledTemplateId)
-        #expect(try await bio.enrollments.enumerate().isEmpty)
+        try await cleanupBio.removeEnrollment(enrolledTemplateId)
+        #expect(try await cleanupBio.enrollments.enumerate().isEmpty)
         print("✅ Fingerprint removed")
     }
 }

--- a/FullStackTests/Tests/CTAP2/BioUVTests.swift
+++ b/FullStackTests/Tests/CTAP2/BioUVTests.swift
@@ -1,0 +1,187 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Testing
+import YubiKit
+
+// MARK: - Bio UV Tests
+
+@Suite("Bio UV", .serialized)
+struct BioUVTests {
+
+    @Test("Create credential using UV token")
+    func testMakeCredentialWithUVToken() async throws {
+        try await withEnrolledFingerprint { session, templateId in
+            // Get UV token via fingerprint (not PIN) with makeCredential permission
+            print("👆 Touch enrolled fingerprint to get UV token...")
+            let uvToken = try await session.getUVToken(
+                permissions: [.makeCredential],
+                rpId: "example.com"
+            )
+
+            let params = CTAP2.MakeCredential.Parameters(
+                clientDataHash: Data(repeating: 0xCD, count: 32),
+                rp: WebAuthn.PublicKeyCredential.RPEntity(id: "example.com", name: "Example"),
+                user: WebAuthn.PublicKeyCredential.UserEntity(
+                    id: Data(repeating: 0x10, count: 32),
+                    name: "uv-user@example.com",
+                    displayName: "UV User"
+                ),
+                pubKeyCredParams: [.es256],
+                rk: true
+            )
+
+            print("👆 Touch enrolled fingerprint to create credential...")
+            let credential = try await session.makeCredential(
+                parameters: params,
+                uvToken: uvToken
+            ).value
+
+            // UV token should set BOTH UV and UP flags
+            #expect(credential.authenticatorData.flags.contains(.userPresent))
+            #expect(credential.authenticatorData.flags.contains(.userVerified))
+            print("✅ Credential created with UV token (UP + UV flags set)")
+        }
+    }
+
+    @Test("UV blocking after wrong fingerprint attempts")
+    func testUVBlocking() async throws {
+        try await withEnrolledFingerprint { session, templateId in
+            // Attempt to get UV token 3 times with WRONG fingerprint
+            // This should cause UV_BLOCKED error
+            print("\n⚠️  Next 3 attempts: Use a DIFFERENT fingerprint (not the enrolled one)")
+
+            for attempt in 1...3 {
+                do {
+                    print("👆 Attempt \(attempt)/3: Touch WRONG fingerprint...")
+                    _ = try await session.getUVToken(
+                        permissions: [.makeCredential],
+                        rpId: "example.com"
+                    )
+                    Issue.record("Wrong fingerprint should have been rejected")
+                } catch let error as CTAP2.SessionError {
+                    if case .ctapError(let code, _) = error {
+                        if attempt < 3 {
+                            #expect(code == .uvInvalid, "Expected uvInvalid on attempt \(attempt), got: \(code)")
+                            print("✅ Received UV_INVALID (\(attempt)/3)")
+                        } else {
+                            #expect(code == .uvBlocked, "Expected uvBlocked on attempt 3, got: \(code)")
+                            print("✅ Received UV_BLOCKED after 3 failed attempts")
+                        }
+                    } else {
+                        Issue.record("Expected CTAP error, got: \(error)")
+                    }
+                }
+            }
+
+            // Now verify that PIN still works even though UV is blocked
+            print("\n👆 Touch sensor for user presence (PIN will be used, not UV)...")
+            let pinToken = try await session.getPinToken(
+                defaultTestPin,
+                permissions: [.makeCredential],
+                rpId: "example.com"
+            )
+
+            let params = CTAP2.MakeCredential.Parameters(
+                clientDataHash: Data(repeating: 0xCD, count: 32),
+                rp: WebAuthn.PublicKeyCredential.RPEntity(id: "example.com", name: "Example"),
+                user: WebAuthn.PublicKeyCredential.UserEntity(
+                    id: Data(repeating: 0x01, count: 32),
+                    name: "pin-user@example.com",
+                    displayName: "PIN User"
+                ),
+                pubKeyCredParams: [.es256],
+                rk: true
+            )
+
+            let credential = try await session.makeCredential(
+                parameters: params,
+                pinToken: pinToken
+            ).value
+
+            // PIN token with uv: nil → authenticator sets UP but not UV
+            #expect(credential.authenticatorData.flags.contains(.userPresent))
+            #expect(!credential.authenticatorData.flags.contains(.userVerified))
+            print("✅ PIN works even with UV blocked (UP set, UV not set)")
+        }
+    }
+}
+
+// MARK: - Test Fixture
+
+/// Helper that enrolls a fingerprint and provides it to the test body
+private func withEnrolledFingerprint(
+    _ body: (CTAP2.Session, Data) async throws -> Void
+) async throws {
+    try await withCTAP2Session { session in
+        guard try await CTAP2.BioEnrollment.isSupported(by: session) else {
+            print("Bio enrollment not supported - skipping")
+            return
+        }
+
+        let info = try await session.getInfo()
+        guard info.options.clientPin == true else {
+            print("PIN not set - skipping")
+            return
+        }
+
+        // Get PIN token for bio enrollment management
+        let pinToken = try await session.getPinToken(
+            defaultTestPin,
+            permissions: [.bioEnrollment]
+        )
+        let bio = try await session.bioEnrollment(pinToken: pinToken)
+
+        // Clean up any existing enrollments
+        let existing = try await bio.enrollments.enumerate()
+        for template in existing {
+            try await bio.removeEnrollment(template.templateId)
+        }
+
+        // Enroll a fingerprint
+        var templateId: Data?
+        print("👆 Press fingerprint against the sensor to enroll...")
+        for try await sample in bio.enroll() {
+            switch sample {
+            case .waitingForUser:
+                print("👆 Touch the sensor...")
+            case .sample(let status, let remaining):
+                if status == .good {
+                    print("✅ \(remaining) more scans needed")
+                } else {
+                    print("⚠️  \(status)")
+                }
+            case .completed(let id, _):
+                templateId = id
+            }
+        }
+
+        guard let enrolledTemplateId = templateId else {
+            Issue.record("Failed to enroll fingerprint")
+            return
+        }
+
+        #expect(try await bio.enrollments.enumerate().count == 1)
+        print("✅ Fingerprint enrolled successfully")
+
+        // Run the test body
+        try await body(session, enrolledTemplateId)
+
+        // Clean up
+        try await bio.removeEnrollment(enrolledTemplateId)
+        #expect(try await bio.enrollments.enumerate().isEmpty)
+        print("✅ Fingerprint removed")
+    }
+}

--- a/FullStackTests/Tests/CTAP2/ConfigTests.swift
+++ b/FullStackTests/Tests/CTAP2/ConfigTests.swift
@@ -24,8 +24,8 @@ struct ConfigFullStackTests {
     @Test("Check authenticatorConfig support")
     func testConfigSupport() async throws {
         try await withCTAP2Session { session in
-            let pinToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let pinToken = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.authenticatorConfig]
             )
 
@@ -56,8 +56,8 @@ struct ConfigFullStackTests {
 
             let initialAlwaysUV = info.options.alwaysUV ?? false
 
-            let pinToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let pinToken = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.authenticatorConfig]
             )
 
@@ -95,8 +95,8 @@ struct ConfigFullStackTests {
                 return
             }
 
-            let pinToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let pinToken = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.authenticatorConfig]
             )
 
@@ -125,8 +125,8 @@ struct ConfigFullStackTests {
                 return
             }
 
-            let pinToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let pinToken = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.authenticatorConfig]
             )
 
@@ -166,8 +166,8 @@ struct ConfigFullStackTests {
                 return
             }
 
-            let pinToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let pinToken = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.authenticatorConfig]
             )
 

--- a/FullStackTests/Tests/CTAP2/CredentialManagementTests.swift
+++ b/FullStackTests/Tests/CTAP2/CredentialManagementTests.swift
@@ -283,7 +283,7 @@ private func createTestCredential(_ session: CTAP2.Session) async throws {
         rp: testRp,
         user: testUser,
         pubKeyCredParams: [.es256],
-        options: .init(rk: true)
+        rk: true
     )
     print("👆 Touch YubiKey: creating test credential...")
     _ = try await session.makeCredential(parameters: params, pinToken: pinToken).value

--- a/FullStackTests/Tests/CTAP2/CredentialManagementTests.swift
+++ b/FullStackTests/Tests/CTAP2/CredentialManagementTests.swift
@@ -160,7 +160,7 @@ struct CredentialManagementTests {
         // First session: setup and get PPUAT
         let testData:
             (
-                ppuat: CTAP2.ClientPin.Token,
+                ppuat: CTAP2.ClientPin.PinToken,
                 credentialId: WebAuthn.PublicKeyCredential.Descriptor,
                 rpIdHash: Data,
                 identifier: Opaque128?,
@@ -179,8 +179,8 @@ struct CredentialManagementTests {
                 let credentials = try await credMgmt.credentials(for: rps[0].rpIdHash).enumerate()
 
                 // Get PPUAT
-                let ppuat = try await session.getPinUVToken(
-                    using: .pin(defaultTestPin),
+                let ppuat = try await session.getPinToken(
+                    defaultTestPin,
                     permissions: [.persistentCredentialManagement]
                 )
 
@@ -265,16 +265,16 @@ private func isSupported(_ session: CTAP2.Session) async throws -> Bool {
 }
 
 private func getCredentialManagement(_ session: CTAP2.Session) async throws -> CTAP2.CredentialManagement {
-    let token = try await session.getPinUVToken(
-        using: .pin(defaultTestPin),
+    let token = try await session.getPinToken(
+        defaultTestPin,
         permissions: [.credentialManagement]
     )
     return try await session.credentialManagement(pinToken: token)
 }
 
 private func createTestCredential(_ session: CTAP2.Session) async throws {
-    let pinToken = try await session.getPinUVToken(
-        using: .pin(defaultTestPin),
+    let pinToken = try await session.getPinToken(
+        defaultTestPin,
         permissions: [.makeCredential],
         rpId: testRpId
     )
@@ -300,7 +300,7 @@ private func deleteAllCredentials(_ session: CTAP2.Session) async throws {
 
 private func verifyReadOnlyOperations(
     session: CTAP2.Session,
-    ppuat: CTAP2.ClientPin.Token,
+    ppuat: CTAP2.ClientPin.PinToken,
     rpIdHash: Data
 ) async throws {
     let credMgmt = try await session.credentialManagement(pinToken: ppuat)

--- a/FullStackTests/Tests/CTAP2/CredentialTests.swift
+++ b/FullStackTests/Tests/CTAP2/CredentialTests.swift
@@ -226,8 +226,8 @@ struct CTAP2FullStackTests {
             }
 
             // Reset retry counter via successful PIN auth
-            _ = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            _ = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.makeCredential],
                 rpId: "localhost",
                 protocol: pinProtocol
@@ -257,8 +257,8 @@ struct CTAP2FullStackTests {
             }
 
             // Reset retries before testing
-            _ = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            _ = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.makeCredential],
                 rpId: "localhost",
                 protocol: pinProtocol
@@ -274,8 +274,8 @@ struct CTAP2FullStackTests {
 
             // Old PIN should fail
             do {
-                _ = try await session.getPinUVToken(
-                    using: .pin(defaultTestPin),
+                _ = try await session.getPinToken(
+                    defaultTestPin,
                     permissions: [.makeCredential, .getAssertion],
                     rpId: "localhost",
                     protocol: pinProtocol
@@ -293,8 +293,8 @@ struct CTAP2FullStackTests {
             #expect(retriesAfterWrongPin.retries == 7, "Retries should decrement after wrong PIN")
 
             // New PIN should succeed and reset retries
-            _ = try await session.getPinUVToken(
-                using: .pin(otherPin),
+            _ = try await session.getPinToken(
+                otherPin,
                 permissions: [.makeCredential, .getAssertion],
                 rpId: "localhost",
                 protocol: pinProtocol
@@ -321,8 +321,7 @@ struct CTAP2FullStackTests {
             // If device doesn't support pinUvAuthToken, verify it throws featureNotSupported
             guard info.options.pinUVAuthToken == true else {
                 do {
-                    _ = try await session.getPinUVToken(
-                        using: .uv,
+                    _ = try await session.getUVToken(
                         permissions: [.makeCredential, .getAssertion],
                         rpId: "example.com",
                         protocol: pinProtocol
@@ -345,8 +344,7 @@ struct CTAP2FullStackTests {
             }
 
             print("👆 Touch the fingerprint sensor on YubiKey Bio...")
-            let token = try await session.getPinUVToken(
-                using: .uv,
+            let token: CTAP2.ClientPin.UVToken = try await session.getUVToken(
                 permissions: [.makeCredential, .getAssertion],
                 rpId: "example.com",
                 protocol: pinProtocol
@@ -412,8 +410,8 @@ struct CTAP2FullStackTests {
             }
 
             // Reset retries before testing
-            _ = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            _ = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.makeCredential, .getAssertion],
                 rpId: "localhost",
                 protocol: pinProtocol
@@ -424,8 +422,8 @@ struct CTAP2FullStackTests {
             // Make 3 wrong attempts: 8 → 7 → 6 → 5 (third attempt may soft-lock)
             for expectedRetries in [7, 6, 5] {
                 do {
-                    _ = try await session.getPinUVToken(
-                        using: .pin(wrongPin),
+                    _ = try await session.getPinToken(
+                        wrongPin,
                         permissions: [.makeCredential, .getAssertion],
                         rpId: "localhost",
                         protocol: pinProtocol
@@ -447,8 +445,8 @@ struct CTAP2FullStackTests {
             // Soft-locked - counter should freeze
             let frozenRetries = retriesResponse.retries
             do {
-                _ = try await session.getPinUVToken(
-                    using: .pin(wrongPin),
+                _ = try await session.getPinToken(
+                    wrongPin,
                     permissions: [.makeCredential, .getAssertion],
                     rpId: "localhost",
                     protocol: pinProtocol
@@ -465,8 +463,8 @@ struct CTAP2FullStackTests {
 
             // Even correct PIN is blocked
             do {
-                _ = try await session.getPinUVToken(
-                    using: .pin(defaultTestPin),
+                _ = try await session.getPinToken(
+                    defaultTestPin,
                     permissions: [.makeCredential, .getAssertion],
                     rpId: "localhost",
                     protocol: pinProtocol

--- a/FullStackTests/Tests/CTAP2/CredentialTests.swift
+++ b/FullStackTests/Tests/CTAP2/CredentialTests.swift
@@ -61,7 +61,7 @@ struct CTAP2FullStackTests {
                     displayName: "Non-RK User"
                 ),
                 pubKeyCredParams: [.es256],
-                options: .init(rk: false)
+                rk: false
             )
 
             print("👆 Touch the YubiKey to create a non-resident credential...")
@@ -83,7 +83,7 @@ struct CTAP2FullStackTests {
                     displayName: "RK User"
                 ),
                 pubKeyCredParams: [.es256],
-                options: .init(rk: true)
+                rk: true
             )
 
             print("👆 Touch the YubiKey to create a resident credential...")

--- a/FullStackTests/Tests/CTAP2/EncryptedFieldsTests.swift
+++ b/FullStackTests/Tests/CTAP2/EncryptedFieldsTests.swift
@@ -28,8 +28,8 @@ struct EncryptedFieldsTests {
             try #require(info.encIdentifier != nil, "encIdentifier not supported")
 
             // Get persistent pinUvAuthToken (PPUAT) with pcmr permission
-            let ppuat = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let ppuat = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.persistentCredentialManagement]
             )
 
@@ -53,8 +53,8 @@ struct EncryptedFieldsTests {
             try #require(info.encCredStoreState != nil, "encCredStoreState not supported")
 
             // Get persistent pinUvAuthToken (PPUAT) with pcmr permission
-            let ppuat = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let ppuat = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.persistentCredentialManagement]
             )
 
@@ -75,13 +75,13 @@ struct EncryptedFieldsTests {
     func testPersistentTokenAcrossReconnects() async throws {
         // First session: get PPUAT and decrypt fields
         typealias Opaque128 = CTAP2.GetInfo.Opaque128
-        let (ppuat, identifier1, credStoreState1): (CTAP2.ClientPin.Token, Opaque128, Opaque128?) =
+        let (ppuat, identifier1, credStoreState1): (CTAP2.ClientPin.PinToken, Opaque128, Opaque128?) =
             try await withCTAP2Session { session in
                 let info = try await session.getInfo()
                 try #require(info.encIdentifier != nil, "encIdentifier not supported")
 
-                let ppuat = try await session.getPinUVToken(
-                    using: .pin(defaultTestPin),
+                let ppuat = try await session.getPinToken(
+                    defaultTestPin,
                     permissions: [.persistentCredentialManagement]
                 )
 
@@ -129,14 +129,14 @@ struct EncryptedFieldsTests {
             try #require(info.options.clientPin == true, "PIN not set")
 
             // Get PPUAT for decrypting credStoreState
-            let ppuat = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let ppuat = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.persistentCredentialManagement]
             )
 
             // Clean up any existing credentials
-            let cmToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let cmToken = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.credentialManagement]
             )
             let credMgmt = try await session.credentialManagement(pinToken: cmToken)
@@ -153,8 +153,8 @@ struct EncryptedFieldsTests {
 
             // 2. Create discoverable credential (requires UP)
             session = try await reconnectWhenOverNFC()
-            let makeCredToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let makeCredToken = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.makeCredential],
                 rpId: "test.example.com"
             )
@@ -179,8 +179,8 @@ struct EncryptedFieldsTests {
             print("✅ credStoreState changed after credential creation: \(state2)")
 
             // 3. Delete credential via CredentialManagement (re-create after potential NFC reconnect)
-            let deleteToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let deleteToken = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.credentialManagement]
             )
             let credMgmt2 = try await session.credentialManagement(pinToken: deleteToken)

--- a/FullStackTests/Tests/CTAP2/EncryptedFieldsTests.swift
+++ b/FullStackTests/Tests/CTAP2/EncryptedFieldsTests.swift
@@ -167,7 +167,7 @@ struct EncryptedFieldsTests {
                     displayName: "Test"
                 ),
                 pubKeyCredParams: [.es256],
-                options: .init(rk: true)
+                rk: true
             )
             print("👆 Touch YubiKey: creating credential...")
             _ = try await session.makeCredential(parameters: params, pinToken: makeCredToken).value

--- a/FullStackTests/Tests/CTAP2/Extensions/CredBlobTests.swift
+++ b/FullStackTests/Tests/CTAP2/Extensions/CredBlobTests.swift
@@ -43,8 +43,8 @@ struct CredBlobFullStackTests {
 
             // 1. Create credential with credBlob extension
             session = try await reconnectWhenOverNFC()
-            let pinToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let pinToken = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.makeCredential],
                 rpId: rpId
             )
@@ -73,8 +73,8 @@ struct CredBlobFullStackTests {
 
             // 2. GetAssertion with credBlob extension to retrieve blob
             session = try await reconnectWhenOverNFC()
-            let gaToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let gaToken = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.getAssertion],
                 rpId: rpId
             )
@@ -119,8 +119,8 @@ struct CredBlobFullStackTests {
 
             // 1. Create credential with credBlob
             session = try await reconnectWhenOverNFC()
-            let pinToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let pinToken = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.makeCredential],
                 rpId: rpId
             )
@@ -146,8 +146,8 @@ struct CredBlobFullStackTests {
 
             // 2. GetAssertion WITHOUT credBlob extension
             session = try await reconnectWhenOverNFC()
-            let gaToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let gaToken = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.getAssertion],
                 rpId: rpId
             )

--- a/FullStackTests/Tests/CTAP2/Extensions/CredBlobTests.swift
+++ b/FullStackTests/Tests/CTAP2/Extensions/CredBlobTests.swift
@@ -61,7 +61,7 @@ struct CredBlobFullStackTests {
                 ),
                 pubKeyCredParams: [.es256],
                 extensions: [try credBlob.makeCredential.input(blob: testBlob)],
-                options: .init(rk: true)
+                rk: true
             )
 
             print("👆 Touch YubiKey: creating credential with credBlob...")
@@ -137,7 +137,7 @@ struct CredBlobFullStackTests {
                 ),
                 pubKeyCredParams: [.es256],
                 extensions: [try credBlob.makeCredential.input(blob: testBlob)],
-                options: .init(rk: true)
+                rk: true
             )
 
             print("👆 Touch YubiKey: creating credential with credBlob...")

--- a/FullStackTests/Tests/CTAP2/Extensions/CredProtectTests.swift
+++ b/FullStackTests/Tests/CTAP2/Extensions/CredProtectTests.swift
@@ -51,7 +51,7 @@ struct CTAP2ExtensionFullStackTests {
                     displayName: "No Extension User"
                 ),
                 pubKeyCredParams: [.es256],
-                options: .init(rk: false)
+                rk: false
             )
             let noExtResponse = try await session.makeCredential(parameters: noExtParams).value
             #expect(credProtect1.output(from: noExtResponse) == nil)
@@ -70,7 +70,7 @@ struct CTAP2ExtensionFullStackTests {
                 ),
                 pubKeyCredParams: [.es256],
                 extensions: [credProtect1.input()],
-                options: .init(rk: false)
+                rk: false
             )
             let level1Response = try await session.makeCredential(parameters: level1Params).value
             #expect(credProtect1.output(from: level1Response) == .userVerificationOptional)
@@ -93,7 +93,7 @@ struct CTAP2ExtensionFullStackTests {
                 ),
                 pubKeyCredParams: [.es256],
                 extensions: [credProtect2.input()],
-                options: .init(rk: false)
+                rk: false
             )
             let level2Response = try await session.makeCredential(parameters: level2Params).value
             #expect(credProtect2.output(from: level2Response) == .userVerificationOptionalWithCredentialIDList)
@@ -128,7 +128,7 @@ struct CTAP2ExtensionFullStackTests {
                 ),
                 pubKeyCredParams: [.es256],
                 extensions: [credProtect3.input()],
-                options: .init(rk: true)
+                rk: true
             )
             let level3Response = try await session.makeCredential(parameters: level3Params, pinToken: pinToken).value
             #expect(credProtect3.output(from: level3Response) == .userVerificationRequired)
@@ -160,7 +160,7 @@ struct CTAP2ExtensionFullStackTests {
                 ),
                 pubKeyCredParams: [.es256],
                 extensions: [hmacSecretInput],
-                options: .init(rk: false)
+                rk: false
             )
 
             print("👆 Touch the YubiKey to create credential with hmac-secret...")
@@ -219,7 +219,7 @@ struct CTAP2ExtensionFullStackTests {
                 ),
                 pubKeyCredParams: [.es256],
                 extensions: [hmacSecretInput],
-                options: .init(rk: true)
+                rk: true
             )
 
             print("👆 Touch the YubiKey to create credential with hmac-secret-mc...")

--- a/FullStackTests/Tests/CTAP2/Extensions/CredProtectTests.swift
+++ b/FullStackTests/Tests/CTAP2/Extensions/CredProtectTests.swift
@@ -107,8 +107,8 @@ struct CTAP2ExtensionFullStackTests {
                 return
             }
 
-            let pinToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let pinToken = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.makeCredential, .credentialManagement],
                 rpId: rpId
             )
@@ -203,8 +203,8 @@ struct CTAP2ExtensionFullStackTests {
             let hmacSecret = try await CTAP2.Extension.HmacSecret(session: session)
             let hmacSecretInput = try hmacSecret.makeCredential.input(salt1: salt1, salt2: salt2)
 
-            let pinToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let pinToken = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.makeCredential],
                 rpId: "hmac-secret-mc-test.com"
             )

--- a/FullStackTests/Tests/CTAP2/Extensions/LargeBlobsTests.swift
+++ b/FullStackTests/Tests/CTAP2/Extensions/LargeBlobsTests.swift
@@ -62,7 +62,7 @@ struct LargeBlobsFullStackTests {
                 ),
                 pubKeyCredParams: [.es256],
                 extensions: [largeBlobKey.makeCredential.input()],
-                options: .init(rk: true)
+                rk: true
             )
 
             print("👆 Touch YubiKey: creating credential with largeBlobKey...")
@@ -149,7 +149,7 @@ struct LargeBlobsFullStackTests {
                 ),
                 pubKeyCredParams: [.es256],
                 extensions: [largeBlobKey.makeCredential.input()],
-                options: .init(rk: true)
+                rk: true
             )
 
             print("👆 Touch YubiKey: creating credential...")
@@ -247,7 +247,7 @@ struct LargeBlobsFullStackTests {
                 ),
                 pubKeyCredParams: [.es256],
                 extensions: [largeBlobKey.makeCredential.input()],
-                options: .init(rk: true)
+                rk: true
             )
 
             print("👆 Touch YubiKey: creating first credential...")
@@ -280,7 +280,7 @@ struct LargeBlobsFullStackTests {
                 ),
                 pubKeyCredParams: [.es256],
                 extensions: [largeBlobKey.makeCredential.input()],
-                options: .init(rk: true)
+                rk: true
             )
 
             print("👆 Touch YubiKey: creating second credential...")

--- a/FullStackTests/Tests/CTAP2/Extensions/LargeBlobsTests.swift
+++ b/FullStackTests/Tests/CTAP2/Extensions/LargeBlobsTests.swift
@@ -44,8 +44,8 @@ struct LargeBlobsFullStackTests {
             // 1. Create credential with largeBlobKey extension
             // Use a single token with makeCredential + largeBlobWrite permissions.
             session = try await reconnectWhenOverNFC()
-            let pinToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let pinToken = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.makeCredential, .largeBlobWrite],
                 rpId: rpId
             )
@@ -89,8 +89,8 @@ struct LargeBlobsFullStackTests {
 
             // 4. Delete the blob
             session = try await reconnectWhenOverNFC()
-            let deleteToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let deleteToken = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.largeBlobWrite],
                 rpId: nil
             )
@@ -131,8 +131,8 @@ struct LargeBlobsFullStackTests {
             // 1. Create credential with largeBlobKey and store blob
             // Use makeCredential + largeBlobWrite token for registration flow.
             session = try await reconnectWhenOverNFC()
-            let mcToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let mcToken = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.makeCredential, .largeBlobWrite],
                 rpId: rpId
             )
@@ -169,8 +169,8 @@ struct LargeBlobsFullStackTests {
             // 3. GetAssertion with largeBlobKey extension to get the key again
             // Use getAssertion + largeBlobWrite token for authentication flow.
             session = try await reconnectWhenOverNFC()
-            let gaToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let gaToken = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.getAssertion, .largeBlobWrite],
                 rpId: rpId
             )
@@ -229,8 +229,8 @@ struct LargeBlobsFullStackTests {
 
             // Create first credential and store its blob
             session = try await reconnectWhenOverNFC()
-            let pinToken1 = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let pinToken1 = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.makeCredential, .largeBlobWrite],
                 rpId: rpId
             )
@@ -264,8 +264,8 @@ struct LargeBlobsFullStackTests {
 
             // Create second credential and store its blob
             session = try await reconnectWhenOverNFC()
-            let pinToken2 = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let pinToken2 = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.makeCredential, .largeBlobWrite],
                 rpId: rpId
             )
@@ -306,8 +306,8 @@ struct LargeBlobsFullStackTests {
 
             // Cleanup
             session = try await reconnectWhenOverNFC()
-            let cleanupToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let cleanupToken = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.largeBlobWrite],
                 rpId: nil
             )
@@ -347,8 +347,8 @@ struct LargeBlobsFullStackTests {
             let randomKey = Data((0..<32).map { _ in UInt8.random(in: 0...255) })
 
             session = try await reconnectWhenOverNFC()
-            let pinToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let pinToken = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.largeBlobWrite],
                 rpId: nil
             )

--- a/FullStackTests/Tests/CTAP2/Extensions/MinPinLengthTests.swift
+++ b/FullStackTests/Tests/CTAP2/Extensions/MinPinLengthTests.swift
@@ -43,16 +43,16 @@ struct MinPinLengthFullStackTests {
             let rpId = "minpinlength-configured-test.example.com"
 
             // Configure the RP ID to receive minPinLength
-            let configToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let configToken = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.authenticatorConfig]
             )
             let config = try await session.config(pinToken: configToken)
             try await config.setMinPINLength(rpIDs: [rpId])
 
             // Create credential with minPinLength extension
-            let makeCredToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let makeCredToken = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.makeCredential],
                 rpId: rpId
             )

--- a/FullStackTests/Tests/CTAP2/Extensions/PRFTests.swift
+++ b/FullStackTests/Tests/CTAP2/Extensions/PRFTests.swift
@@ -65,7 +65,7 @@ struct WebAuthnExtensionFullStackTests {
                 ),
                 pubKeyCredParams: [.es256],
                 extensions: [hmacSecretInput],
-                options: .init(rk: true)
+                rk: true
             )
 
             print("👆 Touch the YubiKey to create credential with PRF support...")
@@ -106,7 +106,7 @@ struct WebAuthnExtensionFullStackTests {
                 clientDataHash: clientDataHash,
                 allowList: [.init(id: credentialId)],
                 extensions: [prfInput1],
-                options: .init(up: true)
+                up: true
             )
 
             print("👆 Touch the YubiKey for PRF assertion (one secret)...")
@@ -147,7 +147,7 @@ struct WebAuthnExtensionFullStackTests {
                 clientDataHash: clientDataHash,
                 allowList: [.init(id: credentialId)],
                 extensions: [prfInput2],
-                options: .init(up: true)
+                up: true
             )
 
             print("👆 Touch the YubiKey for PRF assertion (two secrets, evalByCredential)...")
@@ -221,7 +221,7 @@ struct WebAuthnExtensionFullStackTests {
                 ),
                 pubKeyCredParams: [.es256],
                 extensions: [prfMcInput],
-                options: .init(rk: true)
+                rk: true
             )
 
             print("👆 Touch the YubiKey to create credential with PRF secrets...")
@@ -270,7 +270,7 @@ struct WebAuthnExtensionFullStackTests {
                 clientDataHash: clientDataHash,
                 allowList: [.init(id: credentialId)],
                 extensions: [prfGaInput],
-                options: .init(up: true)
+                up: true
             )
 
             print("👆 Touch the YubiKey for PRF assertion (verifying determinism)...")

--- a/FullStackTests/Tests/CTAP2/Extensions/PRFTests.swift
+++ b/FullStackTests/Tests/CTAP2/Extensions/PRFTests.swift
@@ -46,8 +46,8 @@ struct WebAuthnExtensionFullStackTests {
             // 1. Create a credential with PRF enabled (via hmac-secret) (requires UP)
             session = try await reconnectWhenOverNFC()
 
-            let pinToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let pinToken = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.makeCredential],
                 rpId: rpId
             )
@@ -95,8 +95,8 @@ struct WebAuthnExtensionFullStackTests {
             let prf = try await WebAuthn.Extension.PRF(session: session)
             let prfInput1 = try prf.getAssertion.input(first: secret1)
 
-            let pinToken2 = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let pinToken2 = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.getAssertion],
                 rpId: rpId
             )
@@ -136,8 +136,8 @@ struct WebAuthnExtensionFullStackTests {
 
             let prfInput2 = try prf2.getAssertion.input(for: credentialId)
 
-            let pinToken3 = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let pinToken3 = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.getAssertion],
                 rpId: rpId
             )
@@ -205,8 +205,8 @@ struct WebAuthnExtensionFullStackTests {
             let prf = try await WebAuthn.Extension.PRF(session: session)
             let prfMcInput = try prf.makeCredential.input(first: secret1, second: secret2)
 
-            let pinToken = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let pinToken = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.makeCredential],
                 rpId: rpId
             )
@@ -259,8 +259,8 @@ struct WebAuthnExtensionFullStackTests {
             let prfGa = try await WebAuthn.Extension.PRF(session: session)
             let prfGaInput = try prfGa.getAssertion.input(first: secret1, second: secret2)
 
-            let pinToken2 = try await session.getPinUVToken(
-                using: .pin(defaultTestPin),
+            let pinToken2 = try await session.getPinToken(
+                defaultTestPin,
                 permissions: [.getAssertion],
                 rpId: rpId
             )

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnClientLogic.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnClientLogic.swift
@@ -135,7 +135,7 @@ func extractGetExtensionResults(
     state: GetExtensionState,
     response: CTAP2.GetAssertion.Response,
     session: CTAP2.Session,
-    pinToken: CTAP2.ClientPin.Token?
+    pinToken: CTAP2.ClientPin.PinToken?
 ) async throws -> ExtensionResults {
     var results = ExtensionResults()
 

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnHandler.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnHandler.swift
@@ -66,7 +66,12 @@ actor WebAuthnHandler {
             rk: residentKeyRequired
         )
 
-        let response = try await session.makeCredential(parameters: params, pinToken: pinToken).value
+        let response =
+            if let pinToken {
+                try await session.makeCredential(parameters: params, pinToken: pinToken).value
+            } else {
+                try await session.makeCredential(parameters: params).value
+            }
         let extensionResults = try extractCreateExtensionResults(state: extState, response: response)
 
         let credentials = CredentialResponse(
@@ -107,7 +112,12 @@ actor WebAuthnHandler {
             extensions: extState.inputs
         )
 
-        let response = try await session.getAssertion(parameters: params, pinToken: pinToken).value
+        let response =
+            if let pinToken {
+                try await session.getAssertion(parameters: params, pinToken: pinToken).value
+            } else {
+                try await session.getAssertion(parameters: params).value
+            }
         let extensionResults = try await extractGetExtensionResults(
             state: extState,
             response: response,

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnHandler.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnHandler.swift
@@ -44,10 +44,6 @@ actor WebAuthnHandler {
             request.authenticatorSelection?.residentKey == "required"
             || request.authenticatorSelection?.residentKey == "preferred"
             || request.authenticatorSelection?.requireResidentKey == true
-        let options = CTAP2.MakeCredential.Parameters.Options(
-            rk: residentKeyRequired,
-            uv: request.authenticatorSelection?.userVerification == "required"
-        )
 
         let (activeSession, pinToken) = try await getPinTokenIfNeeded(
             session: session,
@@ -67,7 +63,7 @@ actor WebAuthnHandler {
             pubKeyCredParams: pubKeyParams,
             excludeList: excludeList,
             extensions: extState.inputs,
-            options: options
+            rk: residentKeyRequired
         )
 
         let response = try await session.makeCredential(parameters: params, pinToken: pinToken).value
@@ -93,10 +89,6 @@ actor WebAuthnHandler {
 
         let allowList = request.allowCredentials?.compactMap { $0.toDescriptor() }
 
-        let options = CTAP2.GetAssertion.Parameters.Options(
-            uv: request.userVerification == "required"
-        )
-
         let (activeSession, pinToken) = try await getPinTokenIfNeeded(
             session: session,
             permissions: permissionsForGetAssertion(request: request),
@@ -112,8 +104,7 @@ actor WebAuthnHandler {
             rpId: rpId,
             clientDataHash: clientDataHash,
             allowList: allowList,
-            extensions: extState.inputs,
-            options: options
+            extensions: extState.inputs
         )
 
         let response = try await session.getAssertion(parameters: params, pinToken: pinToken).value

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnHandler.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnHandler.swift
@@ -160,7 +160,7 @@ actor WebAuthnHandler {
         session: CTAP2.Session,
         permissions: CTAP2.ClientPin.Permission,
         rpId: String
-    ) async throws -> (session: CTAP2.Session, pinToken: CTAP2.ClientPin.Token?) {
+    ) async throws -> (session: CTAP2.Session, pinToken: CTAP2.ClientPin.PinToken?) {
         let info = try await session.getInfo()
         guard info.options.clientPin == true else {
             return (session, nil)
@@ -182,8 +182,8 @@ actor WebAuthnHandler {
             #endif
 
             do throws(CTAP2.SessionError) {
-                let token = try await currentSession.getPinUVToken(
-                    using: .pin(pin),
+                let token = try await currentSession.getPinToken(
+                    pin,
                     permissions: permissions,
                     rpId: rpId
                 )

--- a/YubiKit/YubiKit/FIDO/CTAP/BioEnrollment/BioEnrollment.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/BioEnrollment/BioEnrollment.swift
@@ -113,9 +113,7 @@ extension CTAP2 {
         }
 
         /// Gets the bio modality supported by the authenticator.
-        ///
-        /// - SeeAlso: [Get bio modality](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#getUserVerificationModality)
-        public static func getModality(
+        static func getModality(
             for session: CTAP2.Session
         ) async throws(CTAP2.SessionError) -> Modality {
             let command = try await commandCode(for: session)
@@ -234,7 +232,7 @@ extension CTAP2 {
                 let response: EnumerateEnrollmentsResponse =
                     try await execute(subcommand: .enumerateEnrollments)
                 return response.templateInfos
-            } catch .ctapError(.invalidOption, _), .ctapError(.noCredentials, _) {
+            } catch .ctapError(.invalidOption, _) {
                 return []
             }
         }
@@ -312,8 +310,25 @@ extension CTAP2 {
 
 extension CTAP2.BioEnrollment {
     /// Bio modality supported by the authenticator.
-    public enum Modality: UInt8, Sendable {
-        case fingerprint = 0x01
+    public enum Modality: Sendable, Equatable {
+        /// Fingerprint modality.
+        case fingerprint
+        /// Unrecognized modality.
+        case other(UInt8)
+
+        internal static func from(_ rawValue: UInt8) -> Modality {
+            switch rawValue {
+            case 0x01: return .fingerprint
+            default: return .other(rawValue)
+            }
+        }
+
+        fileprivate var rawValue: UInt8 {
+            switch self {
+            case .fingerprint: return 0x01
+            case .other(let v): return v
+            }
+        }
     }
 
     enum Subcommand: UInt8, Sendable {

--- a/YubiKit/YubiKit/FIDO/CTAP/BioEnrollment/BioEnrollment.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/BioEnrollment/BioEnrollment.swift
@@ -1,0 +1,527 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+// MARK: - Session BioEnrollment Accessor
+
+extension CTAP2.Session {
+    /// Returns bio enrollment operations bound to a PIN auth token.
+    ///
+    /// ```swift
+    /// let pinToken = try await session.getPinToken(
+    ///     "123456",
+    ///     permissions: [.bioEnrollment]
+    /// )
+    /// let bio = try await session.bioEnrollment(pinToken: pinToken)
+    /// let sensor = try await bio.getFingerprintSensorInfo()
+    /// ```
+    ///
+    /// - Parameter pinToken: PIN auth token with `bioEnrollment` permission.
+    /// - Returns: BioEnrollment operations bound to the token.
+    /// - Throws: `CTAP2.SessionError.featureNotSupported` if bio enrollment is not supported.
+    /// - SeeAlso: [CTAP2 authenticatorBioEnrollment](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorBioEnrollment)
+    public func bioEnrollment(
+        pinToken: CTAP2.ClientPin.PinToken
+    ) async throws(CTAP2.SessionError) -> CTAP2.BioEnrollment {
+        try await makeBioEnrollment(token: pinToken)
+    }
+
+    /// Returns bio enrollment operations bound to a UV auth token.
+    ///
+    /// ```swift
+    /// let uvToken = try await session.getUVToken(
+    ///     permissions: [.bioEnrollment]
+    /// )
+    /// let bio = try await session.bioEnrollment(uvToken: uvToken)
+    /// let sensor = try await bio.getFingerprintSensorInfo()
+    /// ```
+    ///
+    /// - Parameter uvToken: UV auth token with `bioEnrollment` permission.
+    /// - Returns: BioEnrollment operations bound to the token.
+    /// - Throws: `CTAP2.SessionError.featureNotSupported` if bio enrollment is not supported.
+    /// - SeeAlso: [CTAP2 authenticatorBioEnrollment](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorBioEnrollment)
+    public func bioEnrollment(
+        uvToken: CTAP2.ClientPin.UVToken
+    ) async throws(CTAP2.SessionError) -> CTAP2.BioEnrollment {
+        try await makeBioEnrollment(token: uvToken)
+    }
+
+    /// Returns bio enrollment operations bound to a PIN/UV auth token.
+    ///
+    /// - Deprecated: Use ``bioEnrollment(pinToken:)`` (PinToken) or ``bioEnrollment(uvToken:)`` instead.
+    @available(*, deprecated, message: "Use bioEnrollment(pinToken: PinToken) or bioEnrollment(uvToken:)")
+    public func bioEnrollment(
+        pinToken: CTAP2.ClientPin.Token
+    ) async throws(CTAP2.SessionError) -> CTAP2.BioEnrollment {
+        try await makeBioEnrollment(token: pinToken)
+    }
+
+    private func makeBioEnrollment(
+        token: any CTAP2.ClientPin.PinUVAuthToken
+    ) async throws(CTAP2.SessionError) -> CTAP2.BioEnrollment {
+        guard try await CTAP2.BioEnrollment.isSupported(by: self) else {
+            throw .featureNotSupported(source: .here())
+        }
+        let modality = try await CTAP2.BioEnrollment.getModality(for: self)
+        guard modality == .fingerprint else {
+            throw .featureNotSupported(source: .here())
+        }
+        let command = try await CTAP2.BioEnrollment.commandCode(for: self)
+        return CTAP2.BioEnrollment(session: self, token: token, command: command)
+    }
+}
+
+// MARK: - BioEnrollment
+
+extension CTAP2 {
+    /// Bio enrollment operations bound to a PIN/UV auth token.
+    ///
+    /// Allows managing fingerprint enrollments on biometric authenticators (e.g., YubiKey Bio).
+    ///
+    /// - SeeAlso: [CTAP2 authenticatorBioEnrollment](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorBioEnrollment)
+    public struct BioEnrollment: Sendable {
+        private let session: CTAP2.Session
+        private let token: any CTAP2.ClientPin.PinUVAuthToken
+        private let command: CTAP2.Command
+
+        fileprivate init(session: CTAP2.Session, token: any CTAP2.ClientPin.PinUVAuthToken, command: CTAP2.Command) {
+            self.session = session
+            self.token = token
+            self.command = command
+        }
+
+        // MARK: - Feature Detection
+
+        /// Checks if the authenticator supports bio enrollment.
+        public static func isSupported(by session: CTAP2.Session) async throws(CTAP2.SessionError) -> Bool {
+            let info = try await session.cachedInfo
+            return info.options.supportsBioEnroll
+                || (info.versions.contains(.fido2_1Pre)
+                    && info.options.supportsUserVerificationMgmtPreview)
+        }
+
+        /// Gets the bio modality supported by the authenticator.
+        ///
+        /// - SeeAlso: [Get bio modality](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#getUserVerificationModality)
+        public static func getModality(
+            for session: CTAP2.Session
+        ) async throws(CTAP2.SessionError) -> Modality {
+            let command = try await commandCode(for: session)
+            let response: GetModalityResponse = try await session.interface.send(
+                command: command,
+                payload: getModalityRequest
+            ).value
+            return response.modality
+        }
+
+        // MARK: - Operations
+
+        /// Gets fingerprint sensor information.
+        ///
+        /// - SeeAlso: [Get fingerprint sensor info](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#getFingerprintSensorInfo)
+        public func getFingerprintSensorInfo() async throws(CTAP2.SessionError) -> FingerprintSensorInfo {
+            try await executeNoAuth(subcommand: .getFingerprintSensorInfo)
+        }
+
+        // MARK: - Enrollment
+
+        /// Begins a new fingerprint enrollment and returns an async sequence of samples.
+        ///
+        /// Use this for a simplified enrollment loop:
+        /// ```swift
+        /// for try await sample in bio.enroll(timeout: 10000) {
+        ///     switch sample {
+        ///     case .waitingForUser:
+        ///         print("Touch the fingerprint sensor...")
+        ///     case .sample(let status, let remaining):
+        ///         print("Status: \(status), \(remaining) remaining")
+        ///     case .completed(let templateId, let status):
+        ///         print("Enrollment complete: \(templateId), status: \(status)")
+        ///     }
+        /// }
+        /// ```
+        ///
+        /// - Parameter timeout: Optional timeout in milliseconds for each fingerprint capture.
+        /// - Returns: An async sequence that yields samples until enrollment is complete.
+        /// - SeeAlso: [Enrolling Fingerprint](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#enrollingFingerprint)
+        public func enroll(timeout: UInt? = nil) -> EnrollFingerprint {
+            EnrollFingerprint(bioEnrollment: self, timeout: timeout)
+        }
+
+        fileprivate func enrollBegin(
+            timeout: UInt? = nil
+        ) async -> CTAP2.StatusStream<EnrollBeginResult> {
+            var params: [UInt8: CBOR.Value]?
+            if let timeout {
+                params = [SubcommandParam.timeoutMilliseconds.rawValue: timeout.cbor()]
+            }
+            return await executeStream(subcommand: .enrollBegin, params: params)
+        }
+
+        fileprivate func enrollCaptureNext(
+            templateId: Data,
+            timeout: UInt? = nil
+        ) async -> CTAP2.StatusStream<CaptureResult> {
+            var params: [UInt8: CBOR.Value] = [
+                SubcommandParam.templateId.rawValue: templateId.cbor()
+            ]
+            if let timeout {
+                params[SubcommandParam.timeoutMilliseconds.rawValue] = timeout.cbor()
+            }
+            return await executeStream(subcommand: .enrollCaptureNextSample, params: params)
+        }
+
+        /// Cancels the current enrollment.
+        ///
+        /// - SeeAlso: [Cancel Current Enrollment](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#cancelCurrentEnrollment)
+        public func cancelEnrollment() async throws(CTAP2.SessionError) {
+            try await executeNoAuth(subcommand: .cancelCurrentEnrollment) as Void
+        }
+
+        /// An async sequence of enrolled fingerprint templates.
+        ///
+        /// - SeeAlso: [Enumerate Enrollments](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#enumerateEnrollments)
+        public var enrollments: EnrollmentSequence {
+            EnrollmentSequence(bioEnrollment: self)
+        }
+
+        /// Sets a friendly name for a fingerprint template.
+        ///
+        /// - Parameters:
+        ///   - name: The friendly name to set (e.g., "Right Index").
+        ///   - templateId: The template to rename.
+        /// - SeeAlso: [Set Friendly Name](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#setFriendlyName)
+        public func setFriendlyName(
+            _ name: String,
+            for templateId: Data
+        ) async throws(CTAP2.SessionError) {
+            let params: [UInt8: CBOR.Value] = [
+                SubcommandParam.templateId.rawValue: templateId.cbor(),
+                SubcommandParam.templateFriendlyName.rawValue: name.cbor(),
+            ]
+            try await execute(subcommand: .setFriendlyName, params: params) as Void
+        }
+
+        /// Removes a fingerprint enrollment.
+        ///
+        /// - Parameter templateId: The template to remove.
+        /// - SeeAlso: [Remove Enrollment](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#removeEnrollment)
+        public func removeEnrollment(
+            _ templateId: Data
+        ) async throws(CTAP2.SessionError) {
+            let params: [UInt8: CBOR.Value] = [
+                SubcommandParam.templateId.rawValue: templateId.cbor()
+            ]
+            try await execute(subcommand: .removeEnrollment, params: params) as Void
+        }
+
+        // MARK: - Internal
+
+        fileprivate func fetchEnrollments() async throws(CTAP2.SessionError) -> [TemplateInfo] {
+            do {
+                let response: EnumerateEnrollmentsResponse =
+                    try await execute(subcommand: .enumerateEnrollments)
+                return response.templateInfos
+            } catch .ctapError(.invalidOption, _), .ctapError(.noCredentials, _) {
+                return []
+            }
+        }
+
+        fileprivate static func commandCode(
+            for session: CTAP2.Session
+        ) async throws(CTAP2.SessionError) -> CTAP2.Command {
+            let info = try await session.cachedInfo
+            return info.options.supportsBioEnroll ? .bioEnrollment : .bioEnrollmentPreview
+        }
+
+        private func execute<R: CBOR.Decodable & Sendable>(
+            subcommand: Subcommand,
+            params: [UInt8: CBOR.Value]? = nil
+        ) async throws(CTAP2.SessionError) -> R {
+            let parameters = authParameters(subcommand: subcommand, params: params)
+            return try await session.interface.send(command: command, payload: parameters).value
+        }
+
+        private func execute(
+            subcommand: Subcommand,
+            params: [UInt8: CBOR.Value]? = nil
+        ) async throws(CTAP2.SessionError) {
+            let parameters = authParameters(subcommand: subcommand, params: params)
+            try await session.interface.send(command: command, payload: parameters).value
+        }
+
+        private func executeStream<R: CBOR.Decodable & Sendable>(
+            subcommand: Subcommand,
+            params: [UInt8: CBOR.Value]? = nil
+        ) async -> CTAP2.StatusStream<R> {
+            let parameters = authParameters(subcommand: subcommand, params: params)
+            return await session.interface.send(command: command, payload: parameters)
+        }
+
+        private func executeNoAuth<R: CBOR.Decodable & Sendable>(
+            subcommand: Subcommand
+        ) async throws(CTAP2.SessionError) -> R {
+            try await session.interface.send(
+                command: command,
+                payload: RequestParametersNoAuth(subCommand: subcommand)
+            ).value
+        }
+
+        private func executeNoAuth(
+            subcommand: Subcommand
+        ) async throws(CTAP2.SessionError) {
+            try await session.interface.send(
+                command: command,
+                payload: RequestParametersNoAuth(subCommand: subcommand)
+            ).value
+        }
+
+        private func authParameters(
+            subcommand: Subcommand,
+            params: [UInt8: CBOR.Value]?
+        ) -> RequestParameters {
+            // Auth message format: modality(0x01) || subCommand || CBOR(params)
+            var message = Data([Modality.fingerprint.rawValue, subcommand.rawValue])
+            if let params {
+                message.append(params.cbor().encode())
+            }
+            return RequestParameters(
+                modality: .fingerprint,
+                subCommand: subcommand,
+                subCommandParams: params,
+                pinUVAuthProtocol: token.protocolVersion,
+                pinUVAuthParam: token.authenticate(message: message)
+            )
+        }
+    }
+}
+
+// MARK: - Internal Types
+
+extension CTAP2.BioEnrollment {
+    /// Bio modality supported by the authenticator.
+    public enum Modality: UInt8, Sendable {
+        case fingerprint = 0x01
+    }
+
+    enum Subcommand: UInt8, Sendable {
+        case enrollBegin = 0x01
+        case enrollCaptureNextSample = 0x02
+        case cancelCurrentEnrollment = 0x03
+        case enumerateEnrollments = 0x04
+        case setFriendlyName = 0x05
+        case removeEnrollment = 0x06
+        case getFingerprintSensorInfo = 0x07
+    }
+
+    enum SubcommandParam: UInt8, Sendable {
+        case templateId = 0x01
+        case templateFriendlyName = 0x02
+        case timeoutMilliseconds = 0x03
+    }
+
+    struct RequestParameters: Sendable, CBOR.Encodable {
+        let modality: Modality
+        let subCommand: Subcommand
+        let subCommandParams: [UInt8: CBOR.Value]?
+        let pinUVAuthProtocol: CTAP2.ClientPin.ProtocolVersion
+        let pinUVAuthParam: Data
+
+        func cbor() -> CBOR.Value {
+            var map: [CBOR.Value: CBOR.Value] = [:]
+            map[.int(0x01)] = .int(Int(modality.rawValue))
+            map[.int(0x02)] = .int(Int(subCommand.rawValue))
+            if let params = subCommandParams, !params.isEmpty {
+                var paramsMap: [CBOR.Value: CBOR.Value] = [:]
+                for (key, value) in params {
+                    paramsMap[.int(Int(key))] = value
+                }
+                map[.int(0x03)] = .map(paramsMap)
+            }
+            map[.int(0x04)] = pinUVAuthProtocol.cbor()
+            map[.int(0x05)] = pinUVAuthParam.cbor()
+            return .map(map)
+        }
+    }
+
+    struct RequestParametersNoAuth: Sendable, CBOR.Encodable {
+        let subCommand: Subcommand
+
+        func cbor() -> CBOR.Value {
+            let map: [CBOR.Value: CBOR.Value] = [
+                .int(0x01): .int(Int(Modality.fingerprint.rawValue)),
+                .int(0x02): .int(Int(subCommand.rawValue)),
+            ]
+            return .map(map)
+        }
+    }
+
+    static let getModalityRequest: CBOR.Value = .map([.int(0x06): .boolean(true)])
+}
+
+// MARK: - Enrollment AsyncSequence
+
+extension CTAP2.BioEnrollment {
+
+    /// A sample captured during fingerprint enrollment.
+    public enum EnrollmentSample: Sendable {
+        /// The authenticator is waiting for a finger touch.
+        case waitingForUser
+        /// A sample was captured (good or bad).
+        case sample(status: SampleStatus, remaining: UInt)
+        /// Enrollment completed successfully.
+        case completed(templateId: Data, status: SampleStatus)
+    }
+
+    /// An async sequence that yields enrollment samples until complete.
+    public struct EnrollFingerprint: AsyncSequence, Sendable {
+        public typealias Element = EnrollmentSample
+
+        private let stream: AsyncThrowingStream<EnrollmentSample, any Error>
+
+        fileprivate init(bioEnrollment: CTAP2.BioEnrollment, timeout: UInt?) {
+            self.stream = AsyncThrowingStream { continuation in
+                let task = Task {
+                    do {
+                        try await Self.run(
+                            bioEnrollment: bioEnrollment,
+                            timeout: timeout,
+                            continuation: continuation
+                        )
+                    } catch {
+                        continuation.finish(throwing: error)
+                    }
+                }
+                continuation.onTermination = { termination in
+                    task.cancel()
+                    if case .cancelled = termination {
+                        Task { try? await bioEnrollment.cancelEnrollment() }
+                    }
+                }
+            }
+        }
+
+        private static func run(
+            bioEnrollment: CTAP2.BioEnrollment,
+            timeout: UInt?,
+            continuation: AsyncThrowingStream<EnrollmentSample, any Error>.Continuation
+        ) async throws {
+            // First capture - enrollBegin
+            var templateId: Data?
+            for try await status in await bioEnrollment.enrollBegin(timeout: timeout) {
+                switch status {
+                case .processing:
+                    break
+                case .waitingForUser:
+                    continuation.yield(.waitingForUser)
+                case .finished(let result):
+                    templateId = result.templateId
+                    if result.remainingSamples == 0 {
+                        continuation.yield(
+                            .completed(
+                                templateId: result.templateId,
+                                status: result.sampleStatus
+                            )
+                        )
+                        continuation.finish()
+                        return
+                    }
+                    continuation.yield(
+                        .sample(
+                            status: result.sampleStatus,
+                            remaining: result.remainingSamples
+                        )
+                    )
+                }
+            }
+
+            guard let templateId else {
+                continuation.finish()
+                return
+            }
+
+            // Subsequent captures - enrollCaptureNext
+            while !Task.isCancelled {
+                let stream = await bioEnrollment.enrollCaptureNext(
+                    templateId: templateId,
+                    timeout: timeout
+                )
+                for try await status in stream {
+                    switch status {
+                    case .processing:
+                        break
+                    case .waitingForUser:
+                        continuation.yield(.waitingForUser)
+                    case .finished(let result):
+                        if result.remainingSamples == 0 {
+                            continuation.yield(
+                                .completed(
+                                    templateId: templateId,
+                                    status: result.sampleStatus
+                                )
+                            )
+                            continuation.finish()
+                            return
+                        }
+                        continuation.yield(
+                            .sample(
+                                status: result.sampleStatus,
+                                remaining: result.remainingSamples
+                            )
+                        )
+                    }
+                }
+            }
+        }
+
+        public func makeAsyncIterator() -> AsyncThrowingStream<EnrollmentSample, any Error>.AsyncIterator {
+            stream.makeAsyncIterator()
+        }
+    }
+
+    // AsyncSequence conformance matches RPSequence/CredentialSequence API shape,
+    // though enumerateEnrollments returns all templates in a single response (no pagination).
+    public struct EnrollmentSequence: AsyncSequence, Sendable {
+        public typealias Element = TemplateInfo
+
+        fileprivate let bioEnrollment: CTAP2.BioEnrollment
+
+        /// Collects all enrolled templates into an array.
+        public func enumerate() async throws(CTAP2.SessionError) -> [TemplateInfo] {
+            try await bioEnrollment.fetchEnrollments()
+        }
+
+        public func makeAsyncIterator() -> Iterator {
+            Iterator(bioEnrollment: bioEnrollment)
+        }
+
+        public struct Iterator: AsyncIteratorProtocol {
+            private let bioEnrollment: CTAP2.BioEnrollment
+            private var items: [TemplateInfo]?
+            private var index = 0
+
+            fileprivate init(bioEnrollment: CTAP2.BioEnrollment) {
+                self.bioEnrollment = bioEnrollment
+            }
+
+            public mutating func next() async throws(CTAP2.SessionError) -> TemplateInfo? {
+                if items == nil { items = try await bioEnrollment.fetchEnrollments() }
+                guard let items, index < items.count else { return nil }
+                defer { index += 1 }
+                return items[index]
+            }
+        }
+    }
+}

--- a/YubiKit/YubiKit/FIDO/CTAP/BioEnrollment/BioEnrollmentTypes+CBOR.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/BioEnrollment/BioEnrollmentTypes+CBOR.swift
@@ -1,0 +1,147 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+// MARK: - Response Keys
+
+extension CTAP2.BioEnrollment {
+    fileprivate enum ResponseKey: Int {
+        case modality = 0x01
+        case fingerprintKind = 0x02
+        case maxCaptureSamplesRequired = 0x03
+        case templateId = 0x04
+        case lastEnrollSampleStatus = 0x05
+        case remainingSamples = 0x06
+        case templateInfos = 0x07
+        case maxTemplateFriendlyName = 0x08
+    }
+
+    fileprivate enum TemplateInfoKey: Int {
+        case templateId = 0x01
+        case templateFriendlyName = 0x02
+    }
+}
+
+// MARK: - FingerprintSensorInfo + CBOR
+
+extension CTAP2.BioEnrollment.FingerprintSensorInfo: CBOR.Decodable {
+    init?(cbor: CBOR.Value) {
+        guard let map = cbor.mapValue else {
+            return nil
+        }
+
+        typealias Key = CTAP2.BioEnrollment.ResponseKey
+
+        guard
+            let kindRaw = map[.int(Key.fingerprintKind.rawValue)]?.uint64Value,
+            let kind = CTAP2.BioEnrollment.FingerprintKind(rawValue: UInt8(kindRaw)),
+            let maxSamples = map[.int(Key.maxCaptureSamplesRequired.rawValue)]?.uint64Value
+        else {
+            return nil
+        }
+
+        let maxName = map[.int(Key.maxTemplateFriendlyName.rawValue)]?.uint64Value.map { UInt($0) }
+
+        self.init(
+            fingerprintKind: kind,
+            maxCaptureSamplesRequired: UInt(maxSamples),
+            maxTemplateFriendlyName: maxName
+        )
+    }
+}
+
+// MARK: - EnrollBeginResult + CBOR
+
+extension CTAP2.BioEnrollment.EnrollBeginResult: CBOR.Decodable {
+    init?(cbor: CBOR.Value) {
+        guard let map = cbor.mapValue else { return nil }
+        typealias Key = CTAP2.BioEnrollment.ResponseKey
+        guard
+            let templateId = map[.int(Key.templateId.rawValue)]?.dataValue,
+            let statusRaw = map[.int(Key.lastEnrollSampleStatus.rawValue)]?.uint64Value,
+            let sampleStatus = CTAP2.BioEnrollment.SampleStatus(rawValue: UInt8(statusRaw)),
+            let remaining = map[.int(Key.remainingSamples.rawValue)]?.uint64Value
+        else { return nil }
+        self.init(templateId: templateId, sampleStatus: sampleStatus, remainingSamples: UInt(remaining))
+    }
+}
+
+// MARK: - CaptureResult + CBOR
+
+extension CTAP2.BioEnrollment.CaptureResult: CBOR.Decodable {
+    init?(cbor: CBOR.Value) {
+        guard let map = cbor.mapValue else { return nil }
+        typealias Key = CTAP2.BioEnrollment.ResponseKey
+        guard
+            let statusRaw = map[.int(Key.lastEnrollSampleStatus.rawValue)]?.uint64Value,
+            let sampleStatus = CTAP2.BioEnrollment.SampleStatus(rawValue: UInt8(statusRaw)),
+            let remaining = map[.int(Key.remainingSamples.rawValue)]?.uint64Value
+        else { return nil }
+        self.init(sampleStatus: sampleStatus, remainingSamples: UInt(remaining))
+    }
+}
+
+// MARK: - EnumerateEnrollmentsResponse + CBOR
+
+extension CTAP2.BioEnrollment.EnumerateEnrollmentsResponse: CBOR.Decodable {
+    init?(cbor: CBOR.Value) {
+        guard let map = cbor.mapValue else {
+            return nil
+        }
+
+        typealias Key = CTAP2.BioEnrollment.ResponseKey
+        typealias TKey = CTAP2.BioEnrollment.TemplateInfoKey
+
+        guard let infosArray = map[.int(Key.templateInfos.rawValue)]?.arrayValue else {
+            return nil
+        }
+
+        var templateInfos: [CTAP2.BioEnrollment.TemplateInfo] = []
+        for item in infosArray {
+            guard let itemMap = item.mapValue,
+                let templateId = itemMap[.int(TKey.templateId.rawValue)]?.dataValue
+            else {
+                continue
+            }
+            let friendlyName = itemMap[.int(TKey.templateFriendlyName.rawValue)]?.stringValue
+            templateInfos.append(
+                CTAP2.BioEnrollment.TemplateInfo(templateId: templateId, friendlyName: friendlyName)
+            )
+        }
+
+        self.init(templateInfos: templateInfos)
+    }
+}
+
+// MARK: - GetModalityResponse + CBOR
+
+extension CTAP2.BioEnrollment.GetModalityResponse: CBOR.Decodable {
+    init?(cbor: CBOR.Value) {
+        guard let map = cbor.mapValue else {
+            return nil
+        }
+
+        typealias Key = CTAP2.BioEnrollment.ResponseKey
+
+        guard
+            let raw = map[.int(Key.modality.rawValue)]?.uint64Value,
+            let modality = CTAP2.BioEnrollment.Modality(rawValue: UInt8(raw))
+        else {
+            return nil
+        }
+
+        self.init(modality: modality)
+    }
+}

--- a/YubiKit/YubiKit/FIDO/CTAP/BioEnrollment/BioEnrollmentTypes+CBOR.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/BioEnrollment/BioEnrollmentTypes+CBOR.swift
@@ -46,11 +46,11 @@ extension CTAP2.BioEnrollment.FingerprintSensorInfo: CBOR.Decodable {
 
         guard
             let kindRaw = map[.int(Key.fingerprintKind.rawValue)]?.uint64Value,
-            let kind = CTAP2.BioEnrollment.FingerprintKind(rawValue: UInt8(kindRaw)),
             let maxSamples = map[.int(Key.maxCaptureSamplesRequired.rawValue)]?.uint64Value
         else {
             return nil
         }
+        let kind = CTAP2.BioEnrollment.FingerprintKind.from(UInt8(kindRaw))
 
         let maxName = map[.int(Key.maxTemplateFriendlyName.rawValue)]?.uint64Value.map { UInt($0) }
 
@@ -135,13 +135,10 @@ extension CTAP2.BioEnrollment.GetModalityResponse: CBOR.Decodable {
 
         typealias Key = CTAP2.BioEnrollment.ResponseKey
 
-        guard
-            let raw = map[.int(Key.modality.rawValue)]?.uint64Value,
-            let modality = CTAP2.BioEnrollment.Modality(rawValue: UInt8(raw))
-        else {
+        guard let raw = map[.int(Key.modality.rawValue)]?.uint64Value else {
             return nil
         }
 
-        self.init(modality: modality)
+        self.init(modality: .from(UInt8(raw)))
     }
 }

--- a/YubiKit/YubiKit/FIDO/CTAP/BioEnrollment/BioEnrollmentTypes+CBOR.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/BioEnrollment/BioEnrollmentTypes+CBOR.swift
@@ -71,9 +71,9 @@ extension CTAP2.BioEnrollment.EnrollBeginResult: CBOR.Decodable {
         guard
             let templateId = map[.int(Key.templateId.rawValue)]?.dataValue,
             let statusRaw = map[.int(Key.lastEnrollSampleStatus.rawValue)]?.uint64Value,
-            let sampleStatus = CTAP2.BioEnrollment.SampleStatus(rawValue: UInt8(statusRaw)),
             let remaining = map[.int(Key.remainingSamples.rawValue)]?.uint64Value
         else { return nil }
+        let sampleStatus = CTAP2.BioEnrollment.SampleStatus.from(UInt8(statusRaw))
         self.init(templateId: templateId, sampleStatus: sampleStatus, remainingSamples: UInt(remaining))
     }
 }
@@ -86,9 +86,9 @@ extension CTAP2.BioEnrollment.CaptureResult: CBOR.Decodable {
         typealias Key = CTAP2.BioEnrollment.ResponseKey
         guard
             let statusRaw = map[.int(Key.lastEnrollSampleStatus.rawValue)]?.uint64Value,
-            let sampleStatus = CTAP2.BioEnrollment.SampleStatus(rawValue: UInt8(statusRaw)),
             let remaining = map[.int(Key.remainingSamples.rawValue)]?.uint64Value
         else { return nil }
+        let sampleStatus = CTAP2.BioEnrollment.SampleStatus.from(UInt8(statusRaw))
         self.init(sampleStatus: sampleStatus, remainingSamples: UInt(remaining))
     }
 }

--- a/YubiKit/YubiKit/FIDO/CTAP/BioEnrollment/BioEnrollmentTypes.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/BioEnrollment/BioEnrollmentTypes.swift
@@ -1,0 +1,120 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+// MARK: - Public Types
+
+extension CTAP2.BioEnrollment {
+
+    /// Information about the fingerprint sensor hardware.
+    public struct FingerprintSensorInfo: Sendable {
+        /// The type of fingerprint sensor.
+        public let fingerprintKind: FingerprintKind
+
+        /// Maximum number of good fingerprint samples required for enrollment.
+        public let maxCaptureSamplesRequired: UInt
+
+        /// Maximum length of a template friendly name in bytes, if supported.
+        public let maxTemplateFriendlyName: UInt?
+
+        internal init(
+            fingerprintKind: FingerprintKind,
+            maxCaptureSamplesRequired: UInt,
+            maxTemplateFriendlyName: UInt?
+        ) {
+            self.fingerprintKind = fingerprintKind
+            self.maxCaptureSamplesRequired = maxCaptureSamplesRequired
+            self.maxTemplateFriendlyName = maxTemplateFriendlyName
+        }
+    }
+
+    /// The type of fingerprint sensor.
+    public enum FingerprintKind: UInt8, Sendable {
+        /// Touch-type sensor (place finger and hold).
+        case touch = 1
+        /// Swipe-type sensor (swipe finger across).
+        case swipe = 2
+    }
+
+    /// Feedback status for a fingerprint capture sample.
+    public enum SampleStatus: UInt8, Sendable, Equatable {
+        /// Good fingerprint capture.
+        case good = 0x00
+        /// Fingerprint was too high.
+        case tooHigh = 0x01
+        /// Fingerprint was too low.
+        case tooLow = 0x02
+        /// Fingerprint was too left.
+        case tooLeft = 0x03
+        /// Fingerprint was too right.
+        case tooRight = 0x04
+        /// Finger moved too fast.
+        case tooFast = 0x05
+        /// Finger moved too slow.
+        case tooSlow = 0x06
+        /// Fingerprint image was poor quality.
+        case poorQuality = 0x07
+        /// Fingerprint was too skewed.
+        case tooSkewed = 0x08
+        /// Fingerprint was too short (swipe sensor).
+        case tooShort = 0x09
+        /// Merge failure of the capture.
+        case mergeFailure = 0x0A
+        /// Fingerprint already exists in database.
+        case exists = 0x0B
+        // 0x0C is reserved (unused per CTAP 2.2 spec).
+        /// No user activity detected on the sensor.
+        case noUserActivity = 0x0D
+        /// No user presence transition detected.
+        case noUserPresenceTransition = 0x0E
+    }
+
+    /// Information about an enrolled fingerprint template.
+    public struct TemplateInfo: Sendable {
+        /// The template identifier.
+        public let templateId: Data
+
+        /// The user-assigned friendly name, if set.
+        public let friendlyName: String?
+
+        internal init(templateId: Data, friendlyName: String?) {
+            self.templateId = templateId
+            self.friendlyName = friendlyName
+        }
+    }
+}
+
+// MARK: - Internal Types
+
+extension CTAP2.BioEnrollment {
+    struct EnrollBeginResult: Sendable {
+        let templateId: Data
+        let sampleStatus: SampleStatus
+        let remainingSamples: UInt
+    }
+
+    struct CaptureResult: Sendable {
+        let sampleStatus: SampleStatus
+        let remainingSamples: UInt
+    }
+
+    struct EnumerateEnrollmentsResponse: Sendable {
+        let templateInfos: [TemplateInfo]
+    }
+
+    struct GetModalityResponse: Sendable {
+        let modality: Modality
+    }
+}

--- a/YubiKit/YubiKit/FIDO/CTAP/BioEnrollment/BioEnrollmentTypes.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/BioEnrollment/BioEnrollmentTypes.swift
@@ -41,11 +41,21 @@ extension CTAP2.BioEnrollment {
     }
 
     /// The type of fingerprint sensor.
-    public enum FingerprintKind: UInt8, Sendable {
+    public enum FingerprintKind: Sendable, Equatable {
         /// Touch-type sensor (place finger and hold).
-        case touch = 1
+        case touch
         /// Swipe-type sensor (swipe finger across).
-        case swipe = 2
+        case swipe
+        /// Unrecognized sensor type.
+        case other(UInt8)
+
+        internal static func from(_ rawValue: UInt8) -> FingerprintKind {
+            switch rawValue {
+            case 1: return .touch
+            case 2: return .swipe
+            default: return .other(rawValue)
+            }
+        }
     }
 
     /// Feedback status for a fingerprint capture sample.

--- a/YubiKit/YubiKit/FIDO/CTAP/BioEnrollment/BioEnrollmentTypes.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/BioEnrollment/BioEnrollmentTypes.swift
@@ -49,36 +49,57 @@ extension CTAP2.BioEnrollment {
     }
 
     /// Feedback status for a fingerprint capture sample.
-    public enum SampleStatus: UInt8, Sendable, Equatable {
+    public enum SampleStatus: Sendable, Equatable {
         /// Good fingerprint capture.
-        case good = 0x00
+        case good
         /// Fingerprint was too high.
-        case tooHigh = 0x01
+        case tooHigh
         /// Fingerprint was too low.
-        case tooLow = 0x02
+        case tooLow
         /// Fingerprint was too left.
-        case tooLeft = 0x03
+        case tooLeft
         /// Fingerprint was too right.
-        case tooRight = 0x04
+        case tooRight
         /// Finger moved too fast.
-        case tooFast = 0x05
+        case tooFast
         /// Finger moved too slow.
-        case tooSlow = 0x06
+        case tooSlow
         /// Fingerprint image was poor quality.
-        case poorQuality = 0x07
+        case poorQuality
         /// Fingerprint was too skewed.
-        case tooSkewed = 0x08
+        case tooSkewed
         /// Fingerprint was too short (swipe sensor).
-        case tooShort = 0x09
+        case tooShort
         /// Merge failure of the capture.
-        case mergeFailure = 0x0A
+        case mergeFailure
         /// Fingerprint already exists in database.
-        case exists = 0x0B
-        // 0x0C is reserved (unused per CTAP 2.2 spec).
+        case exists
         /// No user activity detected on the sensor.
-        case noUserActivity = 0x0D
+        case noUserActivity
         /// No user presence transition detected.
-        case noUserPresenceTransition = 0x0E
+        case noUserPresenceTransition
+        /// Unrecognized status code.
+        case other(UInt8)
+
+        internal static func from(_ rawValue: UInt8) -> SampleStatus {
+            switch rawValue {
+            case 0x00: return .good
+            case 0x01: return .tooHigh
+            case 0x02: return .tooLow
+            case 0x03: return .tooLeft
+            case 0x04: return .tooRight
+            case 0x05: return .tooFast
+            case 0x06: return .tooSlow
+            case 0x07: return .poorQuality
+            case 0x08: return .tooSkewed
+            case 0x09: return .tooShort
+            case 0x0A: return .mergeFailure
+            case 0x0B: return .exists
+            case 0x0D: return .noUserActivity
+            case 0x0E: return .noUserPresenceTransition
+            default: return .other(rawValue)
+            }
+        }
     }
 
     /// Information about an enrolled fingerprint template.

--- a/YubiKit/YubiKit/FIDO/CTAP/CTAP2.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/CTAP2.swift
@@ -288,7 +288,7 @@ public enum CTAP2 {
     /// These errors indicate problems at the HID transport level (as opposed to CTAP2 protocol-level errors).
     ///
     /// - SeeAlso: [CTAP 2.2 CTAPHID_ERROR](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#usb-hid-error)
-    public enum HIDError: Swift.Error, Sendable {
+    public enum HIDError: Swift.Error, Sendable, Equatable {
         /// The command in the request is invalid.
         case invalidCmd
         /// The parameter(s) in the request is invalid.

--- a/YubiKit/YubiKit/FIDO/CTAP/CTAP2.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/CTAP2.swift
@@ -107,7 +107,7 @@ public enum CTAP2 {
     /// specific failure conditions during authenticator operations.
     ///
     /// - SeeAlso: [CTAP 2.2 Status Codes](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#error-responses)
-    public enum Error: Swift.Error, Sendable {
+    public enum Error: Swift.Error, Sendable, Equatable {
         /// The command is not a valid CTAP command.
         case invalidCommand
         /// The command included an invalid parameter.

--- a/YubiKit/YubiKit/FIDO/CTAP/ClientPIN/Types.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/ClientPIN/Types.swift
@@ -14,16 +14,21 @@
 
 import Foundation
 
+// MARK: - PinUVAuthToken Protocol
+
+extension CTAP2.ClientPin {
+    /// Protocol for tokens that can authenticate CTAP2 management operations.
+    internal protocol PinUVAuthToken: Sendable {
+        var protocolVersion: CTAP2.ClientPin.ProtocolVersion { get }
+        func authenticate(message: Data) -> Data
+        func deriveKey(info: String) -> Data
+    }
+}
+
 // MARK: - ClientPin Types
 
 extension CTAP2.ClientPin {
     /// PIN/UV Auth Protocol version.
-    ///
-    /// Defines the cryptographic algorithms used for PIN/UV authentication.
-    /// Protocol v1 is supported by all CTAP2 authenticators, v2 adds improved security.
-    ///
-    /// - SeeAlso: [CTAP2 PIN/UV Auth Protocol One](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#pinProto1)
-    /// - SeeAlso: [CTAP2 PIN/UV Auth Protocol Two](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#pinProto2)
     public enum ProtocolVersion: Int, Sendable, CBOR.Encodable {
         /// Protocol version 1 (CTAP 2.0).
         case v1 = 1
@@ -36,21 +41,15 @@ extension CTAP2.ClientPin {
     public enum Method: Sendable {
         /// Verify using a PIN.
         case pin(String)
-
-        /// Verify using built-in user verification (e.g., fingerprint on YubiKey Bio).
+        /// Verify using built-in user verification (e.g., fingerprint).
         case uv
     }
 
-    /// A PIN/UV auth token obtained from the authenticator for authenticating CTAP operations.
+    /// A PIN auth token for authenticating CTAP2 operations.
     ///
-    /// Use ``CTAP2/Session/getPinUVToken(using:permissions:rpId:protocol:)`` to obtain a token,
-    /// then pass it to operations like ``CTAP2/Session/makeCredential(parameters:pinToken:)``
-    /// and ``CTAP2/Session/getAssertion(parameters:pinToken:)``.
-    public struct Token: Sendable {
-        /// The decrypted PIN token.
+    /// Obtain via ``CTAP2/Session/getPinToken(_:permissions:rpId:protocol:)``.
+    public struct PinToken: Sendable {
         private let token: Data
-
-        /// The PIN/UV auth protocol version used to obtain this token.
         public let protocolVersion: ProtocolVersion
 
         internal init(token: Data, protocolVersion: ProtocolVersion) {
@@ -58,19 +57,83 @@ extension CTAP2.ClientPin {
             self.protocolVersion = protocolVersion
         }
 
-        /// Compute the pinUVAuthParam for a given message.
-        ///
-        /// - Parameter message: The data to authenticate (typically clientDataHash).
-        /// - Returns: The authentication parameter to include in the CTAP request.
         func authenticate(message: Data) -> Data {
             protocolVersion.authenticate(key: token, message: message)
         }
 
-        /// Derives an AES key for decrypting encrypted GetInfo fields.
-        ///
-        /// Uses HKDF-SHA-256 with a 32-byte zero salt as specified in CTAP 2.3.
         internal func deriveKey(info: String) -> Data {
             Crypto.KDF.hkdf(token, salt: Data(count: 32), info: info, outputLength: 16)
         }
     }
+
+    /// A UV auth token obtained via built-in user verification (biometric).
+    ///
+    /// Obtain via ``CTAP2/Session/getUVToken(permissions:rpId:protocol:)``.
+    public struct UVToken: Sendable {
+        internal let token: Data
+        public let protocolVersion: ProtocolVersion
+
+        internal init(token: Data, protocolVersion: ProtocolVersion) {
+            self.token = token
+            self.protocolVersion = protocolVersion
+        }
+
+        func authenticate(message: Data) -> Data {
+            protocolVersion.authenticate(key: token, message: message)
+        }
+
+        internal func deriveKey(info: String) -> Data {
+            Crypto.KDF.hkdf(token, salt: Data(count: 32), info: info, outputLength: 16)
+        }
+    }
+
+    // MARK: - Backwards Compatibility
+
+    /// A PIN/UV auth token (deprecated, use ``PinToken`` or ``UVToken``).
+    @available(*, deprecated, message: "Use PinToken or UVToken directly")
+    public struct Token: Sendable {
+        internal enum TokenType {
+            case pin(PinToken)
+            case uv(UVToken)
+        }
+
+        internal let type: TokenType
+
+        public var protocolVersion: ProtocolVersion {
+            switch type {
+            case .pin(let token): return token.protocolVersion
+            case .uv(let token): return token.protocolVersion
+            }
+        }
+
+        internal init(pinToken: PinToken) {
+            self.type = .pin(pinToken)
+        }
+
+        internal init(uvToken: UVToken) {
+            self.type = .uv(uvToken)
+        }
+
+        func authenticate(message: Data) -> Data {
+            switch type {
+            case .pin(let token): return token.authenticate(message: message)
+            case .uv(let token): return token.authenticate(message: message)
+            }
+        }
+
+        func deriveKey(info: String) -> Data {
+            switch type {
+            case .pin(let token): return token.deriveKey(info: info)
+            case .uv(let token): return token.deriveKey(info: info)
+            }
+        }
+    }
 }
+
+// MARK: - PinUVAuthToken Conformances
+
+extension CTAP2.ClientPin.PinToken: CTAP2.ClientPin.PinUVAuthToken {}
+extension CTAP2.ClientPin.UVToken: CTAP2.ClientPin.PinUVAuthToken {}
+
+@available(*, deprecated, message: "Use PinToken or UVToken directly")
+extension CTAP2.ClientPin.Token: CTAP2.ClientPin.PinUVAuthToken {}

--- a/YubiKit/YubiKit/FIDO/CTAP/ClientPIN/Types.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/ClientPIN/Types.swift
@@ -70,7 +70,7 @@ extension CTAP2.ClientPin {
     ///
     /// Obtain via ``CTAP2/Session/getUVToken(permissions:rpId:protocol:)``.
     public struct UVToken: Sendable {
-        internal let token: Data
+        private let token: Data
         public let protocolVersion: ProtocolVersion
 
         internal init(token: Data, protocolVersion: ProtocolVersion) {

--- a/YubiKit/YubiKit/FIDO/CTAP/Config/Config.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/Config/Config.swift
@@ -17,11 +17,11 @@ import Foundation
 // MARK: - Session Config Accessor
 
 extension CTAP2.Session {
-    /// Returns authenticatorConfig operations bound to a PIN/UV auth token.
+    /// Returns authenticatorConfig operations bound to a PIN auth token.
     ///
     /// ```swift
-    /// let pinToken = try await session.getPinUVToken(
-    ///     using: .pin("123456"),
+    /// let pinToken = try await session.getPinToken(
+    ///     "123456",
     ///     permissions: [.authenticatorConfig]
     /// )
     /// let config = try await session.config(pinToken: pinToken)
@@ -29,15 +29,53 @@ extension CTAP2.Session {
     /// try await config.enableEnterpriseAttestation()
     /// ```
     ///
-    /// - Parameter pinToken: PIN/UV auth token with `authenticatorConfig` permission.
+    /// - Parameter pinToken: PIN auth token with `authenticatorConfig` permission.
     /// - Returns: Config operations bound to the token.
     /// - Throws: `CTAP2.SessionError.featureNotSupported` if authenticatorConfig is not supported.
     /// - SeeAlso: [CTAP2 authenticatorConfig](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorConfig)
-    public func config(pinToken: CTAP2.ClientPin.Token) async throws(CTAP2.SessionError) -> CTAP2.Config {
+    public func config(
+        pinToken: CTAP2.ClientPin.PinToken
+    ) async throws(CTAP2.SessionError) -> CTAP2.Config {
+        try await makeConfig(token: pinToken)
+    }
+
+    /// Returns authenticatorConfig operations bound to a UV auth token.
+    ///
+    /// ```swift
+    /// let uvToken = try await session.getUVToken(
+    ///     permissions: [.authenticatorConfig]
+    /// )
+    /// let config = try await session.config(uvToken: uvToken)
+    /// try await config.toggleAlwaysUV()
+    /// ```
+    ///
+    /// - Parameter uvToken: UV auth token with `authenticatorConfig` permission.
+    /// - Returns: Config operations bound to the token.
+    /// - Throws: `CTAP2.SessionError.featureNotSupported` if authenticatorConfig is not supported.
+    /// - SeeAlso: [CTAP2 authenticatorConfig](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorConfig)
+    public func config(
+        uvToken: CTAP2.ClientPin.UVToken
+    ) async throws(CTAP2.SessionError) -> CTAP2.Config {
+        try await makeConfig(token: uvToken)
+    }
+
+    /// Returns authenticatorConfig operations bound to a PIN/UV auth token.
+    ///
+    /// - Deprecated: Use ``config(pinToken:)`` (PinToken) or ``config(uvToken:)`` instead.
+    @available(*, deprecated, message: "Use config(pinToken: PinToken) or config(uvToken:)")
+    public func config(
+        pinToken: CTAP2.ClientPin.Token
+    ) async throws(CTAP2.SessionError) -> CTAP2.Config {
+        try await makeConfig(token: pinToken)
+    }
+
+    private func makeConfig(
+        token: any CTAP2.ClientPin.PinUVAuthToken
+    ) async throws(CTAP2.SessionError) -> CTAP2.Config {
         guard try await cachedInfo.options.authenticatorConfig else {
             throw .featureNotSupported(source: .here())
         }
-        return CTAP2.Config(session: self, pinToken: pinToken)
+        return CTAP2.Config(session: self, token: token)
     }
 }
 
@@ -49,11 +87,11 @@ extension CTAP2 {
     /// - SeeAlso: [CTAP2 authenticatorConfig](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorConfig)
     public struct Config: Sendable {
         private let session: CTAP2.Session
-        private let pinToken: CTAP2.ClientPin.Token
+        private let token: any CTAP2.ClientPin.PinUVAuthToken
 
-        fileprivate init(session: CTAP2.Session, pinToken: CTAP2.ClientPin.Token) {
+        fileprivate init(session: CTAP2.Session, token: any CTAP2.ClientPin.PinUVAuthToken) {
             self.session = session
-            self.pinToken = pinToken
+            self.token = token
         }
 
         /// Checks if the authenticator supports authenticatorConfig.
@@ -114,12 +152,12 @@ extension CTAP2 {
             params: [UInt8: CBOR.Value]? = nil
         ) async throws(CTAP2.SessionError) {
             let message = authMessage(subcommand: subcommand, params: params)
-            let pinUVAuthParam = pinToken.authenticate(message: message)
+            let pinUVAuthParam = token.authenticate(message: message)
 
             let parameters = RequestParameters(
                 subCommand: subcommand,
                 subCommandParams: params,
-                pinUVAuthProtocol: pinToken.protocolVersion,
+                pinUVAuthProtocol: token.protocolVersion,
                 pinUVAuthParam: pinUVAuthParam
             )
 

--- a/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement.swift
@@ -17,11 +17,11 @@ import Foundation
 // MARK: - Session CredentialManagement Accessor
 
 extension CTAP2.Session {
-    /// Returns credential management operations bound to a PIN/UV auth token.
+    /// Returns credential management operations bound to a PIN auth token.
     ///
     /// ```swift
-    /// let pinToken = try await session.getPinUVToken(
-    ///     using: .pin("123456"),
+    /// let pinToken = try await session.getPinToken(
+    ///     "123456",
     ///     permissions: [.credentialManagement]
     /// )
     /// let credMgmt = try await session.credentialManagement(pinToken: pinToken)
@@ -29,17 +29,53 @@ extension CTAP2.Session {
     /// let rps = try await credMgmt.rps.enumerate()
     /// ```
     ///
-    /// - Parameter pinToken: PIN/UV auth token with `credentialManagement` permission.
+    /// - Parameter pinToken: PIN auth token with `credentialManagement` permission.
     /// - Returns: CredentialManagement operations bound to the token.
     /// - Throws: `CTAP2.SessionError.featureNotSupported` if credential management is not supported.
     /// - SeeAlso: [CTAP2 authenticatorCredentialManagement](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorCredentialManagement)
     public func credentialManagement(
+        pinToken: CTAP2.ClientPin.PinToken
+    ) async throws(CTAP2.SessionError) -> CTAP2.CredentialManagement {
+        try await makeCredentialManagement(token: pinToken)
+    }
+
+    /// Returns credential management operations bound to a UV auth token.
+    ///
+    /// ```swift
+    /// let uvToken = try await session.getUVToken(
+    ///     permissions: [.credentialManagement]
+    /// )
+    /// let credMgmt = try await session.credentialManagement(uvToken: uvToken)
+    /// let metadata = try await credMgmt.getMetadata()
+    /// ```
+    ///
+    /// - Parameter uvToken: UV auth token with `credentialManagement` permission.
+    /// - Returns: CredentialManagement operations bound to the token.
+    /// - Throws: `CTAP2.SessionError.featureNotSupported` if credential management is not supported.
+    /// - SeeAlso: [CTAP2 authenticatorCredentialManagement](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorCredentialManagement)
+    public func credentialManagement(
+        uvToken: CTAP2.ClientPin.UVToken
+    ) async throws(CTAP2.SessionError) -> CTAP2.CredentialManagement {
+        try await makeCredentialManagement(token: uvToken)
+    }
+
+    /// Returns credential management operations bound to a PIN/UV auth token.
+    ///
+    /// - Deprecated: Use ``credentialManagement(pinToken:)`` (PinToken) or ``credentialManagement(uvToken:)`` instead.
+    @available(*, deprecated, message: "Use credentialManagement(pinToken: PinToken) or credentialManagement(uvToken:)")
+    public func credentialManagement(
         pinToken: CTAP2.ClientPin.Token
+    ) async throws(CTAP2.SessionError) -> CTAP2.CredentialManagement {
+        try await makeCredentialManagement(token: pinToken)
+    }
+
+    private func makeCredentialManagement(
+        token: any CTAP2.ClientPin.PinUVAuthToken
     ) async throws(CTAP2.SessionError) -> CTAP2.CredentialManagement {
         guard try await CTAP2.CredentialManagement.isSupported(by: self) else {
             throw .featureNotSupported(source: .here())
         }
-        return CTAP2.CredentialManagement(session: self, pinToken: pinToken)
+        return CTAP2.CredentialManagement(session: self, token: token)
     }
 }
 
@@ -53,11 +89,11 @@ extension CTAP2 {
     /// - SeeAlso: [CTAP2 authenticatorCredentialManagement](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorCredentialManagement)
     public struct CredentialManagement: Sendable {
         private let session: CTAP2.Session
-        private let pinToken: CTAP2.ClientPin.Token
+        private let token: any CTAP2.ClientPin.PinUVAuthToken
 
-        fileprivate init(session: CTAP2.Session, pinToken: CTAP2.ClientPin.Token) {
+        fileprivate init(session: CTAP2.Session, token: any CTAP2.ClientPin.PinUVAuthToken) {
             self.session = session
-            self.pinToken = pinToken
+            self.token = token
         }
 
         // MARK: - Feature Detection
@@ -192,8 +228,8 @@ extension CTAP2 {
             return RequestParameters(
                 subCommand: subcommand,
                 subCommandParams: params,
-                pinUVAuthProtocol: pinToken.protocolVersion,
-                pinUVAuthParam: pinToken.authenticate(message: message)
+                pinUVAuthProtocol: token.protocolVersion,
+                pinUVAuthParam: token.authenticate(message: message)
             )
         }
 

--- a/YubiKit/YubiKit/FIDO/CTAP/GetAssertion/GetAssertionParameters+CBOR.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/GetAssertion/GetAssertionParameters+CBOR.swift
@@ -34,20 +34,12 @@ extension CTAP2.GetAssertion.Parameters: CBOR.Encodable {
             }
             map[4] = .map(extMap)
         }
-        map[5] = options?.cbor()
+        var optionsMap: [CBOR.Value: CBOR.Value] = [:]
+        optionsMap["up"] = up?.cbor()
+        optionsMap["uv"] = uv?.cbor()
+        if !optionsMap.isEmpty { map[5] = optionsMap.cbor() }
         map[6] = pinUVAuthParam?.cbor()
         map[7] = pinUVAuthProtocol?.cbor()
-        return map.cbor()
-    }
-}
-
-// MARK: - CTAP.GetAssertion.Parameters.Options + CBOR
-
-extension CTAP2.GetAssertion.Parameters.Options: CBOR.Encodable {
-    func cbor() -> CBOR.Value {
-        var map: [CBOR.Value: CBOR.Value] = [:]
-        map["up"] = up?.cbor()
-        map["uv"] = uv?.cbor()
         return map.cbor()
     }
 }

--- a/YubiKit/YubiKit/FIDO/CTAP/GetAssertion/GetAssertionParameters.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/GetAssertion/GetAssertionParameters.swift
@@ -31,8 +31,11 @@ extension CTAP2.GetAssertion {
         /// Extension inputs for additional authenticator processing.
         public let extensions: [CTAP2.Extension.GetAssertion.Input]
 
-        /// Authenticator options.
-        public let options: Options?
+        /// Require user presence (default: true when omitted).
+        public internal(set) var up: Bool?
+
+        /// Require user verification (internal use only — set by SDK, never by callers).
+        internal var uv: Bool?
 
         /// PIN/UV auth parameter (populated automatically when using PIN authentication).
         private(set) var pinUVAuthParam: Data?
@@ -40,10 +43,14 @@ extension CTAP2.GetAssertion {
         /// PIN/UV protocol version (populated automatically when using PIN authentication).
         private(set) var pinUVAuthProtocol: CTAP2.ClientPin.ProtocolVersion?
 
-        /// Sets the PIN/UV authentication parameters using a PIN token.
-        mutating func setAuthentication(pinToken: CTAP2.ClientPin.Token) {
-            self.pinUVAuthParam = pinToken.authenticate(message: clientDataHash)
-            self.pinUVAuthProtocol = pinToken.protocolVersion
+        /// Sets the PIN/UV authentication parameters.
+        ///
+        /// Clears `uv` per CTAP 2.2 Section 6.1: platforms MUST NOT include both
+        /// the `uv` option and `pinUvAuthParam` in the same request.
+        mutating func setAuthentication(_ token: some CTAP2.ClientPin.PinUVAuthToken) {
+            self.uv = nil
+            self.pinUVAuthParam = token.authenticate(message: clientDataHash)
+            self.pinUVAuthProtocol = token.protocolVersion
         }
 
         public init(
@@ -51,27 +58,13 @@ extension CTAP2.GetAssertion {
             clientDataHash: Data,
             allowList: [WebAuthn.PublicKeyCredential.Descriptor]? = nil,
             extensions: [CTAP2.Extension.GetAssertion.Input] = [],
-            options: Options? = nil
+            up: Bool? = nil
         ) {
             self.rpId = rpId
             self.clientDataHash = clientDataHash
             self.allowList = allowList
             self.extensions = extensions
-            self.options = options
-        }
-
-        /// Authenticator options for getAssertion.
-        public struct Options: Sendable {
-            /// Require user presence (default: true).
-            public let up: Bool?
-
-            /// Require user verification.
-            public let uv: Bool?
-
-            public init(up: Bool? = nil, uv: Bool? = nil) {
-                self.up = up
-                self.uv = uv
-            }
+            self.up = up
         }
     }
 }

--- a/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse.swift
@@ -250,13 +250,72 @@ extension CTAP2.GetInfo {
 // MARK: - Encrypted Field Decryption
 
 extension CTAP2.GetInfo.Encrypted where Value == CTAP2.GetInfo.Opaque128 {
+
     /// Decrypts the encrypted field to raw bytes using a persistent pinUvAuthToken.
     ///
     /// - Parameter token: A persistent pinUvAuthToken obtained with
     ///   the `.persistentCredentialManagement` permission.
     /// - Returns: The decrypted 16-byte value.
     /// - Throws: `CryptoError` if decryption fails.
+    public func decryptedData(using token: CTAP2.ClientPin.PinToken) throws(CryptoError) -> Data {
+        try decryptData(using: token)
+    }
+
+    /// Decrypts the encrypted field to raw bytes using a persistent pinUvAuthToken.
+    ///
+    /// - Parameter token: A persistent pinUvAuthToken obtained with
+    ///   the `.persistentCredentialManagement` permission.
+    /// - Returns: The decrypted 16-byte value.
+    /// - Throws: `CryptoError` if decryption fails.
+    public func decryptedData(using token: CTAP2.ClientPin.UVToken) throws(CryptoError) -> Data {
+        try decryptData(using: token)
+    }
+
+    /// Decrypts the encrypted field to raw bytes using a persistent pinUvAuthToken.
+    ///
+    /// - Deprecated: Use ``decryptedData(using:)`` with `PinToken` or `UVToken` instead.
+    @available(*, deprecated, message: "Use decryptedData(using: PinToken) or decryptedData(using: UVToken)")
     public func decryptedData(using token: CTAP2.ClientPin.Token) throws(CryptoError) -> Data {
+        try decryptData(using: token)
+    }
+
+    /// Decrypts the encrypted field using a persistent pinUvAuthToken.
+    ///
+    /// - Parameter token: A persistent pinUvAuthToken obtained with
+    ///   the `.persistentCredentialManagement` permission.
+    /// - Returns: The decrypted 128-bit value.
+    /// - Throws: `CryptoError` if decryption fails.
+    public func decrypted(
+        using token: CTAP2.ClientPin.PinToken
+    ) throws(CryptoError) -> CTAP2.GetInfo.Opaque128 {
+        try decrypt(using: token)
+    }
+
+    /// Decrypts the encrypted field using a persistent pinUvAuthToken.
+    ///
+    /// - Parameter token: A persistent pinUvAuthToken obtained with
+    ///   the `.persistentCredentialManagement` permission.
+    /// - Returns: The decrypted 128-bit value.
+    /// - Throws: `CryptoError` if decryption fails.
+    public func decrypted(
+        using token: CTAP2.ClientPin.UVToken
+    ) throws(CryptoError) -> CTAP2.GetInfo.Opaque128 {
+        try decrypt(using: token)
+    }
+
+    /// Decrypts the encrypted field using a persistent pinUvAuthToken.
+    ///
+    /// - Deprecated: Use ``decrypted(using:)`` with `PinToken` or `UVToken` instead.
+    @available(*, deprecated, message: "Use decrypted(using: PinToken) or decrypted(using: UVToken)")
+    public func decrypted(
+        using token: CTAP2.ClientPin.Token
+    ) throws(CryptoError) -> CTAP2.GetInfo.Opaque128 {
+        try decrypt(using: token)
+    }
+
+    // MARK: - Private
+
+    private func decryptData(using token: some CTAP2.ClientPin.PinUVAuthToken) throws(CryptoError) -> Data {
         let ivSize = Crypto.AES.blockSize
         guard encryptedData.count > ivSize else {
             throw .missingData
@@ -269,16 +328,10 @@ extension CTAP2.GetInfo.Encrypted where Value == CTAP2.GetInfo.Opaque128 {
         return try Crypto.AES.decrypt(Data(ciphertext), key: aesKey, mode: .cbc(iv: Data(iv)))
     }
 
-    /// Decrypts the encrypted field using a persistent pinUvAuthToken.
-    ///
-    /// - Parameter token: A persistent pinUvAuthToken obtained with
-    ///   the `.persistentCredentialManagement` permission.
-    /// - Returns: The decrypted 128-bit value.
-    /// - Throws: `CryptoError` if decryption fails.
-    public func decrypted(
-        using token: CTAP2.ClientPin.Token
+    private func decrypt(
+        using token: some CTAP2.ClientPin.PinUVAuthToken
     ) throws(CryptoError) -> CTAP2.GetInfo.Opaque128 {
-        let data = try decryptedData(using: token)
+        let data = try decryptData(using: token)
         guard let value = CTAP2.GetInfo.Opaque128(data) else { throw .missingData }
         return value
     }

--- a/YubiKit/YubiKit/FIDO/CTAP/LargeBlobs/CTAPSession+LargeBlobs.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/LargeBlobs/CTAPSession+LargeBlobs.swift
@@ -62,12 +62,47 @@ extension CTAP2.Session {
     /// - Parameters:
     ///   - key: The 32-byte largeBlobKey for the credential.
     ///   - data: The data to store.
-    ///   - pinToken: PIN/UV auth token with largeBlobWrite permission.
+    ///   - pinToken: PIN auth token with largeBlobWrite permission.
     /// - Throws: `CTAP2.SessionError` if the operation fails.
     public func putBlob(
         key: Data,
         data: Data,
+        pinToken: CTAP2.ClientPin.PinToken
+    ) async throws(CTAP2.SessionError) {
+        try await putBlobInternal(key: key, data: data, token: pinToken)
+    }
+
+    /// Stores an encrypted blob for a credential.
+    ///
+    /// - Parameters:
+    ///   - key: The 32-byte largeBlobKey for the credential.
+    ///   - data: The data to store.
+    ///   - uvToken: UV auth token with largeBlobWrite permission.
+    /// - Throws: `CTAP2.SessionError` if the operation fails.
+    public func putBlob(
+        key: Data,
+        data: Data,
+        uvToken: CTAP2.ClientPin.UVToken
+    ) async throws(CTAP2.SessionError) {
+        try await putBlobInternal(key: key, data: data, token: uvToken)
+    }
+
+    /// Stores an encrypted blob for a credential.
+    ///
+    /// - Deprecated: Use ``putBlob(key:data:pinToken:)`` (PinToken) or ``putBlob(key:data:uvToken:)`` instead.
+    @available(*, deprecated, message: "Use putBlob(key:data:pinToken: PinToken) or putBlob(key:data:uvToken:)")
+    public func putBlob(
+        key: Data,
+        data: Data,
         pinToken: CTAP2.ClientPin.Token
+    ) async throws(CTAP2.SessionError) {
+        try await putBlobInternal(key: key, data: data, token: pinToken)
+    }
+
+    private func putBlobInternal(
+        key: Data,
+        data: Data,
+        token: any CTAP2.ClientPin.PinUVAuthToken
     ) async throws(CTAP2.SessionError) {
         var entries = try await readBlobArray()
 
@@ -80,7 +115,7 @@ extension CTAP2.Session {
         let newEntry = try CTAP2.LargeBlobs.Entry(encrypting: data, key: key)
         entries.append(newEntry)
 
-        try await writeBlobArray(entries, pinToken: pinToken)
+        try await writeBlobArray(entries, token: token)
     }
 
     /// Deletes any blobs for a credential.
@@ -90,11 +125,42 @@ extension CTAP2.Session {
     ///
     /// - Parameters:
     ///   - key: The 32-byte largeBlobKey for the credential.
-    ///   - pinToken: PIN/UV auth token with largeBlobWrite permission.
+    ///   - pinToken: PIN auth token with largeBlobWrite permission.
     /// - Throws: `CTAP2.SessionError` if the operation fails.
     public func deleteBlob(
         key: Data,
+        pinToken: CTAP2.ClientPin.PinToken
+    ) async throws(CTAP2.SessionError) {
+        try await deleteBlobInternal(key: key, token: pinToken)
+    }
+
+    /// Deletes any blobs for a credential.
+    ///
+    /// - Parameters:
+    ///   - key: The 32-byte largeBlobKey for the credential.
+    ///   - uvToken: UV auth token with largeBlobWrite permission.
+    /// - Throws: `CTAP2.SessionError` if the operation fails.
+    public func deleteBlob(
+        key: Data,
+        uvToken: CTAP2.ClientPin.UVToken
+    ) async throws(CTAP2.SessionError) {
+        try await deleteBlobInternal(key: key, token: uvToken)
+    }
+
+    /// Deletes any blobs for a credential.
+    ///
+    /// - Deprecated: Use ``deleteBlob(key:pinToken:)`` (PinToken) or ``deleteBlob(key:uvToken:)`` instead.
+    @available(*, deprecated, message: "Use deleteBlob(key:pinToken: PinToken) or deleteBlob(key:uvToken:)")
+    public func deleteBlob(
+        key: Data,
         pinToken: CTAP2.ClientPin.Token
+    ) async throws(CTAP2.SessionError) {
+        try await deleteBlobInternal(key: key, token: pinToken)
+    }
+
+    private func deleteBlobInternal(
+        key: Data,
+        token: any CTAP2.ClientPin.PinUVAuthToken
     ) async throws(CTAP2.SessionError) {
         var entries = try await readBlobArray()
         let originalCount = entries.count
@@ -104,7 +170,7 @@ extension CTAP2.Session {
         }
 
         if entries.count != originalCount {
-            try await writeBlobArray(entries, pinToken: pinToken)
+            try await writeBlobArray(entries, token: token)
         }
     }
 
@@ -158,7 +224,7 @@ extension CTAP2.Session {
     // Writes the entire large blob array with automatic fragmentation.
     private func writeBlobArray(
         _ entries: [CTAP2.LargeBlobs.Entry],
-        pinToken: CTAP2.ClientPin.Token
+        token: any CTAP2.ClientPin.PinUVAuthToken
     ) async throws(CTAP2.SessionError) {
         let info = try await cachedInfo
         let maxFragment = Int(info.maxMsgSize) - Self.maxFragmentLengthOverhead
@@ -189,7 +255,7 @@ extension CTAP2.Session {
                 set: fragment,
                 offset: offset,
                 length: length,
-                pinToken: pinToken
+                token: token
             )
 
             offset += UInt(fragmentSize)
@@ -216,17 +282,17 @@ extension CTAP2.Session {
         set: Data,
         offset: UInt,
         length: UInt?,
-        pinToken: CTAP2.ClientPin.Token
+        token: any CTAP2.ClientPin.PinUVAuthToken
     ) async throws(CTAP2.SessionError) {
         let message = writeAuthMessage(fragment: set, offset: offset)
-        let pinUVAuthParam = pinToken.authenticate(message: message)
+        let pinUVAuthParam = token.authenticate(message: message)
 
         let params = WriteParameters(
             set: set,
             offset: offset,
             length: length,
             pinUVAuthParam: pinUVAuthParam,
-            pinUVAuthProtocol: pinToken.protocolVersion
+            pinUVAuthProtocol: token.protocolVersion
         )
 
         let stream: CTAP2.StatusStream<Void> = await interface.send(

--- a/YubiKit/YubiKit/FIDO/CTAP/MakeCredential/MakeCredentialParameters+CBOR.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/MakeCredential/MakeCredentialParameters+CBOR.swift
@@ -44,21 +44,13 @@ extension CTAP2.MakeCredential.Parameters: CBOR.Encodable {
             }
             map[6] = .map(extMap)
         }
-        map[7] = options?.cbor()
+        var optionsMap: [CBOR.Value: CBOR.Value] = [:]
+        if rk { optionsMap["rk"] = true.cbor() }
+        optionsMap["uv"] = uv?.cbor()
+        if !optionsMap.isEmpty { map[7] = optionsMap.cbor() }
         map[8] = pinUVAuthParam?.cbor()
         map[9] = pinUVAuthProtocol?.cbor()
         map[10] = enterpriseAttestation?.cbor()
-        return map.cbor()
-    }
-}
-
-// MARK: - MakeCredentialParameters.Options + CBOR
-
-extension CTAP2.MakeCredential.Parameters.Options: CBOR.Encodable {
-    func cbor() -> CBOR.Value {
-        var map: [CBOR.Value: CBOR.Value] = [:]
-        map["rk"] = rk?.cbor()
-        map["uv"] = uv?.cbor()
         return map.cbor()
     }
 }

--- a/YubiKit/YubiKit/FIDO/CTAP/MakeCredential/MakeCredentialParameters.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/MakeCredential/MakeCredentialParameters.swift
@@ -37,8 +37,11 @@ extension CTAP2.MakeCredential {
         /// Extension inputs for additional authenticator processing.
         public let extensions: [CTAP2.Extension.MakeCredential.Input]
 
-        /// Authenticator options.
-        public let options: Options?
+        /// Require resident key (discoverable credential).
+        public internal(set) var rk: Bool
+
+        /// Require user verification (internal use only — set by SDK, never by callers).
+        internal var uv: Bool?
 
         /// Enterprise attestation level (1 or 2).
         public let enterpriseAttestation: Int?
@@ -49,10 +52,14 @@ extension CTAP2.MakeCredential {
         /// PIN/UV protocol version (populated automatically when using PIN authentication).
         private(set) var pinUVAuthProtocol: CTAP2.ClientPin.ProtocolVersion?
 
-        /// Sets the PIN/UV authentication parameters using a PIN token.
-        mutating func setAuthentication(pinToken: CTAP2.ClientPin.Token) {
-            self.pinUVAuthParam = pinToken.authenticate(message: clientDataHash)
-            self.pinUVAuthProtocol = pinToken.protocolVersion
+        /// Sets the PIN/UV authentication parameters.
+        ///
+        /// Clears `uv` per CTAP 2.2 Section 6.1: platforms MUST NOT include both
+        /// the `uv` option and `pinUvAuthParam` in the same request.
+        mutating func setAuthentication(_ token: some CTAP2.ClientPin.PinUVAuthToken) {
+            self.uv = nil
+            self.pinUVAuthParam = token.authenticate(message: clientDataHash)
+            self.pinUVAuthProtocol = token.protocolVersion
         }
 
         public init(
@@ -62,7 +69,7 @@ extension CTAP2.MakeCredential {
             pubKeyCredParams: [COSE.Algorithm],
             excludeList: [WebAuthn.PublicKeyCredential.Descriptor]? = nil,
             extensions: [CTAP2.Extension.MakeCredential.Input] = [],
-            options: Options? = nil,
+            rk: Bool = false,
             enterpriseAttestation: Int? = nil
         ) {
             self.clientDataHash = clientDataHash
@@ -71,22 +78,8 @@ extension CTAP2.MakeCredential {
             self.pubKeyCredParams = pubKeyCredParams
             self.excludeList = excludeList
             self.extensions = extensions
-            self.options = options
+            self.rk = rk
             self.enterpriseAttestation = enterpriseAttestation
-        }
-
-        /// Authenticator options for makeCredential.
-        public struct Options: Sendable {
-            /// Require resident key (discoverable credential).
-            public let rk: Bool?
-
-            /// Require user verification.
-            public let uv: Bool?
-
-            public init(rk: Bool? = nil, uv: Bool? = nil) {
-                self.rk = rk
-                self.uv = uv
-            }
         }
     }
 }

--- a/YubiKit/YubiKit/FIDO/Session/CTAPSession+BackwardsCompatibility.swift
+++ b/YubiKit/YubiKit/FIDO/Session/CTAPSession+BackwardsCompatibility.swift
@@ -1,0 +1,243 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+// MARK: - Backwards Compatibility
+
+/// This file contains deprecated API overloads for backwards compatibility.
+
+// MARK: - Deprecated Options Types
+
+extension CTAP2.MakeCredential.Parameters {
+
+    /// Authenticator options for makeCredential.
+    ///
+    /// - Deprecated: Pass `rk` directly to
+    /// ``init(clientDataHash:rp:user:pubKeyCredParams:excludeList:extensions:rk:enterpriseAttestation:)``.
+    @available(*, deprecated, message: "Pass rk directly to Parameters init")
+    public struct Options: Sendable {
+        public let rk: Bool?
+        public let uv: Bool?
+        public init(rk: Bool? = nil, uv: Bool? = nil) {
+            self.rk = rk
+            self.uv = uv
+        }
+    }
+
+    @available(*, deprecated, message: "Pass rk directly to Parameters init")
+    public init(
+        clientDataHash: Data,
+        rp: WebAuthn.PublicKeyCredential.RPEntity,
+        user: WebAuthn.PublicKeyCredential.UserEntity,
+        pubKeyCredParams: [COSE.Algorithm],
+        excludeList: [WebAuthn.PublicKeyCredential.Descriptor]? = nil,
+        extensions: [CTAP2.Extension.MakeCredential.Input] = [],
+        options: Options?,
+        enterpriseAttestation: Int? = nil
+    ) {
+        self.init(
+            clientDataHash: clientDataHash,
+            rp: rp,
+            user: user,
+            pubKeyCredParams: pubKeyCredParams,
+            excludeList: excludeList,
+            extensions: extensions,
+            rk: options?.rk ?? false,
+            enterpriseAttestation: enterpriseAttestation
+        )
+        self.uv = options?.uv
+    }
+}
+
+extension CTAP2.GetAssertion.Parameters {
+
+    /// Authenticator options for getAssertion.
+    ///
+    /// - Deprecated: Pass `up` directly to
+    /// ``init(rpId:clientDataHash:allowList:extensions:up:)``.
+    @available(*, deprecated, message: "Pass up directly to Parameters init")
+    public struct Options: Sendable {
+        public let up: Bool?
+        public let uv: Bool?
+        public init(up: Bool? = nil, uv: Bool? = nil) {
+            self.up = up
+            self.uv = uv
+        }
+    }
+
+    @available(*, deprecated, message: "Pass up directly to Parameters init")
+    public init(
+        rpId: String,
+        clientDataHash: Data,
+        allowList: [WebAuthn.PublicKeyCredential.Descriptor]? = nil,
+        extensions: [CTAP2.Extension.GetAssertion.Input] = [],
+        options: Options?
+    ) {
+        self.init(
+            rpId: rpId,
+            clientDataHash: clientDataHash,
+            allowList: allowList,
+            extensions: extensions,
+            up: options?.up
+        )
+        self.uv = options?.uv
+    }
+}
+
+// MARK: - Deprecated Session Methods
+
+extension CTAP2.Session {
+
+    // MARK: - MakeCredential (Deprecated Token type)
+
+    /// Create a new credential using PIN/UV authentication.
+    ///
+    /// - Deprecated: Use ``makeCredential(parameters:pinToken:)`` or
+    /// ``makeCredential(parameters:uvToken:)`` for type safety.
+    @available(
+        *,
+        deprecated,
+        message: "Use makeCredential with PinToken or UVToken directly"
+    )
+    public func makeCredential(
+        parameters: CTAP2.MakeCredential.Parameters,
+        pinToken: CTAP2.ClientPin.Token
+    ) async -> CTAP2.StatusStream<CTAP2.MakeCredential.Response> {
+        switch pinToken.type {
+        case .pin(let token):
+            return await makeCredential(parameters: parameters, pinToken: token)
+        case .uv(let token):
+            return await makeCredential(parameters: parameters, uvToken: token)
+        }
+    }
+
+    // MARK: - MakeCredential (Deprecated requireResidentKey parameter)
+
+    @available(*, deprecated, message: "Set rk in Parameters init instead")
+    public func makeCredential(
+        parameters: CTAP2.MakeCredential.Parameters,
+        pinToken: CTAP2.ClientPin.PinToken,
+        requireResidentKey: Bool
+    ) async -> CTAP2.StatusStream<CTAP2.MakeCredential.Response> {
+        var params = parameters
+        params.rk = requireResidentKey
+        return await makeCredential(parameters: params, pinToken: pinToken)
+    }
+
+    @available(*, deprecated, message: "Set rk in Parameters init instead")
+    public func makeCredential(
+        parameters: CTAP2.MakeCredential.Parameters,
+        uvToken: CTAP2.ClientPin.UVToken,
+        requireResidentKey: Bool
+    ) async -> CTAP2.StatusStream<CTAP2.MakeCredential.Response> {
+        var params = parameters
+        params.rk = requireResidentKey
+        return await makeCredential(parameters: params, uvToken: uvToken)
+    }
+
+    // MARK: - GetAssertion (Deprecated Token type)
+
+    /// Authenticate with a credential using PIN/UV authentication.
+    ///
+    /// - Deprecated: Use ``getAssertion(parameters:pinToken:)`` or
+    /// ``getAssertion(parameters:uvToken:)`` for type safety.
+    @available(
+        *,
+        deprecated,
+        message: "Use getAssertion with PinToken or UVToken directly"
+    )
+    public func getAssertion(
+        parameters: CTAP2.GetAssertion.Parameters,
+        pinToken: CTAP2.ClientPin.Token
+    ) async -> CTAP2.StatusStream<CTAP2.GetAssertion.Response> {
+        switch pinToken.type {
+        case .pin(let token):
+            return await getAssertion(parameters: parameters, pinToken: token)
+        case .uv(let token):
+            return await getAssertion(parameters: parameters, uvToken: token)
+        }
+    }
+
+    // MARK: - GetAssertion (Deprecated requireUserPresence parameter)
+
+    @available(*, deprecated, message: "Set up in Parameters init instead")
+    public func getAssertion(
+        parameters: CTAP2.GetAssertion.Parameters,
+        pinToken: CTAP2.ClientPin.PinToken,
+        requireUserPresence: Bool?
+    ) async -> CTAP2.StatusStream<CTAP2.GetAssertion.Response> {
+        var params = parameters
+        params.up = requireUserPresence
+        return await getAssertion(parameters: params, pinToken: pinToken)
+    }
+
+    @available(*, deprecated, message: "Set up in Parameters init instead")
+    public func getAssertion(
+        parameters: CTAP2.GetAssertion.Parameters,
+        uvToken: CTAP2.ClientPin.UVToken,
+        requireUserPresence: Bool?
+    ) async -> CTAP2.StatusStream<CTAP2.GetAssertion.Response> {
+        var params = parameters
+        params.up = requireUserPresence
+        return await getAssertion(parameters: params, uvToken: uvToken)
+    }
+
+    // MARK: - GetAssertions Sequence (Deprecated Token type)
+
+    /// Get all assertions as an async sequence using PIN/UV authentication.
+    ///
+    /// - Deprecated: Use ``getAssertions(parameters:pinToken:)`` or
+    /// ``getAssertions(parameters:uvToken:)`` for type safety.
+    @available(
+        *,
+        deprecated,
+        message: "Use getAssertions with PinToken or UVToken directly"
+    )
+    public func getAssertions(
+        parameters: CTAP2.GetAssertion.Parameters,
+        pinToken: CTAP2.ClientPin.Token
+    ) async -> CTAP2.GetAssertion.Sequence {
+        switch pinToken.type {
+        case .pin(let token):
+            return await getAssertions(parameters: parameters, pinToken: token)
+        case .uv(let token):
+            return await getAssertions(parameters: parameters, uvToken: token)
+        }
+    }
+
+    // MARK: - GetAssertions Sequence (Deprecated requireUserPresence parameter)
+
+    @available(*, deprecated, message: "Set up in Parameters init instead")
+    public func getAssertions(
+        parameters: CTAP2.GetAssertion.Parameters,
+        pinToken: CTAP2.ClientPin.PinToken,
+        requireUserPresence: Bool?
+    ) async -> CTAP2.GetAssertion.Sequence {
+        var params = parameters
+        params.up = requireUserPresence
+        return await getAssertions(parameters: params, pinToken: pinToken)
+    }
+
+    @available(*, deprecated, message: "Set up in Parameters init instead")
+    public func getAssertions(
+        parameters: CTAP2.GetAssertion.Parameters,
+        uvToken: CTAP2.ClientPin.UVToken,
+        requireUserPresence: Bool?
+    ) async -> CTAP2.GetAssertion.Sequence {
+        var params = parameters
+        params.up = requireUserPresence
+        return await getAssertions(parameters: params, uvToken: uvToken)
+    }
+}

--- a/YubiKit/YubiKit/FIDO/Session/CTAPSession+BackwardsCompatibility.swift
+++ b/YubiKit/YubiKit/FIDO/Session/CTAPSession+BackwardsCompatibility.swift
@@ -104,7 +104,7 @@ extension CTAP2.Session {
 
     /// Create a new credential using PIN/UV authentication.
     ///
-    /// - Deprecated: Use ``makeCredential(parameters:pinToken:)`` or
+    /// - Deprecated: Use ``makeCredential(parameters:pinToken:)`` (PinToken) or
     /// ``makeCredential(parameters:uvToken:)`` for type safety.
     @available(
         *,
@@ -113,13 +113,15 @@ extension CTAP2.Session {
     )
     public func makeCredential(
         parameters: CTAP2.MakeCredential.Parameters,
-        pinToken: CTAP2.ClientPin.Token
+        pinToken: CTAP2.ClientPin.Token? = nil
     ) async -> CTAP2.StatusStream<CTAP2.MakeCredential.Response> {
-        switch pinToken.type {
+        switch pinToken?.type {
         case .pin(let token):
             return await makeCredential(parameters: parameters, pinToken: token)
         case .uv(let token):
             return await makeCredential(parameters: parameters, uvToken: token)
+        case nil:
+            return await makeCredential(parameters: parameters)
         }
     }
 
@@ -151,7 +153,7 @@ extension CTAP2.Session {
 
     /// Authenticate with a credential using PIN/UV authentication.
     ///
-    /// - Deprecated: Use ``getAssertion(parameters:pinToken:)`` or
+    /// - Deprecated: Use ``getAssertion(parameters:pinToken:)`` (PinToken) or
     /// ``getAssertion(parameters:uvToken:)`` for type safety.
     @available(
         *,
@@ -160,13 +162,15 @@ extension CTAP2.Session {
     )
     public func getAssertion(
         parameters: CTAP2.GetAssertion.Parameters,
-        pinToken: CTAP2.ClientPin.Token
+        pinToken: CTAP2.ClientPin.Token? = nil
     ) async -> CTAP2.StatusStream<CTAP2.GetAssertion.Response> {
-        switch pinToken.type {
+        switch pinToken?.type {
         case .pin(let token):
             return await getAssertion(parameters: parameters, pinToken: token)
         case .uv(let token):
             return await getAssertion(parameters: parameters, uvToken: token)
+        case nil:
+            return await getAssertion(parameters: parameters)
         }
     }
 
@@ -198,7 +202,7 @@ extension CTAP2.Session {
 
     /// Get all assertions as an async sequence using PIN/UV authentication.
     ///
-    /// - Deprecated: Use ``getAssertions(parameters:pinToken:)`` or
+    /// - Deprecated: Use ``getAssertions(parameters:pinToken:)`` (PinToken) or
     /// ``getAssertions(parameters:uvToken:)`` for type safety.
     @available(
         *,
@@ -207,13 +211,15 @@ extension CTAP2.Session {
     )
     public func getAssertions(
         parameters: CTAP2.GetAssertion.Parameters,
-        pinToken: CTAP2.ClientPin.Token
+        pinToken: CTAP2.ClientPin.Token? = nil
     ) async -> CTAP2.GetAssertion.Sequence {
-        switch pinToken.type {
+        switch pinToken?.type {
         case .pin(let token):
             return await getAssertions(parameters: parameters, pinToken: token)
         case .uv(let token):
             return await getAssertions(parameters: parameters, uvToken: token)
+        case nil:
+            return await getAssertions(parameters: parameters)
         }
     }
 

--- a/YubiKit/YubiKit/FIDO/Session/CTAPSession+ClientPIN.swift
+++ b/YubiKit/YubiKit/FIDO/Session/CTAPSession+ClientPIN.swift
@@ -40,26 +40,57 @@ extension CTAP2.Session {
         return try await handler.getUVRetries()
     }
 
-    /// Get a PIN/UV auth token from the authenticator.
+    /// Get a PIN auth token from the authenticator.
     ///
     /// The returned token can be used to authenticate subsequent CTAP operations
-    /// like ``makeCredential(parameters:pinToken:)`` and ``getAssertion(parameters:pinToken:)``.
+    /// like ``makeCredential(parameters:pinToken:requireResidentKey:)`` and ``getAssertion(parameters:pinToken:requireUserPresence:)``.
     ///
     /// - Parameters:
-    ///   - method: The authentication method to use (PIN or built-in UV).
+    ///   - pin: The PIN to verify.
     ///   - permissions: Permissions for the token.
     ///   - rpId: Optional relying party ID (required for mc/ga permissions).
     ///   - pinProtocol: The PIN/UV auth protocol version to use. If nil, auto-selects.
-    /// - Returns: A PIN/UV auth token that can be used to authenticate CTAP operations.
+    /// - Returns: A PIN auth token that can be used to authenticate CTAP operations.
+    public func getPinToken(
+        _ pin: String,
+        permissions: CTAP2.ClientPin.Permission,
+        rpId: String? = nil,
+        protocol pinProtocol: CTAP2.ClientPin.ProtocolVersion? = nil
+    ) async throws(CTAP2.SessionError) -> CTAP2.ClientPin.PinToken {
+        let handler = try await clientPinHandler(protocol: pinProtocol)
+        return try await handler.getPinToken(pin, permissions: permissions, rpId: rpId)
+    }
+
+    /// Get a UV auth token from the authenticator using built-in user verification (biometric).
     ///
-    /// Example:
-    /// ```swift
-    /// // Using PIN
-    /// let token = try await session.getPinUVToken(using: .pin("1234"), permissions: .makeCredential, rpId: "example.com")
+    /// The returned token can be used to authenticate subsequent CTAP operations.
     ///
-    /// // Using biometrics (YubiKey Bio)
-    /// let token = try await session.getPinUVToken(using: .uv, permissions: .makeCredential, rpId: "example.com")
-    /// ```
+    /// > Important: When using a UV token, user verification has already occurred. Do not set
+    /// > `uv: true` in command options - use the type-safe overloads that accept ``UVToken``.
+    ///
+    /// - Parameters:
+    ///   - permissions: Permissions for the token.
+    ///   - rpId: Optional relying party ID (required for mc/ga permissions).
+    ///   - pinProtocol: The PIN/UV auth protocol version to use. If nil, auto-selects.
+    /// - Returns: A UV auth token that can be used to authenticate CTAP operations.
+    public func getUVToken(
+        permissions: CTAP2.ClientPin.Permission,
+        rpId: String? = nil,
+        protocol pinProtocol: CTAP2.ClientPin.ProtocolVersion? = nil
+    ) async throws(CTAP2.SessionError) -> CTAP2.ClientPin.UVToken {
+        let handler = try await clientPinHandler(protocol: pinProtocol)
+        return try await handler.getUVToken(permissions: permissions, rpId: rpId)
+    }
+
+    /// Get a PIN/UV auth token from the authenticator.
+    ///
+    /// - Deprecated: Use ``getPinToken(_:permissions:rpId:protocol:)`` or
+    /// ``getUVToken(permissions:rpId:protocol:)`` instead for better type safety.
+    @available(
+        *,
+        deprecated,
+        message: "Use getPinToken(_:permissions:rpId:protocol:) or getUVToken(permissions:rpId:protocol:) instead"
+    )
     public func getPinUVToken(
         using method: CTAP2.ClientPin.Method,
         permissions: CTAP2.ClientPin.Permission,
@@ -67,7 +98,15 @@ extension CTAP2.Session {
         protocol pinProtocol: CTAP2.ClientPin.ProtocolVersion? = nil
     ) async throws(CTAP2.SessionError) -> CTAP2.ClientPin.Token {
         let handler = try await clientPinHandler(protocol: pinProtocol)
-        return try await handler.getToken(using: method, permissions: permissions, rpId: rpId)
+        switch method {
+        case .pin(let pin):
+            let pinToken = try await handler.getPinToken(pin, permissions: permissions, rpId: rpId)
+            return CTAP2.ClientPin.Token(pinToken: pinToken)
+        case .uv:
+            // Return Token wrapping the UV token for backwards compatibility
+            let uvToken = try await handler.getUVToken(permissions: permissions, rpId: rpId)
+            return CTAP2.ClientPin.Token(uvToken: uvToken)
+        }
     }
 
     /// Set a new PIN on the authenticator (must not already have a PIN).
@@ -152,13 +191,73 @@ private struct ClientPinHandler: Sendable {
         return try await stream.value.keyAgreement
     }
 
-    func getToken(
-        using method: CTAP2.ClientPin.Method,
+    func getPinToken(
+        _ pin: String,
         permissions: CTAP2.ClientPin.Permission,
         rpId: String? = nil
-    ) async throws(CTAP2.SessionError) -> CTAP2.ClientPin.Token {
+    ) async throws(CTAP2.SessionError) -> CTAP2.ClientPin.PinToken {
+        let authenticatorKey = try await getKeyAgreement()
+
+        // Generate ephemeral key pair and derive shared secret
+        let secretResult = try pinProtocol.establishSharedSecret(peerKey: authenticatorKey)
+        let sharedSecret = secretResult.sharedSecret
+        let platformKey = secretResult.platformKey
+
+        // Hash and encrypt PIN
+        let normalizedPin = pin.precomposedStringWithCanonicalMapping
+        let pinHash = Data(Data(normalizedPin.utf8).sha256().prefix(16))
+        let pinHashEnc = try pinProtocol.encrypt(key: sharedSecret, plaintext: pinHash)
+
+        let response: CTAP2.ClientPin.GetToken.Response
+        if supportsTokenPermissions {
+            // Use 0x09 (getPinUvAuthTokenUsingPinWithPermissions)
+            let params = CTAP2.ClientPin.GetTokenWithPermissions.Parameters(
+                pinUVAuthProtocol: pinProtocol,
+                keyAgreement: platformKey,
+                pinHashEnc: pinHashEnc,
+                permissions: permissions,
+                rpId: rpId
+            )
+            let stream: CTAP2.StatusStream<CTAP2.ClientPin.GetToken.Response> = await interface.send(
+                command: .clientPin,
+                payload: params
+            )
+            response = try await stream.value
+        } else {
+            // Fall back to 0x05 (legacy getPinToken)
+            let params = CTAP2.ClientPin.GetToken.Parameters(
+                pinUVAuthProtocol: pinProtocol,
+                keyAgreement: platformKey,
+                pinHashEnc: pinHashEnc
+            )
+            let stream: CTAP2.StatusStream<CTAP2.ClientPin.GetToken.Response> = await interface.send(
+                command: .clientPin,
+                payload: params
+            )
+            response = try await stream.value
+        }
+
+        let pinTokenData = try pinProtocol.decrypt(key: sharedSecret, ciphertext: response.pinUVAuthToken)
+
+        // Validate token size: V1 allows 16 or 32 bytes, V2 requires exactly 32 bytes
+        let validSize =
+            pinProtocol == .v1 ? (pinTokenData.count == 16 || pinTokenData.count == 32) : pinTokenData.count == 32
+        guard validSize else {
+            throw CTAP2.SessionError.responseParseError(
+                "Invalid PIN token size: expected \(pinProtocol == .v1 ? "16 or 32" : "32") bytes, got \(pinTokenData.count)",
+                source: .here()
+            )
+        }
+
+        return CTAP2.ClientPin.PinToken(token: pinTokenData, protocolVersion: pinProtocol)
+    }
+
+    func getUVToken(
+        permissions: CTAP2.ClientPin.Permission,
+        rpId: String? = nil
+    ) async throws(CTAP2.SessionError) -> CTAP2.ClientPin.UVToken {
         // UV requires pinUvAuthToken support
-        if case .uv = method, !supportsTokenPermissions {
+        guard supportsTokenPermissions else {
             throw CTAP2.SessionError.featureNotSupported(source: .here())
         }
 
@@ -169,70 +268,32 @@ private struct ClientPinHandler: Sendable {
         let sharedSecret = secretResult.sharedSecret
         let platformKey = secretResult.platformKey
 
-        // Build command parameters and send based on auth method
-        let response: CTAP2.ClientPin.GetToken.Response
-        switch method {
-        case .pin(let pin):
-            // Hash and encrypt PIN
-            let normalizedPin = pin.precomposedStringWithCanonicalMapping
-            let pinHash = Data(Data(normalizedPin.utf8).sha256().prefix(16))
-            let pinHashEnc = try pinProtocol.encrypt(key: sharedSecret, plaintext: pinHash)
+        // Use 0x06 (getPinUvAuthTokenUsingUvWithPermissions)
+        let params = CTAP2.ClientPin.GetTokenUsingUV.Parameters(
+            pinUVAuthProtocol: pinProtocol,
+            keyAgreement: platformKey,
+            permissions: permissions,
+            rpId: rpId
+        )
+        let stream: CTAP2.StatusStream<CTAP2.ClientPin.GetToken.Response> = await interface.send(
+            command: .clientPin,
+            payload: params
+        )
+        let response = try await stream.value
 
-            if supportsTokenPermissions {
-                // Use 0x09 (getPinUvAuthTokenUsingPinWithPermissions)
-                let params = CTAP2.ClientPin.GetTokenWithPermissions.Parameters(
-                    pinUVAuthProtocol: pinProtocol,
-                    keyAgreement: platformKey,
-                    pinHashEnc: pinHashEnc,
-                    permissions: permissions,
-                    rpId: rpId
-                )
-                let stream: CTAP2.StatusStream<CTAP2.ClientPin.GetToken.Response> = await interface.send(
-                    command: .clientPin,
-                    payload: params
-                )
-                response = try await stream.value
-            } else {
-                // Fall back to 0x05 (legacy getPinToken)
-                let params = CTAP2.ClientPin.GetToken.Parameters(
-                    pinUVAuthProtocol: pinProtocol,
-                    keyAgreement: platformKey,
-                    pinHashEnc: pinHashEnc
-                )
-                let stream: CTAP2.StatusStream<CTAP2.ClientPin.GetToken.Response> = await interface.send(
-                    command: .clientPin,
-                    payload: params
-                )
-                response = try await stream.value
-            }
-
-        case .uv:
-            // Use 0x06 (getPinUvAuthTokenUsingUvWithPermissions)
-            let params = CTAP2.ClientPin.GetTokenUsingUV.Parameters(
-                pinUVAuthProtocol: pinProtocol,
-                keyAgreement: platformKey,
-                permissions: permissions,
-                rpId: rpId
-            )
-            let stream: CTAP2.StatusStream<CTAP2.ClientPin.GetToken.Response> = await interface.send(
-                command: .clientPin,
-                payload: params
-            )
-            response = try await stream.value
-        }
-        let pinToken = try pinProtocol.decrypt(key: sharedSecret, ciphertext: response.pinUVAuthToken)
+        let tokenData = try pinProtocol.decrypt(key: sharedSecret, ciphertext: response.pinUVAuthToken)
 
         // Validate token size: V1 allows 16 or 32 bytes, V2 requires exactly 32 bytes
         let validSize =
-            pinProtocol == .v1 ? (pinToken.count == 16 || pinToken.count == 32) : pinToken.count == 32
+            pinProtocol == .v1 ? (tokenData.count == 16 || tokenData.count == 32) : tokenData.count == 32
         guard validSize else {
             throw CTAP2.SessionError.responseParseError(
-                "Invalid PIN token size: expected \(pinProtocol == .v1 ? "16 or 32" : "32") bytes, got \(pinToken.count)",
+                "Invalid UV token size: expected \(pinProtocol == .v1 ? "16 or 32" : "32") bytes, got \(tokenData.count)",
                 source: .here()
             )
         }
 
-        return CTAP2.ClientPin.Token(token: pinToken, protocolVersion: pinProtocol)
+        return CTAP2.ClientPin.UVToken(token: tokenData, protocolVersion: pinProtocol)
     }
 
     func set(_ pin: String) async throws(CTAP2.SessionError) {

--- a/YubiKit/YubiKit/FIDO/Session/CTAPSession+ClientPIN.swift
+++ b/YubiKit/YubiKit/FIDO/Session/CTAPSession+ClientPIN.swift
@@ -43,7 +43,7 @@ extension CTAP2.Session {
     /// Get a PIN auth token from the authenticator.
     ///
     /// The returned token can be used to authenticate subsequent CTAP operations
-    /// like ``makeCredential(parameters:pinToken:requireResidentKey:)`` and ``getAssertion(parameters:pinToken:requireUserPresence:)``.
+    /// like ``makeCredential(parameters:pinToken:)`` and ``getAssertion(parameters:pinToken:)``.
     ///
     /// - Parameters:
     ///   - pin: The PIN to verify.

--- a/YubiKit/YubiKit/FIDO/Session/CTAPSession+GetAssertion.swift
+++ b/YubiKit/YubiKit/FIDO/Session/CTAPSession+GetAssertion.swift
@@ -18,42 +18,59 @@ import Foundation
 
 extension CTAP2.Session {
 
-    /// Authenticate with a credential.
+    /// Authenticate with a credential without authentication.
     ///
-    /// Generates an authentication assertion for an existing credential. This is used during
-    /// WebAuthn authentication to prove possession of the private key for a credential.
+    /// Use this when no PIN/UV is required (e.g., user presence only).
     ///
-    /// The authenticator validates the request, locates the credential, and generates a signature
-    /// over the authenticator data and client data hash using the credential's private key.
+    /// - Parameter parameters: The assertion request parameters.
+    /// - Returns: AsyncStream of status updates, ending with `.finished(response)` containing the assertion data
     ///
-    /// > Note: This functionality is available on YubiKey 5.0 or later.
+    /// - SeeAlso: [CTAP 2.2 authenticatorGetAssertion](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorGetAssertion)
+    public func getAssertion(
+        parameters: CTAP2.GetAssertion.Parameters
+    ) async -> CTAP2.StatusStream<CTAP2.GetAssertion.Response> {
+        await interface.send(command: .getAssertion, payload: parameters)
+    }
+
+    /// Authenticate with a credential using PIN authentication.
+    ///
+    /// > Important: Per CTAP 2.2 spec, platforms MUST NOT include both the `uv` option and
+    /// > `pinUvAuthParam` in the same request. UV with PIN tokens must occur during token
+    /// > acquisition via ``getPinToken(_:permissions:rpId:protocol:)``.
     ///
     /// - Parameters:
     ///   - parameters: The assertion request parameters.
-    ///   - pinToken: Optional PIN token for user verification. Obtain via ``getPinUVToken(using:permissions:rpId:protocol:)``.
+    ///   - pinToken: PIN token obtained via ``getPinToken(_:permissions:rpId:protocol:)``.
     /// - Returns: AsyncStream of status updates, ending with `.finished(response)` containing the assertion data
     ///
     /// - SeeAlso: [CTAP 2.2 authenticatorGetAssertion](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorGetAssertion)
     public func getAssertion(
         parameters: CTAP2.GetAssertion.Parameters,
-        pinToken: CTAP2.ClientPin.Token? = nil
+        pinToken: CTAP2.ClientPin.PinToken
     ) async -> CTAP2.StatusStream<CTAP2.GetAssertion.Response> {
+        var params = parameters
+        params.setAuthentication(pinToken)
+        return await interface.send(command: .getAssertion, payload: params)
+    }
 
-        // If no PIN token provided, send parameters as-is
-        guard let pinToken else {
-            return await interface.send(
-                command: .getAssertion,
-                payload: parameters
-            )
-        }
-
-        var authenticatedParams = parameters
-        authenticatedParams.setAuthentication(pinToken: pinToken)
-
-        return await interface.send(
-            command: .getAssertion,
-            payload: authenticatedParams
-        )
+    /// Authenticate with a credential using biometric authentication.
+    ///
+    /// > Important: When using a UV token, user verification has already occurred during token
+    /// > acquisition, so there is no `requireUserVerification` parameter.
+    ///
+    /// - Parameters:
+    ///   - parameters: The assertion request parameters.
+    ///   - uvToken: UV token obtained via ``getUVToken(permissions:rpId:protocol:)``.
+    /// - Returns: AsyncStream of status updates, ending with `.finished(response)` containing the assertion data
+    ///
+    /// - SeeAlso: [CTAP 2.2 authenticatorGetAssertion](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorGetAssertion)
+    public func getAssertion(
+        parameters: CTAP2.GetAssertion.Parameters,
+        uvToken: CTAP2.ClientPin.UVToken
+    ) async -> CTAP2.StatusStream<CTAP2.GetAssertion.Response> {
+        var params = parameters
+        params.setAuthentication(uvToken)
+        return await interface.send(command: .getAssertion, payload: params)
     }
 
     /// Get the next assertion when multiple credentials are available.
@@ -76,32 +93,68 @@ extension CTAP2.Session {
 
     // MARK: - Multiple Assertions
 
-    /// Get all assertions as an async sequence.
+    /// Get all assertions as an async sequence without authentication.
     ///
     /// Returns an async sequence that lazily fetches assertions one at a time. This automatically
-    /// handles calling ``getAssertion(parameters:pinToken:)`` for the first assertion and
+    /// handles calling ``getAssertion(parameters:)`` for the first assertion and
     /// ``getNextAssertion()`` for subsequent assertions based on `numberOfCredentials`.
     ///
-    /// When only one credential matches, the sequence yields a single assertion. When multiple credentials
-    /// are available (resident key discovery with no allowList), the sequence yields all of them.
+    /// - Parameter parameters: The assertion request parameters.
+    /// - Returns: An async sequence of assertion responses.
+    ///
+    /// - SeeAlso: ``getAssertion(parameters:)`` for low-level access to a single assertion.
+    public func getAssertions(
+        parameters: CTAP2.GetAssertion.Parameters
+    ) async -> CTAP2.GetAssertion.Sequence {
+        .init(session: self, parameters: parameters)
+    }
+
+    /// Get all assertions as an async sequence using PIN authentication.
+    ///
+    /// Returns an async sequence that lazily fetches assertions one at a time. This automatically
+    /// handles calling ``getAssertion(parameters:pinToken:)``
+    /// for the first assertion and ``getNextAssertion()`` for subsequent assertions.
+    ///
+    /// > Important: Per CTAP 2.2 spec, platforms MUST NOT include both the `uv` option and
+    /// > `pinUvAuthParam` in the same request.
     ///
     /// - Parameters:
     ///   - parameters: The assertion request parameters.
-    ///   - pinToken: Optional PIN token for user verification. Obtain via ``getPinUVToken(using:permissions:rpId:protocol:)``.
+    ///   - pinToken: PIN token obtained via ``getPinToken(_:permissions:rpId:protocol:)``.
     /// - Returns: An async sequence of assertion responses.
     ///
-    /// - SeeAlso: ``getAssertion(parameters:pinToken:)`` for low-level access to a single assertion.
+    /// - SeeAlso: ``getAssertion(parameters:pinToken:)``
     public func getAssertions(
         parameters: CTAP2.GetAssertion.Parameters,
-        pinToken: CTAP2.ClientPin.Token? = nil
+        pinToken: CTAP2.ClientPin.PinToken
     ) async -> CTAP2.GetAssertion.Sequence {
-        var authenticatedParams = parameters
+        var params = parameters
+        params.setAuthentication(pinToken)
+        return .init(session: self, parameters: params)
+    }
 
-        if let pinToken {
-            authenticatedParams.setAuthentication(pinToken: pinToken)
-        }
-
-        return .init(session: self, parameters: authenticatedParams)
+    /// Get all assertions as an async sequence using biometric authentication.
+    ///
+    /// Returns an async sequence that lazily fetches assertions one at a time. This automatically
+    /// handles calling ``getAssertion(parameters:uvToken:)`` for the first
+    /// assertion and ``getNextAssertion()`` for subsequent assertions.
+    ///
+    /// > Important: When using a UV token, user verification has already occurred during token
+    /// > acquisition, so there is no `requireUserVerification` parameter.
+    ///
+    /// - Parameters:
+    ///   - parameters: The assertion request parameters.
+    ///   - uvToken: UV token obtained via ``getUVToken(permissions:rpId:protocol:)``.
+    /// - Returns: An async sequence of assertion responses.
+    ///
+    /// - SeeAlso: ``getAssertion(parameters:uvToken:)``
+    public func getAssertions(
+        parameters: CTAP2.GetAssertion.Parameters,
+        uvToken: CTAP2.ClientPin.UVToken
+    ) async -> CTAP2.GetAssertion.Sequence {
+        var params = parameters
+        params.setAuthentication(uvToken)
+        return .init(session: self, parameters: params)
     }
 }
 

--- a/YubiKit/YubiKit/FIDO/Session/CTAPSession+MakeCredential.swift
+++ b/YubiKit/YubiKit/FIDO/Session/CTAPSession+MakeCredential.swift
@@ -18,42 +18,58 @@ import Foundation
 
 extension CTAP2.Session {
 
-    /// Create a new credential on the authenticator.
+    /// Create a new credential on the authenticator without authentication.
     ///
-    /// This command registers a new FIDO2 credential with the authenticator. The authenticator
-    /// will verify user presence (and optionally user verification via PIN/biometric), generate
-    /// a new credential keypair, and return attestation data.
+    /// Use this when no PIN/UV is required (e.g., user presence only).
     ///
-    /// > Important: This operation requires user interaction (touch) and may require PIN entry
-    /// > if user verification is requested.
+    /// - Parameter parameters: The credential creation parameters.
+    /// - Returns: AsyncSequence of status updates, ending with `.finished(response)` containing the credential data
     ///
-    /// > Note: This functionality is available on YubiKey 5.0 or later.
+    /// - SeeAlso: [CTAP 2.2 authenticatorMakeCredential](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorMakeCredential)
+    public func makeCredential(
+        parameters: CTAP2.MakeCredential.Parameters
+    ) async -> CTAP2.StatusStream<CTAP2.MakeCredential.Response> {
+        await interface.send(command: .makeCredential, payload: parameters)
+    }
+
+    /// Create a new credential using PIN authentication.
+    ///
+    /// > Important: Per CTAP 2.2 spec, platforms MUST NOT include both the `uv` option and
+    /// > `pinUvAuthParam` in the same request. UV with PIN tokens must occur during token
+    /// > acquisition via ``getPinToken(_:permissions:rpId:protocol:)``.
     ///
     /// - Parameters:
     ///   - parameters: The credential creation parameters.
-    ///   - pinToken: Optional PIN token for user verification. Obtain via ``getPinUVToken(using:permissions:rpId:protocol:)``.
+    ///   - pinToken: PIN token obtained via ``getPinToken(_:permissions:rpId:protocol:)``.
     /// - Returns: AsyncSequence of status updates, ending with `.finished(response)` containing the credential data
     ///
     /// - SeeAlso: [CTAP 2.2 authenticatorMakeCredential](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorMakeCredential)
     public func makeCredential(
         parameters: CTAP2.MakeCredential.Parameters,
-        pinToken: CTAP2.ClientPin.Token? = nil
+        pinToken: CTAP2.ClientPin.PinToken
     ) async -> CTAP2.StatusStream<CTAP2.MakeCredential.Response> {
+        var params = parameters
+        params.setAuthentication(pinToken)
+        return await interface.send(command: .makeCredential, payload: params)
+    }
 
-        // If no PIN token provided, send parameters as-is
-        guard let pinToken else {
-            return await interface.send(
-                command: .makeCredential,
-                payload: parameters
-            )
-        }
-
-        var authenticatedParams = parameters
-        authenticatedParams.setAuthentication(pinToken: pinToken)
-
-        return await interface.send(
-            command: .makeCredential,
-            payload: authenticatedParams
-        )
+    /// Create a new credential using biometric authentication.
+    ///
+    /// > Important: When using a UV token, user verification has already occurred during token
+    /// > acquisition, so there is no `requireUserVerification` parameter.
+    ///
+    /// - Parameters:
+    ///   - parameters: The credential creation parameters.
+    ///   - uvToken: UV token obtained via ``getUVToken(permissions:rpId:protocol:)``.
+    /// - Returns: AsyncSequence of status updates, ending with `.finished(response)` containing the credential data
+    ///
+    /// - SeeAlso: [CTAP 2.2 authenticatorMakeCredential](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorMakeCredential)
+    public func makeCredential(
+        parameters: CTAP2.MakeCredential.Parameters,
+        uvToken: CTAP2.ClientPin.UVToken
+    ) async -> CTAP2.StatusStream<CTAP2.MakeCredential.Response> {
+        var params = parameters
+        params.setAuthentication(uvToken)
+        return await interface.send(command: .makeCredential, payload: params)
     }
 }


### PR DESCRIPTION
## Motivation for the approach

The CTAP2 session API used a single `Token` type for both PIN and UV authentication, making it impossible to enforce at compile time that `uv` and `pinUvAuthParam` are never sent together (CTAP 2.2 §6.1). 

## Changes

### Type-safe PIN/UV tokens
- `Token` split into `PinToken` and `UVToken` with dedicated overloads across all session methods (`makeCredential`, `getAssertion`, `config`, `credentialManagement`, `largeBlobs`).
- `setAuthentication()` enforces `uv = nil` when a token is present.

### Flattened parameters
- `Options` structs deprecated; `rk`/`up` promoted to top-level params, `uv` made internal-only.

### Bio enrollment
- Full CTAP 2 implementation: modality, sensor info, enroll/cancel/enumerate/rename/remove.
- `enroll()` returns an `AsyncSequence` of samples for a clean enrollment loop.
- Supports standard (`0x09`) and preview (`0x40`) command codes.
- Forward-compatible enums with `.other(rawValue)` cases.

### Backwards compatibility
- All old APIs preserved with `@available(*, deprecated)`.
- `CTAPSession+BackwardsCompatibility.swift` isolates deprecated overloads.

### Tests
- `BioEnrollmentTests`: sensor info, full enroll/rename/delete lifecycle.
- `BioUVTests`: UV token credential creation, UV blocking, PIN fallback.
- Existing tests migrated to `getPinToken`/`getUVToken`.
