### PR TITLE
Bio enrollment + flatten MakeCredential/GetAssertion Options

### DIFF
--- a/FullStackTests/FullStackTests.xcodeproj/project.pbxproj
+++ b/FullStackTests/FullStackTests.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		6CMINPINLEN2F1116000000001 /* MinPinLengthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CMINPINLEN2F1116000000000 /* MinPinLengthTests.swift */; };
 		B2A73E5DE80348329B8FA710 /* EncryptedFieldsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E3FD736FBE49ECAAAFA28E /* EncryptedFieldsTests.swift */; };
 		583058DA680743A1B11C558F /* CredentialManagementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA359818D52447249DB07BD1 /* CredentialManagementTests.swift */; };
+		13BE63C7192C4B728038C6A1 /* BioEnrollmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72D7C4A8CBA8427693C73A4D /* BioEnrollmentTests.swift */; };
+		39665FDAD3234C40B63D96C652AF6BDC /* BioUVTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D791282CF7244B319C15DAB12BE8C426 /* BioUVTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -82,6 +84,8 @@
 		6CMINPINLEN2F1116000000000 /* MinPinLengthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinPinLengthTests.swift; sourceTree = "<group>"; };
 		59E3FD736FBE49ECAAAFA28E /* EncryptedFieldsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptedFieldsTests.swift; sourceTree = "<group>"; };
 		FA359818D52447249DB07BD1 /* CredentialManagementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialManagementTests.swift; sourceTree = "<group>"; };
+		72D7C4A8CBA8427693C73A4D /* BioEnrollmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BioEnrollmentTests.swift; sourceTree = "<group>"; };
+		D791282CF7244B319C15DAB12BE8C426 /* BioUVTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BioUVTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -170,6 +174,8 @@
 			isa = PBXGroup;
 			children = (
 				CD75D32D2F1114C8000624CB /* Extensions */,
+				72D7C4A8CBA8427693C73A4D /* BioEnrollmentTests.swift */,
+				D791282CF7244B319C15DAB12BE8C426 /* BioUVTests.swift */,
 				CD89AB9B1BB24FA6B5FD79D3 /* ConfigTests.swift */,
 				FA359818D52447249DB07BD1 /* CredentialManagementTests.swift */,
 				6C734BB42EE860E100972E2A /* CredentialTests.swift */,
@@ -350,6 +356,8 @@
 				6CDATAHEX2EF1234500000001 /* Data+Hex.swift in Sources */,
 				B2A73E5DE80348329B8FA710 /* EncryptedFieldsTests.swift in Sources */,
 				583058DA680743A1B11C558F /* CredentialManagementTests.swift in Sources */,
+				13BE63C7192C4B728038C6A1 /* BioEnrollmentTests.swift in Sources */,
+				39665FDAD3234C40B63D96C652AF6BDC /* BioUVTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FullStackTests/Tests/CTAP2/BioEnrollmentTests.swift
+++ b/FullStackTests/Tests/CTAP2/BioEnrollmentTests.swift
@@ -1,0 +1,133 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Testing
+import YubiKit
+
+// MARK: - Bio Enrollment Tests
+
+@Suite("Bio Enrollment", .serialized)
+struct BioEnrollmentTests {
+
+    @Test("Get fingerprint sensor info")
+    func testGetSensorInfo() async throws {
+        try await withBioEnrollment { bio in
+            let info = try await bio.getFingerprintSensorInfo()
+            // fingerprintKind should be 'touch' or 'swipe'
+            #expect([.touch, .swipe].contains(info.fingerprintKind))
+            // maxCaptureSamplesRequired should be > 0
+            #expect(info.maxCaptureSamplesRequired > 0)
+            // maxTemplateFriendlyName should be > 0 if present
+            if let maxName = info.maxTemplateFriendlyName {
+                #expect(maxName > 0)
+            }
+        }
+    }
+
+    @Test("Enroll, rename, and delete fingerprint")
+    func testEnrollRenameDelete() async throws {
+        try await withBioEnrollment { bio in
+            // Remove all existing enrollments
+            let existing = try await bio.enrollments.enumerate()
+            for template in existing {
+                try await bio.removeEnrollment(template.templateId)
+            }
+
+            // Verify we start with no enrollments
+            #expect(try await bio.enrollments.enumerate().isEmpty)
+
+            // Enroll fingerprint
+            var templateId: Data?
+            print("👆 Press your fingerprint against the sensor now...")
+            for try await sample in bio.enroll() {
+                switch sample {
+                case .waitingForUser:
+                    print("👆 Touch the sensor...")
+                case .sample(let status, let remaining):
+                    if status == .good {
+                        print("✅ \(remaining) more scans needed")
+                    } else {
+                        print("⚠️  \(status)")
+                    }
+                case .completed(let id, _):
+                    templateId = id
+                }
+            }
+
+            #expect(templateId != nil)
+
+            // Check enrollment exists with no name
+            var enrollments = try await bio.enrollments.enumerate()
+            #expect(enrollments.count == 1)
+            #expect(enrollments[0].templateId == templateId)
+            #expect(enrollments[0].friendlyName == nil || enrollments[0].friendlyName == "")
+
+            // Set name
+            try await bio.setFriendlyName("Test 1", for: templateId!)
+            enrollments = try await bio.enrollments.enumerate()
+            #expect(enrollments.count == 1)
+            #expect(enrollments[0].friendlyName == "Test 1")
+
+            // Set name to max length
+            let sensorInfo = try await bio.getFingerprintSensorInfo()
+            if let maxLen = sensorInfo.maxTemplateFriendlyName {
+                let maxName = "Test" + String(repeating: "!", count: Int(maxLen) - 4)
+                try await bio.setFriendlyName(maxName, for: templateId!)
+                enrollments = try await bio.enrollments.enumerate()
+                #expect(enrollments.count == 1)
+                #expect(enrollments[0].friendlyName == maxName)
+
+                // Test max length + 1 error
+                let tooLongName = "Test" + String(repeating: "!", count: Int(maxLen) - 3)
+                do {
+                    try await bio.setFriendlyName(tooLongName, for: templateId!)
+                    Issue.record("Should have thrown error for name exceeding max length")
+                } catch let error as CTAP2.SessionError {
+                    guard case .ctapError(.invalidLength, _) = error else {
+                        Issue.record("Expected invalidLength error, got: \(error)")
+                        return
+                    }
+                    print("✅ Correctly rejected name exceeding max length with invalidLength error")
+                }
+            }
+
+            // Delete fingerprint
+            try await bio.removeEnrollment(templateId!)
+            #expect(try await bio.enrollments.enumerate().isEmpty)
+        }
+    }
+}
+
+// MARK: - Test Fixture
+
+private func withBioEnrollment(
+    _ body: (CTAP2.BioEnrollment) async throws -> Void
+) async throws {
+    try await withCTAP2Session { session in
+        try #require(await CTAP2.BioEnrollment.isSupported(by: session), "Bio enrollment not supported")
+
+        let info = try await session.getInfo()
+        try #require(info.options.clientPin == true, "PIN not set")
+
+        let pinToken = try await session.getPinUVToken(
+            using: .pin(defaultTestPin),
+            permissions: [.bioEnrollment]
+        )
+
+        let bio = try await session.bioEnrollment(pinToken: pinToken)
+
+        try await body(bio)
+    }
+}

--- a/FullStackTests/Tests/CTAP2/BioEnrollmentTests.swift
+++ b/FullStackTests/Tests/CTAP2/BioEnrollmentTests.swift
@@ -50,7 +50,7 @@ struct BioEnrollmentTests {
 
             // Enroll fingerprint
             var templateId: Data?
-            print("👆 Press your fingerprint against the sensor now...")
+            print("👆 Starting enrollment...")
             for try await sample in bio.enroll() {
                 switch sample {
                 case .waitingForUser:

--- a/FullStackTests/Tests/CTAP2/BioUVTests.swift
+++ b/FullStackTests/Tests/CTAP2/BioUVTests.swift
@@ -1,0 +1,190 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Testing
+import YubiKit
+
+// MARK: - Bio UV Tests
+
+@Suite("Bio UV", .serialized)
+struct BioUVTests {
+
+    @Test("Create credential using UV token")
+    func testMakeCredentialWithUVToken() async throws {
+        try await withEnrolledFingerprint { session, templateId in
+            // Get UV token via fingerprint (not PIN) with makeCredential permission
+            print("👆 Touch enrolled fingerprint to get UV token...")
+            let uvToken = try await session.getPinUVToken(
+                using: .uv,
+                permissions: [.makeCredential],
+                rpId: "example.com"
+            )
+
+            let params = CTAP2.MakeCredential.Parameters(
+                clientDataHash: Data(repeating: 0xCD, count: 32),
+                rp: WebAuthn.PublicKeyCredential.RPEntity(id: "example.com", name: "Example"),
+                user: WebAuthn.PublicKeyCredential.UserEntity(
+                    id: Data(repeating: 0x10, count: 32),
+                    name: "uv-user@example.com",
+                    displayName: "UV User"
+                ),
+                pubKeyCredParams: [.es256],
+                rk: true
+            )
+
+            print("👆 Touch enrolled fingerprint to create credential...")
+            let credential = try await session.makeCredential(
+                parameters: params,
+                pinToken: uvToken
+            ).value
+
+            // UV token should set BOTH UV and UP flags
+            #expect(credential.authenticatorData.flags.contains(.userPresent))
+            #expect(credential.authenticatorData.flags.contains(.userVerified))
+            print("✅ Credential created with UV token (UP + UV flags set)")
+        }
+    }
+
+    @Test("UV blocking after wrong fingerprint attempts")
+    func testUVBlocking() async throws {
+        try await withEnrolledFingerprint { session, templateId in
+            // Attempt UV with wrong fingerprint until the authenticator blocks UV.
+            // The retry threshold is authenticator-specific (typically 3–5).
+            let maxAttempts = 10
+            print("\n⚠️  Use a DIFFERENT fingerprint (not the enrolled one) until UV is blocked")
+
+            var attempt = 0
+            while attempt < maxAttempts {
+                attempt += 1
+                do {
+                    print("👆 Attempt \(attempt): Touch WRONG fingerprint...")
+                    _ = try await session.getPinUVToken(
+                        using: .uv,
+                        permissions: [.makeCredential],
+                        rpId: "example.com"
+                    )
+                    Issue.record("Wrong fingerprint should have been rejected")
+                } catch let error as CTAP2.SessionError {
+                    if case .ctapError(let code, _) = error {
+                        if code == .uvBlocked {
+                            print("✅ UV_BLOCKED after \(attempt) failed attempts")
+                            break
+                        }
+                        #expect(code == .uvInvalid, "Expected uvInvalid on attempt \(attempt), got: \(code)")
+                        print("✅ UV_INVALID (\(attempt))")
+                    } else {
+                        Issue.record("Expected CTAP error, got: \(error)")
+                    }
+                }
+            }
+            #expect(attempt <= maxAttempts, "UV was not blocked after \(maxAttempts) attempts")
+
+            // Now verify that PIN still works even though UV is blocked
+            print("\n👆 Touch sensor for user presence (PIN will be used, not UV)...")
+            let pinToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.makeCredential],
+                rpId: "example.com"
+            )
+
+            let params = CTAP2.MakeCredential.Parameters(
+                clientDataHash: Data(repeating: 0xCD, count: 32),
+                rp: WebAuthn.PublicKeyCredential.RPEntity(id: "example.com", name: "Example"),
+                user: WebAuthn.PublicKeyCredential.UserEntity(
+                    id: Data(repeating: 0x01, count: 32),
+                    name: "pin-user@example.com",
+                    displayName: "PIN User"
+                ),
+                pubKeyCredParams: [.es256],
+                rk: true
+            )
+
+            let credential = try await session.makeCredential(
+                parameters: params,
+                pinToken: pinToken
+            ).value
+
+            // Per CTAP 2.2 §6.1.1: valid pinUvAuthParam sets UV flag regardless of token type
+            #expect(credential.authenticatorData.flags.contains(.userPresent))
+            #expect(credential.authenticatorData.flags.contains(.userVerified))
+            print("✅ PIN works even with UV blocked (UP + UV flags set)")
+        }
+    }
+}
+
+// MARK: - Test Fixture
+
+/// Helper that enrolls a fingerprint and provides it to the test body
+private func withEnrolledFingerprint(
+    _ body: (CTAP2.Session, Data) async throws -> Void
+) async throws {
+    try await withCTAP2Session { session in
+        try #require(await CTAP2.BioEnrollment.isSupported(by: session), "Bio enrollment not supported")
+
+        let info = try await session.getInfo()
+        try #require(info.options.clientPin == true, "PIN not set")
+
+        // Get PIN token for bio enrollment management
+        let pinToken = try await session.getPinUVToken(
+            using: .pin(defaultTestPin),
+            permissions: [.bioEnrollment]
+        )
+        let bio = try await session.bioEnrollment(pinToken: pinToken)
+
+        // Clean up any existing enrollments
+        let existing = try await bio.enrollments.enumerate()
+        for template in existing {
+            try await bio.removeEnrollment(template.templateId)
+        }
+
+        // Enroll a fingerprint
+        var templateId: Data?
+        print("👆 Press fingerprint against the sensor to enroll...")
+        for try await sample in bio.enroll() {
+            switch sample {
+            case .waitingForUser:
+                print("👆 Touch the sensor...")
+            case .sample(let status, let remaining):
+                if status == .good {
+                    print("✅ \(remaining) more scans needed")
+                } else {
+                    print("⚠️  \(status)")
+                }
+            case .completed(let id, _):
+                templateId = id
+            }
+        }
+
+        let enrolledTemplateId = try #require(templateId, "Failed to enroll fingerprint")
+
+        #expect(try await bio.enrollments.enumerate().count == 1)
+        print("✅ Fingerprint enrolled successfully")
+
+        // Run the test body
+        try await body(session, enrolledTemplateId)
+
+        // Re-obtain PIN token for cleanup (test body may have invalidated the original token)
+        let cleanupToken = try await session.getPinUVToken(
+            using: .pin(defaultTestPin),
+            permissions: [.bioEnrollment]
+        )
+        let cleanupBio = try await session.bioEnrollment(pinToken: cleanupToken)
+
+        // Clean up
+        try await cleanupBio.removeEnrollment(enrolledTemplateId)
+        #expect(try await cleanupBio.enrollments.enumerate().isEmpty)
+        print("✅ Fingerprint removed")
+    }
+}

--- a/FullStackTests/Tests/CTAP2/BioUVTests.swift
+++ b/FullStackTests/Tests/CTAP2/BioUVTests.swift
@@ -44,7 +44,6 @@ struct BioUVTests {
                 rk: true
             )
 
-            print("👆 Touch enrolled fingerprint to create credential...")
             let credential = try await session.makeCredential(
                 parameters: params,
                 pinToken: uvToken
@@ -151,7 +150,7 @@ private func withEnrolledFingerprint(
 
         // Enroll a fingerprint
         var templateId: Data?
-        print("👆 Press fingerprint against the sensor to enroll...")
+        print("👆 Starting enrollment...")
         for try await sample in bio.enroll() {
             switch sample {
             case .waitingForUser:

--- a/FullStackTests/Tests/CTAP2/CredentialManagementTests.swift
+++ b/FullStackTests/Tests/CTAP2/CredentialManagementTests.swift
@@ -283,7 +283,7 @@ private func createTestCredential(_ session: CTAP2.Session) async throws {
         rp: testRp,
         user: testUser,
         pubKeyCredParams: [.es256],
-        options: .init(rk: true)
+        rk: true
     )
     print("👆 Touch YubiKey: creating test credential...")
     _ = try await session.makeCredential(parameters: params, pinToken: pinToken).value

--- a/FullStackTests/Tests/CTAP2/CredentialTests.swift
+++ b/FullStackTests/Tests/CTAP2/CredentialTests.swift
@@ -61,13 +61,16 @@ struct CTAP2FullStackTests {
                     displayName: "Non-RK User"
                 ),
                 pubKeyCredParams: [.es256],
-                options: .init(rk: false)
+                rk: false
             )
 
             print("👆 Touch the YubiKey to create a non-resident credential...")
             let nonRkCredential = try await session.makeCredential(parameters: nonRkParams).value
 
-            #expect(["packed", "none"].contains(nonRkCredential.format), "Expected packed or none format")
+            #expect(
+                ["packed", "none"].contains(nonRkCredential.attestationObject.format),
+                "Expected packed or none format"
+            )
             #expect(nonRkCredential.authenticatorData.attestedCredentialData != nil, "Missing attested credential data")
             print("✅ Non-resident credential created")
 
@@ -83,7 +86,7 @@ struct CTAP2FullStackTests {
                     displayName: "RK User"
                 ),
                 pubKeyCredParams: [.es256],
-                options: .init(rk: true)
+                rk: true
             )
 
             print("👆 Touch the YubiKey to create a resident credential...")
@@ -160,7 +163,8 @@ struct CTAP2FullStackTests {
                     name: "cancel-test@example.com",
                     displayName: "Cancel Test User"
                 ),
-                pubKeyCredParams: [.es256]
+                pubKeyCredParams: [.es256],
+                rk: true
             )
 
             print("DO NOT touch the YubiKey - operation will be cancelled...")

--- a/FullStackTests/Tests/CTAP2/EncryptedFieldsTests.swift
+++ b/FullStackTests/Tests/CTAP2/EncryptedFieldsTests.swift
@@ -167,7 +167,7 @@ struct EncryptedFieldsTests {
                     displayName: "Test"
                 ),
                 pubKeyCredParams: [.es256],
-                options: .init(rk: true)
+                rk: true
             )
             print("👆 Touch YubiKey: creating credential...")
             _ = try await session.makeCredential(parameters: params, pinToken: makeCredToken).value

--- a/FullStackTests/Tests/CTAP2/Extensions/CredBlobTests.swift
+++ b/FullStackTests/Tests/CTAP2/Extensions/CredBlobTests.swift
@@ -61,7 +61,7 @@ struct CredBlobFullStackTests {
                 ),
                 pubKeyCredParams: [.es256],
                 extensions: [try credBlob.makeCredential.input(blob: testBlob)],
-                options: .init(rk: true)
+                rk: true
             )
 
             print("👆 Touch YubiKey: creating credential with credBlob...")
@@ -137,7 +137,7 @@ struct CredBlobFullStackTests {
                 ),
                 pubKeyCredParams: [.es256],
                 extensions: [try credBlob.makeCredential.input(blob: testBlob)],
-                options: .init(rk: true)
+                rk: true
             )
 
             print("👆 Touch YubiKey: creating credential with credBlob...")

--- a/FullStackTests/Tests/CTAP2/Extensions/CredProtectTests.swift
+++ b/FullStackTests/Tests/CTAP2/Extensions/CredProtectTests.swift
@@ -51,7 +51,7 @@ struct CTAP2ExtensionFullStackTests {
                     displayName: "No Extension User"
                 ),
                 pubKeyCredParams: [.es256],
-                options: .init(rk: false)
+                rk: false
             )
             let noExtResponse = try await session.makeCredential(parameters: noExtParams).value
             #expect(credProtect1.output(from: noExtResponse) == nil)
@@ -70,7 +70,7 @@ struct CTAP2ExtensionFullStackTests {
                 ),
                 pubKeyCredParams: [.es256],
                 extensions: [credProtect1.input()],
-                options: .init(rk: false)
+                rk: false
             )
             let level1Response = try await session.makeCredential(parameters: level1Params).value
             #expect(credProtect1.output(from: level1Response) == .userVerificationOptional)
@@ -93,7 +93,7 @@ struct CTAP2ExtensionFullStackTests {
                 ),
                 pubKeyCredParams: [.es256],
                 extensions: [credProtect2.input()],
-                options: .init(rk: false)
+                rk: false
             )
             let level2Response = try await session.makeCredential(parameters: level2Params).value
             #expect(credProtect2.output(from: level2Response) == .userVerificationOptionalWithCredentialIDList)
@@ -128,7 +128,7 @@ struct CTAP2ExtensionFullStackTests {
                 ),
                 pubKeyCredParams: [.es256],
                 extensions: [credProtect3.input()],
-                options: .init(rk: true)
+                rk: true
             )
             let level3Response = try await session.makeCredential(parameters: level3Params, pinToken: pinToken).value
             #expect(credProtect3.output(from: level3Response) == .userVerificationRequired)
@@ -160,7 +160,7 @@ struct CTAP2ExtensionFullStackTests {
                 ),
                 pubKeyCredParams: [.es256],
                 extensions: [hmacSecretInput],
-                options: .init(rk: false)
+                rk: false
             )
 
             print("👆 Touch the YubiKey to create credential with hmac-secret...")
@@ -219,7 +219,7 @@ struct CTAP2ExtensionFullStackTests {
                 ),
                 pubKeyCredParams: [.es256],
                 extensions: [hmacSecretInput],
-                options: .init(rk: true)
+                rk: true
             )
 
             print("👆 Touch the YubiKey to create credential with hmac-secret-mc...")

--- a/FullStackTests/Tests/CTAP2/Extensions/LargeBlobsTests.swift
+++ b/FullStackTests/Tests/CTAP2/Extensions/LargeBlobsTests.swift
@@ -62,7 +62,7 @@ struct LargeBlobsFullStackTests {
                 ),
                 pubKeyCredParams: [.es256],
                 extensions: [largeBlobKey.makeCredential.input()],
-                options: .init(rk: true)
+                rk: true
             )
 
             print("👆 Touch YubiKey: creating credential with largeBlobKey...")
@@ -149,7 +149,7 @@ struct LargeBlobsFullStackTests {
                 ),
                 pubKeyCredParams: [.es256],
                 extensions: [largeBlobKey.makeCredential.input()],
-                options: .init(rk: true)
+                rk: true
             )
 
             print("👆 Touch YubiKey: creating credential...")
@@ -247,7 +247,7 @@ struct LargeBlobsFullStackTests {
                 ),
                 pubKeyCredParams: [.es256],
                 extensions: [largeBlobKey.makeCredential.input()],
-                options: .init(rk: true)
+                rk: true
             )
 
             print("👆 Touch YubiKey: creating first credential...")
@@ -280,7 +280,7 @@ struct LargeBlobsFullStackTests {
                 ),
                 pubKeyCredParams: [.es256],
                 extensions: [largeBlobKey.makeCredential.input()],
-                options: .init(rk: true)
+                rk: true
             )
 
             print("👆 Touch YubiKey: creating second credential...")

--- a/FullStackTests/Tests/CTAP2/Extensions/MinPinLengthTests.swift
+++ b/FullStackTests/Tests/CTAP2/Extensions/MinPinLengthTests.swift
@@ -68,7 +68,8 @@ struct MinPinLengthFullStackTests {
                     displayName: "MinPinLength Test User"
                 ),
                 pubKeyCredParams: [.es256],
-                extensions: [minPinLength.makeCredential.input()]
+                extensions: [minPinLength.makeCredential.input()],
+                rk: true
             )
 
             print("👆 Touch YubiKey: creating credential with minPinLength extension...")

--- a/FullStackTests/Tests/CTAP2/Extensions/PRFTests.swift
+++ b/FullStackTests/Tests/CTAP2/Extensions/PRFTests.swift
@@ -65,7 +65,7 @@ struct WebAuthnExtensionFullStackTests {
                 ),
                 pubKeyCredParams: [.es256],
                 extensions: [hmacSecretInput],
-                options: .init(rk: true)
+                rk: true
             )
 
             print("👆 Touch the YubiKey to create credential with PRF support...")
@@ -106,7 +106,7 @@ struct WebAuthnExtensionFullStackTests {
                 clientDataHash: clientDataHash,
                 allowList: [.init(id: credentialId)],
                 extensions: [prfInput1],
-                options: .init(up: true)
+                up: true
             )
 
             print("👆 Touch the YubiKey for PRF assertion (one secret)...")
@@ -147,7 +147,7 @@ struct WebAuthnExtensionFullStackTests {
                 clientDataHash: clientDataHash,
                 allowList: [.init(id: credentialId)],
                 extensions: [prfInput2],
-                options: .init(up: true)
+                up: true
             )
 
             print("👆 Touch the YubiKey for PRF assertion (two secrets, evalByCredential)...")
@@ -221,7 +221,7 @@ struct WebAuthnExtensionFullStackTests {
                 ),
                 pubKeyCredParams: [.es256],
                 extensions: [prfMcInput],
-                options: .init(rk: true)
+                rk: true
             )
 
             print("👆 Touch the YubiKey to create credential with PRF secrets...")
@@ -270,7 +270,7 @@ struct WebAuthnExtensionFullStackTests {
                 clientDataHash: clientDataHash,
                 allowList: [.init(id: credentialId)],
                 extensions: [prfGaInput],
-                options: .init(up: true)
+                up: true
             )
 
             print("👆 Touch the YubiKey for PRF assertion (verifying determinism)...")

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnHandler.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnHandler.swift
@@ -44,10 +44,6 @@ actor WebAuthnHandler {
             request.authenticatorSelection?.residentKey == "required"
             || request.authenticatorSelection?.residentKey == "preferred"
             || request.authenticatorSelection?.requireResidentKey == true
-        let options = CTAP2.MakeCredential.Parameters.Options(
-            rk: residentKeyRequired,
-            uv: request.authenticatorSelection?.userVerification == "required"
-        )
 
         let (activeSession, pinToken) = try await getPinTokenIfNeeded(
             session: session,
@@ -67,10 +63,16 @@ actor WebAuthnHandler {
             pubKeyCredParams: pubKeyParams,
             excludeList: excludeList,
             extensions: extState.inputs,
-            options: options
+            rk: residentKeyRequired,
+            uv: request.authenticatorSelection?.userVerification == "required" ? true : nil
         )
 
-        let response = try await session.makeCredential(parameters: params, pinToken: pinToken).value
+        let response =
+            if let pinToken {
+                try await session.makeCredential(parameters: params, pinToken: pinToken).value
+            } else {
+                try await session.makeCredential(parameters: params).value
+            }
         let extensionResults = try extractCreateExtensionResults(state: extState, response: response)
 
         let credentials = CredentialResponse(
@@ -93,10 +95,6 @@ actor WebAuthnHandler {
 
         let allowList = request.allowCredentials?.compactMap { $0.toDescriptor() }
 
-        let options = CTAP2.GetAssertion.Parameters.Options(
-            uv: request.userVerification == "required"
-        )
-
         let (activeSession, pinToken) = try await getPinTokenIfNeeded(
             session: session,
             permissions: permissionsForGetAssertion(request: request),
@@ -113,10 +111,15 @@ actor WebAuthnHandler {
             clientDataHash: clientDataHash,
             allowList: allowList,
             extensions: extState.inputs,
-            options: options
+            uv: request.userVerification == "required" ? true : nil
         )
 
-        let response = try await session.getAssertion(parameters: params, pinToken: pinToken).value
+        let response =
+            if let pinToken {
+                try await session.getAssertion(parameters: params, pinToken: pinToken).value
+            } else {
+                try await session.getAssertion(parameters: params).value
+            }
         let extensionResults = try await extractGetExtensionResults(
             state: extState,
             response: response,

--- a/YubiKit/YubiKit/FIDO/CTAP/BioEnrollment/BioEnrollment.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/BioEnrollment/BioEnrollment.swift
@@ -33,7 +33,7 @@ extension CTAP2.Session {
     /// - Throws: `CTAP2.SessionError.featureNotSupported` if bio enrollment is not supported.
     /// - SeeAlso: [CTAP2 authenticatorBioEnrollment](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorBioEnrollment)
     public func bioEnrollment(
-        token: CTAP2.ClientPin.Token
+        token: CTAP2.Token
     ) async throws(CTAP2.SessionError) -> CTAP2.BioEnrollment {
         guard try await CTAP2.BioEnrollment.isSupported(by: self) else {
             throw .featureNotSupported(source: .here())
@@ -55,12 +55,12 @@ extension CTAP2 {
     public struct BioEnrollment: Sendable {
 
         private let session: CTAP2.Session
-        private let token: CTAP2.ClientPin.Token
+        private let token: CTAP2.Token
         private let command: CTAP2.Command
 
         fileprivate init(
             session: CTAP2.Session,
-            token: CTAP2.ClientPin.Token,
+            token: CTAP2.Token,
             command: CTAP2.Command
         ) {
             self.session = session

--- a/YubiKit/YubiKit/FIDO/CTAP/BioEnrollment/BioEnrollment.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/BioEnrollment/BioEnrollment.swift
@@ -20,27 +20,27 @@ extension CTAP2.Session {
     /// Returns bio enrollment operations bound to a PIN/UV auth token.
     ///
     /// ```swift
-    /// let pinToken = try await session.getPinUVToken(
+    /// let token = try await session.getPinUVToken(
     ///     using: .pin("123456"),
     ///     permissions: [.bioEnrollment]
     /// )
-    /// let bio = try await session.bioEnrollment(pinToken: pinToken)
+    /// let bio = try await session.bioEnrollment(token: token)
     /// let sensor = try await bio.getFingerprintSensorInfo()
     /// ```
     ///
-    /// - Parameter pinToken: PIN/UV auth token with `bioEnrollment` permission.
+    /// - Parameter token: PIN/UV auth token with `bioEnrollment` permission.
     /// - Returns: BioEnrollment operations bound to the token.
     /// - Throws: `CTAP2.SessionError.featureNotSupported` if bio enrollment is not supported.
     /// - SeeAlso: [CTAP2 authenticatorBioEnrollment](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorBioEnrollment)
     public func bioEnrollment(
-        pinToken: CTAP2.ClientPin.Token
+        token: CTAP2.ClientPin.Token
     ) async throws(CTAP2.SessionError) -> CTAP2.BioEnrollment {
         guard try await CTAP2.BioEnrollment.isSupported(by: self) else {
             throw .featureNotSupported(source: .here())
         }
         let command = try await CTAP2.BioEnrollment.commandCode(for: self)
         try await CTAP2.BioEnrollment.verifyFingerprintModality(session: self, command: command)
-        return CTAP2.BioEnrollment(session: self, pinToken: pinToken, command: command)
+        return CTAP2.BioEnrollment(session: self, token: token, command: command)
     }
 }
 
@@ -55,16 +55,16 @@ extension CTAP2 {
     public struct BioEnrollment: Sendable {
 
         private let session: CTAP2.Session
-        private let pinToken: CTAP2.ClientPin.Token
+        private let token: CTAP2.ClientPin.Token
         private let command: CTAP2.Command
 
         fileprivate init(
             session: CTAP2.Session,
-            pinToken: CTAP2.ClientPin.Token,
+            token: CTAP2.ClientPin.Token,
             command: CTAP2.Command
         ) {
             self.session = session
-            self.pinToken = pinToken
+            self.token = token
             self.command = command
         }
 
@@ -269,8 +269,8 @@ extension CTAP2 {
             return RequestParameters(
                 subCommand: subcommand,
                 subCommandParams: params,
-                pinUVAuthProtocol: pinToken.protocolVersion,
-                pinUVAuthParam: pinToken.authenticate(message: message)
+                pinUVAuthProtocol: token.protocolVersion,
+                pinUVAuthParam: token.authenticate(message: message)
             )
         }
     }

--- a/YubiKit/YubiKit/FIDO/CTAP/BioEnrollment/BioEnrollment.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/BioEnrollment/BioEnrollment.swift
@@ -328,8 +328,10 @@ extension CTAP2.BioEnrollment {
                         continuation: continuation
                     )
                 }
-                continuation.onTermination = { _ in
-                    task.cancel()
+                continuation.onTermination = { termination in
+                    if case .cancelled = termination {
+                        task.cancel()
+                    }
                 }
             }
         }

--- a/YubiKit/YubiKit/FIDO/CTAP/BioEnrollment/BioEnrollment.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/BioEnrollment/BioEnrollment.swift
@@ -1,0 +1,518 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+// MARK: - Session BioEnrollment Accessor
+
+extension CTAP2.Session {
+    /// Returns bio enrollment operations bound to a PIN/UV auth token.
+    ///
+    /// ```swift
+    /// let pinToken = try await session.getPinUVToken(
+    ///     using: .pin("123456"),
+    ///     permissions: [.bioEnrollment]
+    /// )
+    /// let bio = try await session.bioEnrollment(pinToken: pinToken)
+    /// let sensor = try await bio.getFingerprintSensorInfo()
+    /// ```
+    ///
+    /// - Parameter pinToken: PIN/UV auth token with `bioEnrollment` permission.
+    /// - Returns: BioEnrollment operations bound to the token.
+    /// - Throws: `CTAP2.SessionError.featureNotSupported` if bio enrollment is not supported.
+    /// - SeeAlso: [CTAP2 authenticatorBioEnrollment](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorBioEnrollment)
+    public func bioEnrollment(
+        pinToken: CTAP2.ClientPin.Token
+    ) async throws(CTAP2.SessionError) -> CTAP2.BioEnrollment {
+        guard try await CTAP2.BioEnrollment.isSupported(by: self) else {
+            throw .featureNotSupported(source: .here())
+        }
+        let command = try await CTAP2.BioEnrollment.commandCode(for: self)
+        try await CTAP2.BioEnrollment.verifyFingerprintModality(session: self, command: command)
+        return CTAP2.BioEnrollment(session: self, pinToken: pinToken, command: command)
+    }
+}
+
+// MARK: - BioEnrollment
+
+extension CTAP2 {
+    /// Bio enrollment operations bound to a PIN/UV auth token.
+    ///
+    /// Allows managing fingerprint enrollments on biometric authenticators (e.g., YubiKey Bio).
+    ///
+    /// - SeeAlso: [CTAP2 authenticatorBioEnrollment](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorBioEnrollment)
+    public struct BioEnrollment: Sendable {
+
+        private let session: CTAP2.Session
+        private let pinToken: CTAP2.ClientPin.Token
+        private let command: CTAP2.Command
+
+        fileprivate init(
+            session: CTAP2.Session,
+            pinToken: CTAP2.ClientPin.Token,
+            command: CTAP2.Command
+        ) {
+            self.session = session
+            self.pinToken = pinToken
+            self.command = command
+        }
+
+        // MARK: - Feature Detection
+
+        /// Checks if the authenticator supports bio enrollment.
+        public static func isSupported(by session: CTAP2.Session) async throws(CTAP2.SessionError) -> Bool {
+            let info = try await session.cachedInfo
+            return info.options.supportsBioEnroll
+                || (info.versions.contains(.fido2_1Pre)
+                    && info.options.supportsUserVerificationMgmtPreview)
+        }
+
+        // MARK: - Sensor Info
+
+        /// Gets fingerprint sensor information.
+        ///
+        /// - SeeAlso: [Get fingerprint sensor info](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#getFingerprintSensorInfo)
+        public func getFingerprintSensorInfo() async throws(CTAP2.SessionError) -> FingerprintSensorInfo {
+            try await executeNoAuth(subcommand: .getFingerprintSensorInfo)
+        }
+
+        // MARK: - Enrollment
+
+        /// Begins a new fingerprint enrollment and returns an async sequence of samples.
+        ///
+        /// Use this for a simplified enrollment loop:
+        /// ```swift
+        /// for try await sample in bio.enroll(timeout: 10000) {
+        ///     switch sample {
+        ///     case .waitingForUser:
+        ///         print("Touch the fingerprint sensor...")
+        ///     case .sample(let status, let remaining):
+        ///         print("Status: \(status), \(remaining) remaining")
+        ///     case .completed(let templateId, let status):
+        ///         print("Enrollment complete: \(templateId), status: \(status)")
+        ///     }
+        /// }
+        /// ```
+        ///
+        /// - Parameter timeout: Optional timeout in milliseconds for each fingerprint capture.
+        /// - Returns: An async sequence that yields samples until enrollment is complete.
+        /// - SeeAlso: [Enrolling Fingerprint](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#enrollingFingerprint)
+        public func enroll(timeout: UInt? = nil) -> EnrollFingerprint {
+            EnrollFingerprint(bioEnrollment: self, timeout: timeout)
+        }
+
+        /// Cancels the current enrollment.
+        ///
+        /// - SeeAlso: [Cancel Current Enrollment](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#cancelCurrentEnrollment)
+        public func cancelEnrollment() async throws(CTAP2.SessionError) {
+            try await executeNoAuth(subcommand: .cancelCurrentEnrollment) as Void
+        }
+
+        // MARK: - Template Management
+
+        /// An async sequence of enrolled fingerprint templates.
+        ///
+        /// - SeeAlso: [Enumerate Enrollments](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#enumerateEnrollments)
+        public var enrollments: EnrollmentSequence {
+            EnrollmentSequence(bioEnrollment: self)
+        }
+
+        /// Sets a friendly name for a fingerprint template.
+        ///
+        /// - Parameters:
+        ///   - name: The friendly name to set (e.g., "Right Index").
+        ///   - templateId: The template to rename.
+        /// - SeeAlso: [Set Friendly Name](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#setFriendlyName)
+        public func setFriendlyName(
+            _ name: String,
+            for templateId: Data
+        ) async throws(CTAP2.SessionError) {
+            let params: [UInt8: CBOR.Value] = [
+                SubcommandParam.templateId.rawValue: templateId.cbor(),
+                SubcommandParam.templateFriendlyName.rawValue: name.cbor(),
+            ]
+            try await execute(subcommand: .setFriendlyName, params: params) as Void
+        }
+
+        /// Removes a fingerprint enrollment.
+        ///
+        /// - Parameter templateId: The template to remove.
+        /// - SeeAlso: [Remove Enrollment](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#removeEnrollment)
+        public func removeEnrollment(
+            _ templateId: Data
+        ) async throws(CTAP2.SessionError) {
+            let params: [UInt8: CBOR.Value] = [
+                SubcommandParam.templateId.rawValue: templateId.cbor()
+            ]
+            try await execute(subcommand: .removeEnrollment, params: params) as Void
+        }
+
+        // MARK: - Private Helpers
+
+        fileprivate static func commandCode(
+            for session: CTAP2.Session
+        ) async throws(CTAP2.SessionError) -> CTAP2.Command {
+            let info = try await session.cachedInfo
+            return info.options.supportsBioEnroll ? .bioEnrollment : .bioEnrollmentPreview
+        }
+
+        fileprivate static func verifyFingerprintModality(
+            session: CTAP2.Session,
+            command: CTAP2.Command
+        ) async throws(CTAP2.SessionError) {
+            let request: CBOR.Value = .map([.int(0x06): .boolean(true)])  // getModality
+            let response: CBOR.Value = try await session.interface.send(
+                command: command,
+                payload: request
+            ).value
+            let modality = response.mapValue?[.int(0x01)]?.uint64Value
+            guard modality == 0x01 else {  // fingerprint
+                throw .featureNotSupported(source: .here())
+            }
+        }
+
+        private func enrollBegin(
+            timeout: UInt? = nil
+        ) async -> CTAP2.StatusStream<EnrollBeginResult> {
+            var params: [UInt8: CBOR.Value]?
+            if let timeout {
+                params = [SubcommandParam.timeoutMilliseconds.rawValue: timeout.cbor()]
+            }
+            return await executeStream(subcommand: .enrollBegin, params: params)
+        }
+
+        private func enrollCaptureNext(
+            templateId: Data,
+            timeout: UInt? = nil
+        ) async -> CTAP2.StatusStream<CaptureResult> {
+            var params: [UInt8: CBOR.Value] = [
+                SubcommandParam.templateId.rawValue: templateId.cbor()
+            ]
+            if let timeout {
+                params[SubcommandParam.timeoutMilliseconds.rawValue] = timeout.cbor()
+            }
+            return await executeStream(subcommand: .enrollCaptureNextSample, params: params)
+        }
+
+        private func fetchEnrollments() async throws(CTAP2.SessionError) -> [TemplateInfo] {
+            do {
+                let response: EnumerateEnrollmentsResponse =
+                    try await execute(subcommand: .enumerateEnrollments)
+                return response.templateInfos
+            } catch .ctapError(.invalidOption, _) {
+                return []
+            }
+        }
+
+        private func execute<R: CBOR.Decodable & Sendable>(
+            subcommand: Subcommand,
+            params: [UInt8: CBOR.Value]? = nil
+        ) async throws(CTAP2.SessionError) -> R {
+            let parameters = authParameters(subcommand: subcommand, params: params)
+            return try await session.interface.send(command: command, payload: parameters).value
+        }
+
+        private func execute(
+            subcommand: Subcommand,
+            params: [UInt8: CBOR.Value]? = nil
+        ) async throws(CTAP2.SessionError) {
+            let parameters = authParameters(subcommand: subcommand, params: params)
+            try await session.interface.send(command: command, payload: parameters).value
+        }
+
+        private func executeStream<R: CBOR.Decodable & Sendable>(
+            subcommand: Subcommand,
+            params: [UInt8: CBOR.Value]? = nil
+        ) async -> CTAP2.StatusStream<R> {
+            let parameters = authParameters(subcommand: subcommand, params: params)
+            return await session.interface.send(command: command, payload: parameters)
+        }
+
+        private func executeNoAuth<R: CBOR.Decodable & Sendable>(
+            subcommand: Subcommand
+        ) async throws(CTAP2.SessionError) -> R {
+            try await session.interface.send(
+                command: command,
+                payload: RequestParametersNoAuth(subCommand: subcommand)
+            ).value
+        }
+
+        private func executeNoAuth(
+            subcommand: Subcommand
+        ) async throws(CTAP2.SessionError) {
+            try await session.interface.send(
+                command: command,
+                payload: RequestParametersNoAuth(subCommand: subcommand)
+            ).value
+        }
+
+        private func authParameters(
+            subcommand: Subcommand,
+            params: [UInt8: CBOR.Value]?
+        ) -> RequestParameters {
+            // Auth message: modality (0x01 = fingerprint) || subCommand || CBOR(params)
+            var message = Data([0x01, subcommand.rawValue])
+            if let params {
+                message.append(params.cbor().encode())
+            }
+            return RequestParameters(
+                subCommand: subcommand,
+                subCommandParams: params,
+                pinUVAuthProtocol: pinToken.protocolVersion,
+                pinUVAuthParam: pinToken.authenticate(message: message)
+            )
+        }
+    }
+}
+
+// MARK: - EnrollFingerprint
+
+extension CTAP2.BioEnrollment {
+
+    /// A sample captured during fingerprint enrollment.
+    public enum EnrollmentSample: Sendable {
+        /// The authenticator is waiting for a finger touch.
+        case waitingForUser
+        /// A sample was captured (good or bad).
+        case sample(status: SampleStatus, remaining: UInt)
+        /// Enrollment completed successfully.
+        case completed(templateId: Data, status: SampleStatus)
+    }
+
+    /// An async sequence that yields enrollment samples until complete.
+    public struct EnrollFingerprint: AsyncSequence, Sendable {
+        public typealias Element = EnrollmentSample
+
+        public func makeAsyncIterator() -> Iterator {
+            Iterator(stream.makeAsyncIterator())
+        }
+
+        public struct Iterator: AsyncIteratorProtocol {
+            private var iterator:
+                AsyncStream<
+                    Result<EnrollmentSample, CTAP2.SessionError>
+                >.AsyncIterator
+
+            fileprivate init(
+                _ iterator: AsyncStream<Result<EnrollmentSample, CTAP2.SessionError>>.AsyncIterator
+            ) {
+                self.iterator = iterator
+            }
+
+            public mutating func next() async throws(CTAP2.SessionError) -> EnrollmentSample? {
+                guard let result = await iterator.next() else { return nil }
+                switch result {
+                case .success(let sample): return sample
+                case .failure(let error): throw error
+                }
+            }
+        }
+
+        fileprivate init(bioEnrollment: CTAP2.BioEnrollment, timeout: UInt?) {
+            self.stream = AsyncStream { continuation in
+                let task = Task {
+                    await Self.run(
+                        bioEnrollment: bioEnrollment,
+                        timeout: timeout,
+                        continuation: continuation
+                    )
+                }
+                continuation.onTermination = { _ in
+                    task.cancel()
+                }
+            }
+        }
+
+        private let stream: AsyncStream<Result<EnrollmentSample, CTAP2.SessionError>>
+
+        private static func run(
+            bioEnrollment: CTAP2.BioEnrollment,
+            timeout: UInt?,
+            continuation: AsyncStream<Result<EnrollmentSample, CTAP2.SessionError>>.Continuation
+        ) async {
+            var completed = false
+            do {
+                completed = try await runEnrollment(
+                    bioEnrollment: bioEnrollment,
+                    timeout: timeout,
+                    continuation: continuation
+                )
+            } catch {
+                continuation.yield(.failure(error))
+            }
+            continuation.finish()
+            if !completed {
+                try? await bioEnrollment.cancelEnrollment()
+            }
+        }
+
+        /// Returns `true` when enrollment completed successfully, `false` if interrupted or cancelled.
+        private static func runEnrollment(
+            bioEnrollment: CTAP2.BioEnrollment,
+            timeout: UInt?,
+            continuation: AsyncStream<Result<EnrollmentSample, CTAP2.SessionError>>.Continuation
+        ) async throws(CTAP2.SessionError) -> Bool {
+            // First capture - enrollBegin
+            var templateId: Data?
+            for try await status in await bioEnrollment.enrollBegin(timeout: timeout) {
+                switch status {
+                case .processing:
+                    break
+                case .waitingForUser:
+                    continuation.yield(.success(.waitingForUser))
+                case .finished(let result):
+                    templateId = result.templateId
+                    let sample = enrollmentSample(
+                        templateId: result.templateId,
+                        status: result.sampleStatus,
+                        remaining: result.remainingSamples
+                    )
+                    continuation.yield(.success(sample))
+                    if result.remainingSamples == 0 { return true }
+                }
+            }
+
+            guard let templateId else { return false }
+
+            // Subsequent captures - enrollCaptureNext
+            while !Task.isCancelled {
+                let stream = await bioEnrollment.enrollCaptureNext(
+                    templateId: templateId,
+                    timeout: timeout
+                )
+                for try await status in stream {
+                    switch status {
+                    case .processing:
+                        break
+                    case .waitingForUser:
+                        continuation.yield(.success(.waitingForUser))
+                    case .finished(let result):
+                        let sample = enrollmentSample(
+                            templateId: templateId,
+                            status: result.sampleStatus,
+                            remaining: result.remainingSamples
+                        )
+                        continuation.yield(.success(sample))
+                        if result.remainingSamples == 0 { return true }
+                    }
+                }
+            }
+            return false
+        }
+
+        private static func enrollmentSample(
+            templateId: Data,
+            status: SampleStatus,
+            remaining: UInt
+        ) -> EnrollmentSample {
+            if remaining == 0 {
+                return .completed(templateId: templateId, status: status)
+            }
+            return .sample(status: status, remaining: remaining)
+        }
+    }
+}
+
+// MARK: - EnrollmentSequence
+
+extension CTAP2.BioEnrollment {
+
+    public struct EnrollmentSequence: AsyncSequence, Sendable {
+        public typealias Element = TemplateInfo
+
+        fileprivate let bioEnrollment: CTAP2.BioEnrollment
+
+        /// Collects all enrolled templates into an array.
+        public func enumerate() async throws(CTAP2.SessionError) -> [TemplateInfo] {
+            try await bioEnrollment.fetchEnrollments()
+        }
+
+        public func makeAsyncIterator() -> Iterator {
+            Iterator(bioEnrollment: bioEnrollment)
+        }
+
+        public struct Iterator: AsyncIteratorProtocol {
+            private let bioEnrollment: CTAP2.BioEnrollment
+            private var items: [TemplateInfo]?
+            private var index = 0
+
+            fileprivate init(bioEnrollment: CTAP2.BioEnrollment) {
+                self.bioEnrollment = bioEnrollment
+            }
+
+            public mutating func next() async throws(CTAP2.SessionError) -> TemplateInfo? {
+                if items == nil { items = try await bioEnrollment.fetchEnrollments() }
+                guard let items, index < items.count else { return nil }
+                defer { index += 1 }
+                return items[index]
+            }
+        }
+    }
+}
+
+// MARK: - Private Wire Types
+
+extension CTAP2.BioEnrollment {
+    private enum Subcommand: UInt8, Sendable {
+        case enrollBegin = 0x01
+        case enrollCaptureNextSample = 0x02
+        case cancelCurrentEnrollment = 0x03
+        case enumerateEnrollments = 0x04
+        case setFriendlyName = 0x05
+        case removeEnrollment = 0x06
+        case getFingerprintSensorInfo = 0x07
+    }
+
+    private enum SubcommandParam: UInt8, Sendable {
+        case templateId = 0x01
+        case templateFriendlyName = 0x02
+        case timeoutMilliseconds = 0x03
+    }
+
+    private struct RequestParameters: Sendable, CBOR.Encodable {
+        let subCommand: Subcommand
+        let subCommandParams: [UInt8: CBOR.Value]?
+        let pinUVAuthProtocol: CTAP2.ClientPin.ProtocolVersion
+        let pinUVAuthParam: Data
+
+        func cbor() -> CBOR.Value {
+            var map: [CBOR.Value: CBOR.Value] = [:]
+            map[.int(0x01)] = .int(0x01)  // modality: fingerprint
+            map[.int(0x02)] = .int(Int(subCommand.rawValue))
+            if let params = subCommandParams, !params.isEmpty {
+                var paramsMap: [CBOR.Value: CBOR.Value] = [:]
+                for (key, value) in params {
+                    paramsMap[.int(Int(key))] = value
+                }
+                map[.int(0x03)] = .map(paramsMap)
+            }
+            map[.int(0x04)] = pinUVAuthProtocol.cbor()
+            map[.int(0x05)] = pinUVAuthParam.cbor()
+            return .map(map)
+        }
+    }
+
+    private struct RequestParametersNoAuth: Sendable, CBOR.Encodable {
+        let subCommand: Subcommand
+
+        func cbor() -> CBOR.Value {
+            let map: [CBOR.Value: CBOR.Value] = [
+                .int(0x01): .int(0x01),  // modality: fingerprint
+                .int(0x02): .int(Int(subCommand.rawValue)),
+            ]
+            return .map(map)
+        }
+    }
+
+}

--- a/YubiKit/YubiKit/FIDO/CTAP/BioEnrollment/BioEnrollmentTypes+CBOR.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/BioEnrollment/BioEnrollmentTypes+CBOR.swift
@@ -1,0 +1,109 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+// MARK: - Response Keys
+
+extension CTAP2.BioEnrollment {
+    fileprivate enum ResponseKey: Int {
+        case fingerprintKind = 0x02
+        case maxCaptureSamplesRequired = 0x03
+        case templateId = 0x04
+        case lastEnrollSampleStatus = 0x05
+        case remainingSamples = 0x06
+        case templateInfos = 0x07
+        case maxTemplateFriendlyName = 0x08
+    }
+
+    fileprivate enum TemplateInfoKey: Int {
+        case templateId = 0x01
+        case templateFriendlyName = 0x02
+    }
+}
+
+// MARK: - FingerprintSensorInfo + CBOR
+
+extension CTAP2.BioEnrollment.FingerprintSensorInfo: CBOR.Decodable {
+    init?(cbor: CBOR.Value) {
+        guard let map = cbor.mapValue else { return nil }
+        typealias Key = CTAP2.BioEnrollment.ResponseKey
+        guard
+            let kindRaw = map[.int(Key.fingerprintKind.rawValue)]?.uint64Value,
+            let maxSamples = map[.int(Key.maxCaptureSamplesRequired.rawValue)]?.uint64Value
+        else { return nil }
+        self.init(
+            fingerprintKind: .from(UInt8(kindRaw)),
+            maxCaptureSamplesRequired: UInt(maxSamples),
+            maxTemplateFriendlyName: map[.int(Key.maxTemplateFriendlyName.rawValue)]?.uint64Value
+                .map { UInt($0) }
+        )
+    }
+}
+
+// MARK: - EnrollBeginResult + CBOR
+
+extension CTAP2.BioEnrollment.EnrollBeginResult: CBOR.Decodable {
+    init?(cbor: CBOR.Value) {
+        guard let map = cbor.mapValue else { return nil }
+        typealias Key = CTAP2.BioEnrollment.ResponseKey
+        guard
+            let templateId = map[.int(Key.templateId.rawValue)]?.dataValue,
+            let statusRaw = map[.int(Key.lastEnrollSampleStatus.rawValue)]?.uint64Value,
+            let remaining = map[.int(Key.remainingSamples.rawValue)]?.uint64Value
+        else { return nil }
+        let sampleStatus = CTAP2.BioEnrollment.SampleStatus.from(UInt8(statusRaw))
+        self.init(templateId: templateId, sampleStatus: sampleStatus, remainingSamples: UInt(remaining))
+    }
+}
+
+// MARK: - CaptureResult + CBOR
+
+extension CTAP2.BioEnrollment.CaptureResult: CBOR.Decodable {
+    init?(cbor: CBOR.Value) {
+        guard let map = cbor.mapValue else { return nil }
+        typealias Key = CTAP2.BioEnrollment.ResponseKey
+        guard
+            let statusRaw = map[.int(Key.lastEnrollSampleStatus.rawValue)]?.uint64Value,
+            let remaining = map[.int(Key.remainingSamples.rawValue)]?.uint64Value
+        else { return nil }
+        let sampleStatus = CTAP2.BioEnrollment.SampleStatus.from(UInt8(statusRaw))
+        self.init(sampleStatus: sampleStatus, remainingSamples: UInt(remaining))
+    }
+}
+
+// MARK: - TemplateInfo + CBOR
+
+extension CTAP2.BioEnrollment.TemplateInfo: CBOR.Decodable {
+    init?(cbor: CBOR.Value) {
+        guard let map = cbor.mapValue else { return nil }
+        typealias Key = CTAP2.BioEnrollment.TemplateInfoKey
+        guard let templateId = map[.int(Key.templateId.rawValue)]?.dataValue else { return nil }
+        self.init(
+            templateId: templateId,
+            friendlyName: map[.int(Key.templateFriendlyName.rawValue)]?.stringValue
+        )
+    }
+}
+
+// MARK: - EnumerateEnrollmentsResponse + CBOR
+
+extension CTAP2.BioEnrollment.EnumerateEnrollmentsResponse: CBOR.Decodable {
+    init?(cbor: CBOR.Value) {
+        guard let map = cbor.mapValue else { return nil }
+        typealias Key = CTAP2.BioEnrollment.ResponseKey
+        guard let infosArray = map[.int(Key.templateInfos.rawValue)]?.arrayValue else { return nil }
+        self.init(templateInfos: infosArray.compactMap { $0.cborDecoded() })
+    }
+}

--- a/YubiKit/YubiKit/FIDO/CTAP/BioEnrollment/BioEnrollmentTypes.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/BioEnrollment/BioEnrollmentTypes.swift
@@ -1,0 +1,147 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+// MARK: - Public Types
+
+extension CTAP2.BioEnrollment {
+
+    /// Information about the fingerprint sensor hardware.
+    public struct FingerprintSensorInfo: Sendable {
+        /// The type of fingerprint sensor.
+        public let fingerprintKind: FingerprintKind
+
+        /// Maximum number of good fingerprint samples required for enrollment.
+        public let maxCaptureSamplesRequired: UInt
+
+        /// Maximum length of a template friendly name in bytes, if supported.
+        public let maxTemplateFriendlyName: UInt?
+
+        internal init(
+            fingerprintKind: FingerprintKind,
+            maxCaptureSamplesRequired: UInt,
+            maxTemplateFriendlyName: UInt?
+        ) {
+            self.fingerprintKind = fingerprintKind
+            self.maxCaptureSamplesRequired = maxCaptureSamplesRequired
+            self.maxTemplateFriendlyName = maxTemplateFriendlyName
+        }
+    }
+
+    /// The type of fingerprint sensor.
+    public enum FingerprintKind: Sendable, Equatable {
+        /// Touch-type sensor (place finger and hold).
+        case touch
+        /// Swipe-type sensor (swipe finger across).
+        case swipe
+        /// Unrecognized sensor type.
+        case other(UInt8)
+
+        internal static func from(_ rawValue: UInt8) -> FingerprintKind {
+            switch rawValue {
+            case 1: return .touch
+            case 2: return .swipe
+            default: return .other(rawValue)
+            }
+        }
+    }
+
+    /// Feedback status for a fingerprint capture sample.
+    public enum SampleStatus: Sendable, Equatable {
+        /// Good fingerprint capture.
+        case good
+        /// Fingerprint was too high.
+        case tooHigh
+        /// Fingerprint was too low.
+        case tooLow
+        /// Fingerprint was too left.
+        case tooLeft
+        /// Fingerprint was too right.
+        case tooRight
+        /// Finger moved too fast.
+        case tooFast
+        /// Finger moved too slow.
+        case tooSlow
+        /// Fingerprint image was poor quality.
+        case poorQuality
+        /// Fingerprint was too skewed.
+        case tooSkewed
+        /// Fingerprint was too short (swipe sensor).
+        case tooShort
+        /// Merge failure of the capture.
+        case mergeFailure
+        /// Fingerprint already exists in database.
+        case exists
+        /// No user activity detected on the sensor.
+        case noUserActivity
+        /// No user presence transition detected.
+        case noUserPresenceTransition
+        /// Unrecognized status code.
+        case other(UInt8)
+
+        internal static func from(_ rawValue: UInt8) -> SampleStatus {
+            switch rawValue {
+            case 0x00: return .good
+            case 0x01: return .tooHigh
+            case 0x02: return .tooLow
+            case 0x03: return .tooLeft
+            case 0x04: return .tooRight
+            case 0x05: return .tooFast
+            case 0x06: return .tooSlow
+            case 0x07: return .poorQuality
+            case 0x08: return .tooSkewed
+            case 0x09: return .tooShort
+            case 0x0A: return .mergeFailure
+            case 0x0B: return .exists
+            case 0x0D: return .noUserActivity
+            case 0x0E: return .noUserPresenceTransition
+            default: return .other(rawValue)
+            }
+        }
+    }
+
+    /// Information about an enrolled fingerprint template.
+    public struct TemplateInfo: Sendable {
+        /// The template identifier.
+        public let templateId: Data
+
+        /// The user-assigned friendly name, if set.
+        public let friendlyName: String?
+
+        internal init(templateId: Data, friendlyName: String?) {
+            self.templateId = templateId
+            self.friendlyName = friendlyName
+        }
+    }
+}
+
+// MARK: - Internal Types
+
+extension CTAP2.BioEnrollment {
+    struct EnrollBeginResult: Sendable {
+        let templateId: Data
+        let sampleStatus: SampleStatus
+        let remainingSamples: UInt
+    }
+
+    struct CaptureResult: Sendable {
+        let sampleStatus: SampleStatus
+        let remainingSamples: UInt
+    }
+
+    struct EnumerateEnrollmentsResponse: Sendable {
+        let templateInfos: [TemplateInfo]
+    }
+}

--- a/YubiKit/YubiKit/FIDO/CTAP/CTAP2.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/CTAP2.swift
@@ -107,7 +107,7 @@ public enum CTAP2 {
     /// specific failure conditions during authenticator operations.
     ///
     /// - SeeAlso: [CTAP 2.2 Status Codes](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#error-responses)
-    public enum Error: Swift.Error, Sendable {
+    public enum Error: Swift.Error, Sendable, Equatable {
         /// The command is not a valid CTAP command.
         case invalidCommand
         /// The command included an invalid parameter.
@@ -288,7 +288,7 @@ public enum CTAP2 {
     /// These errors indicate problems at the HID transport level (as opposed to CTAP2 protocol-level errors).
     ///
     /// - SeeAlso: [CTAP 2.2 CTAPHID_ERROR](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#usb-hid-error)
-    public enum HIDError: Swift.Error, Sendable {
+    public enum HIDError: Swift.Error, Sendable, Equatable {
         /// The command in the request is invalid.
         case invalidCmd
         /// The parameter(s) in the request is invalid.

--- a/YubiKit/YubiKit/FIDO/CTAP/ClientPIN/Types.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/ClientPIN/Types.swift
@@ -14,6 +14,36 @@
 
 import Foundation
 
+// MARK: - Token
+
+extension CTAP2 {
+    /// A PIN/UV auth token for authenticating CTAP2 operations.
+    ///
+    /// Obtain via ``CTAP2/Session/getPinUVToken(using:permissions:rpId:protocol:)``, then pass it to
+    /// operations like ``CTAP2/Session/makeCredential(parameters:token:)``
+    /// and ``CTAP2/Session/getAssertion(parameters:token:)``.
+    public struct Token: Sendable {
+        /// The decrypted token data.
+        private let tokenData: Data
+
+        /// The PIN/UV auth protocol version used to obtain this token.
+        public let protocolVersion: ClientPin.ProtocolVersion
+
+        internal init(token: Data, protocolVersion: ClientPin.ProtocolVersion) {
+            self.tokenData = token
+            self.protocolVersion = protocolVersion
+        }
+
+        func authenticate(message: Data) -> Data {
+            protocolVersion.authenticate(key: tokenData, message: message)
+        }
+
+        internal func deriveKey(info: String) -> Data {
+            Crypto.KDF.hkdf(tokenData, salt: Data(count: 32), info: info, outputLength: 16)
+        }
+    }
+}
+
 // MARK: - ClientPin Types
 
 extension CTAP2.ClientPin {
@@ -39,31 +69,5 @@ extension CTAP2.ClientPin {
 
         /// Verify using built-in user verification (e.g., fingerprint on YubiKey Bio).
         case uv
-    }
-
-    /// A PIN/UV auth token for authenticating CTAP2 operations.
-    ///
-    /// Obtain via ``CTAP2/Session/getPinUVToken(using:permissions:rpId:protocol:)``, then pass it to
-    /// operations like ``CTAP2/Session/makeCredential(parameters:token:)``
-    /// and ``CTAP2/Session/getAssertion(parameters:token:)``.
-    public struct Token: Sendable {
-        /// The decrypted PIN token.
-        private let token: Data
-
-        /// The PIN/UV auth protocol version used to obtain this token.
-        public let protocolVersion: ProtocolVersion
-
-        internal init(token: Data, protocolVersion: ProtocolVersion) {
-            self.token = token
-            self.protocolVersion = protocolVersion
-        }
-
-        func authenticate(message: Data) -> Data {
-            protocolVersion.authenticate(key: token, message: message)
-        }
-
-        internal func deriveKey(info: String) -> Data {
-            Crypto.KDF.hkdf(token, salt: Data(count: 32), info: info, outputLength: 16)
-        }
     }
 }

--- a/YubiKit/YubiKit/FIDO/CTAP/ClientPIN/Types.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/ClientPIN/Types.swift
@@ -44,8 +44,8 @@ extension CTAP2.ClientPin {
     /// A PIN/UV auth token for authenticating CTAP2 operations.
     ///
     /// Obtain via ``CTAP2/Session/getPinUVToken(using:permissions:rpId:protocol:)``, then pass it to
-    /// operations like ``CTAP2/Session/makeCredential(parameters:pinToken:)``
-    /// and ``CTAP2/Session/getAssertion(parameters:pinToken:)``.
+    /// operations like ``CTAP2/Session/makeCredential(parameters:token:)``
+    /// and ``CTAP2/Session/getAssertion(parameters:token:)``.
     public struct Token: Sendable {
         /// The decrypted PIN token.
         private let token: Data

--- a/YubiKit/YubiKit/FIDO/CTAP/ClientPIN/Types.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/ClientPIN/Types.swift
@@ -41,10 +41,10 @@ extension CTAP2.ClientPin {
         case uv
     }
 
-    /// A PIN/UV auth token obtained from the authenticator for authenticating CTAP operations.
+    /// A PIN/UV auth token for authenticating CTAP2 operations.
     ///
-    /// Use ``CTAP2/Session/getPinUVToken(using:permissions:rpId:protocol:)`` to obtain a token,
-    /// then pass it to operations like ``CTAP2/Session/makeCredential(parameters:pinToken:)``
+    /// Obtain via ``CTAP2/Session/getPinUVToken(using:permissions:rpId:protocol:)``, then pass it to
+    /// operations like ``CTAP2/Session/makeCredential(parameters:pinToken:)``
     /// and ``CTAP2/Session/getAssertion(parameters:pinToken:)``.
     public struct Token: Sendable {
         /// The decrypted PIN token.
@@ -58,17 +58,10 @@ extension CTAP2.ClientPin {
             self.protocolVersion = protocolVersion
         }
 
-        /// Compute the pinUVAuthParam for a given message.
-        ///
-        /// - Parameter message: The data to authenticate (typically clientDataHash).
-        /// - Returns: The authentication parameter to include in the CTAP request.
         func authenticate(message: Data) -> Data {
             protocolVersion.authenticate(key: token, message: message)
         }
 
-        /// Derives an AES key for decrypting encrypted GetInfo fields.
-        ///
-        /// Uses HKDF-SHA-256 with a 32-byte zero salt as specified in CTAP 2.3.
         internal func deriveKey(info: String) -> Data {
             Crypto.KDF.hkdf(token, salt: Data(count: 32), info: info, outputLength: 16)
         }

--- a/YubiKit/YubiKit/FIDO/CTAP/Config/Config.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/Config/Config.swift
@@ -20,26 +20,26 @@ extension CTAP2.Session {
     /// Returns authenticatorConfig operations bound to a PIN/UV auth token.
     ///
     /// ```swift
-    /// let pinToken = try await session.getPinUVToken(
+    /// let token = try await session.getPinUVToken(
     ///     using: .pin("123456"),
     ///     permissions: [.authenticatorConfig]
     /// )
-    /// let config = try await session.config(pinToken: pinToken)
+    /// let config = try await session.config(token: token)
     /// try await config.toggleAlwaysUV()
     /// try await config.enableEnterpriseAttestation()
     /// ```
     ///
-    /// - Parameter pinToken: PIN/UV auth token with `authenticatorConfig` permission.
+    /// - Parameter token: PIN/UV auth token with `authenticatorConfig` permission.
     /// - Returns: Config operations bound to the token.
     /// - Throws: `CTAP2.SessionError.featureNotSupported` if authenticatorConfig is not supported.
     /// - SeeAlso: [CTAP2 authenticatorConfig](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorConfig)
     public func config(
-        pinToken: CTAP2.ClientPin.Token
+        token: CTAP2.ClientPin.Token
     ) async throws(CTAP2.SessionError) -> CTAP2.Config {
         guard try await cachedInfo.options.authenticatorConfig else {
             throw .featureNotSupported(source: .here())
         }
-        return CTAP2.Config(session: self, pinToken: pinToken)
+        return CTAP2.Config(session: self, token: token)
     }
 }
 
@@ -51,11 +51,11 @@ extension CTAP2 {
     /// - SeeAlso: [CTAP2 authenticatorConfig](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorConfig)
     public struct Config: Sendable {
         private let session: CTAP2.Session
-        private let pinToken: CTAP2.ClientPin.Token
+        private let token: CTAP2.ClientPin.Token
 
-        fileprivate init(session: CTAP2.Session, pinToken: CTAP2.ClientPin.Token) {
+        fileprivate init(session: CTAP2.Session, token: CTAP2.ClientPin.Token) {
             self.session = session
-            self.pinToken = pinToken
+            self.token = token
         }
 
         /// Checks if the authenticator supports authenticatorConfig.
@@ -116,12 +116,12 @@ extension CTAP2 {
             params: [UInt8: CBOR.Value]? = nil
         ) async throws(CTAP2.SessionError) {
             let message = authMessage(subcommand: subcommand, params: params)
-            let pinUVAuthParam = pinToken.authenticate(message: message)
+            let pinUVAuthParam = token.authenticate(message: message)
 
             let parameters = RequestParameters(
                 subCommand: subcommand,
                 subCommandParams: params,
-                pinUVAuthProtocol: pinToken.protocolVersion,
+                pinUVAuthProtocol: token.protocolVersion,
                 pinUVAuthParam: pinUVAuthParam
             )
 

--- a/YubiKit/YubiKit/FIDO/CTAP/Config/Config.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/Config/Config.swift
@@ -33,7 +33,9 @@ extension CTAP2.Session {
     /// - Returns: Config operations bound to the token.
     /// - Throws: `CTAP2.SessionError.featureNotSupported` if authenticatorConfig is not supported.
     /// - SeeAlso: [CTAP2 authenticatorConfig](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorConfig)
-    public func config(pinToken: CTAP2.ClientPin.Token) async throws(CTAP2.SessionError) -> CTAP2.Config {
+    public func config(
+        pinToken: CTAP2.ClientPin.Token
+    ) async throws(CTAP2.SessionError) -> CTAP2.Config {
         guard try await cachedInfo.options.authenticatorConfig else {
             throw .featureNotSupported(source: .here())
         }

--- a/YubiKit/YubiKit/FIDO/CTAP/Config/Config.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/Config/Config.swift
@@ -34,7 +34,7 @@ extension CTAP2.Session {
     /// - Throws: `CTAP2.SessionError.featureNotSupported` if authenticatorConfig is not supported.
     /// - SeeAlso: [CTAP2 authenticatorConfig](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorConfig)
     public func config(
-        token: CTAP2.ClientPin.Token
+        token: CTAP2.Token
     ) async throws(CTAP2.SessionError) -> CTAP2.Config {
         guard try await cachedInfo.options.authenticatorConfig else {
             throw .featureNotSupported(source: .here())
@@ -51,9 +51,9 @@ extension CTAP2 {
     /// - SeeAlso: [CTAP2 authenticatorConfig](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorConfig)
     public struct Config: Sendable {
         private let session: CTAP2.Session
-        private let token: CTAP2.ClientPin.Token
+        private let token: CTAP2.Token
 
-        fileprivate init(session: CTAP2.Session, token: CTAP2.ClientPin.Token) {
+        fileprivate init(session: CTAP2.Session, token: CTAP2.Token) {
             self.session = session
             self.token = token
         }

--- a/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement.swift
@@ -20,26 +20,26 @@ extension CTAP2.Session {
     /// Returns credential management operations bound to a PIN/UV auth token.
     ///
     /// ```swift
-    /// let pinToken = try await session.getPinUVToken(
+    /// let token = try await session.getPinUVToken(
     ///     using: .pin("123456"),
     ///     permissions: [.credentialManagement]
     /// )
-    /// let credMgmt = try await session.credentialManagement(pinToken: pinToken)
+    /// let credMgmt = try await session.credentialManagement(token: token)
     /// let metadata = try await credMgmt.getMetadata()
     /// let rps = try await credMgmt.rps.enumerate()
     /// ```
     ///
-    /// - Parameter pinToken: PIN/UV auth token with `credentialManagement` permission.
+    /// - Parameter token: PIN/UV auth token with `credentialManagement` permission.
     /// - Returns: CredentialManagement operations bound to the token.
     /// - Throws: `CTAP2.SessionError.featureNotSupported` if credential management is not supported.
     /// - SeeAlso: [CTAP2 authenticatorCredentialManagement](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorCredentialManagement)
     public func credentialManagement(
-        pinToken: CTAP2.ClientPin.Token
+        token: CTAP2.ClientPin.Token
     ) async throws(CTAP2.SessionError) -> CTAP2.CredentialManagement {
         guard try await CTAP2.CredentialManagement.isSupported(by: self) else {
             throw .featureNotSupported(source: .here())
         }
-        return CTAP2.CredentialManagement(session: self, pinToken: pinToken)
+        return CTAP2.CredentialManagement(session: self, token: token)
     }
 }
 
@@ -53,11 +53,11 @@ extension CTAP2 {
     /// - SeeAlso: [CTAP2 authenticatorCredentialManagement](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorCredentialManagement)
     public struct CredentialManagement: Sendable {
         private let session: CTAP2.Session
-        private let pinToken: CTAP2.ClientPin.Token
+        private let token: CTAP2.ClientPin.Token
 
-        fileprivate init(session: CTAP2.Session, pinToken: CTAP2.ClientPin.Token) {
+        fileprivate init(session: CTAP2.Session, token: CTAP2.ClientPin.Token) {
             self.session = session
-            self.pinToken = pinToken
+            self.token = token
         }
 
         // MARK: - Feature Detection
@@ -192,8 +192,8 @@ extension CTAP2 {
             return RequestParameters(
                 subCommand: subcommand,
                 subCommandParams: params,
-                pinUVAuthProtocol: pinToken.protocolVersion,
-                pinUVAuthParam: pinToken.authenticate(message: message)
+                pinUVAuthProtocol: token.protocolVersion,
+                pinUVAuthParam: token.authenticate(message: message)
             )
         }
 

--- a/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/CredentialManagement/CredentialManagement.swift
@@ -34,7 +34,7 @@ extension CTAP2.Session {
     /// - Throws: `CTAP2.SessionError.featureNotSupported` if credential management is not supported.
     /// - SeeAlso: [CTAP2 authenticatorCredentialManagement](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorCredentialManagement)
     public func credentialManagement(
-        token: CTAP2.ClientPin.Token
+        token: CTAP2.Token
     ) async throws(CTAP2.SessionError) -> CTAP2.CredentialManagement {
         guard try await CTAP2.CredentialManagement.isSupported(by: self) else {
             throw .featureNotSupported(source: .here())
@@ -53,9 +53,9 @@ extension CTAP2 {
     /// - SeeAlso: [CTAP2 authenticatorCredentialManagement](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorCredentialManagement)
     public struct CredentialManagement: Sendable {
         private let session: CTAP2.Session
-        private let token: CTAP2.ClientPin.Token
+        private let token: CTAP2.Token
 
-        fileprivate init(session: CTAP2.Session, token: CTAP2.ClientPin.Token) {
+        fileprivate init(session: CTAP2.Session, token: CTAP2.Token) {
             self.session = session
             self.token = token
         }

--- a/YubiKit/YubiKit/FIDO/CTAP/GetAssertion/GetAssertionParameters+CBOR.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/GetAssertion/GetAssertionParameters+CBOR.swift
@@ -34,20 +34,12 @@ extension CTAP2.GetAssertion.Parameters: CBOR.Encodable {
             }
             map[4] = .map(extMap)
         }
-        map[5] = options?.cbor()
+        var optionsMap: [CBOR.Value: CBOR.Value] = [:]
+        optionsMap["up"] = up?.cbor()
+        optionsMap["uv"] = uv?.cbor()
+        if !optionsMap.isEmpty { map[5] = optionsMap.cbor() }
         map[6] = pinUVAuthParam?.cbor()
         map[7] = pinUVAuthProtocol?.cbor()
-        return map.cbor()
-    }
-}
-
-// MARK: - CTAP.GetAssertion.Parameters.Options + CBOR
-
-extension CTAP2.GetAssertion.Parameters.Options: CBOR.Encodable {
-    func cbor() -> CBOR.Value {
-        var map: [CBOR.Value: CBOR.Value] = [:]
-        map["up"] = up?.cbor()
-        map["uv"] = uv?.cbor()
         return map.cbor()
     }
 }

--- a/YubiKit/YubiKit/FIDO/CTAP/GetAssertion/GetAssertionParameters.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/GetAssertion/GetAssertionParameters.swift
@@ -34,22 +34,22 @@ extension CTAP2.GetAssertion {
         /// Require user presence (default: true when omitted).
         public internal(set) var up: Bool?
 
-        /// Require user verification during the command (ignored if pinToken is provided).
+        /// Require user verification during the command (ignored if token is provided).
         public internal(set) var uv: Bool?
 
-        /// PIN/UV auth parameter (populated automatically when using PIN authentication).
+        /// PIN/UV auth parameter (populated automatically when using a PIN/UV token).
         private(set) var pinUVAuthParam: Data?
 
-        /// PIN/UV protocol version (populated automatically when using PIN authentication).
+        /// PIN/UV protocol version (populated automatically when using a PIN/UV token).
         private(set) var pinUVAuthProtocol: CTAP2.ClientPin.ProtocolVersion?
 
         /// Sets the PIN/UV authentication parameters.
         ///
         /// Clears `uv` since it must not coexist with `pinUvAuthParam`.
-        mutating func setAuthentication(pinToken: CTAP2.ClientPin.Token) {
+        mutating func setAuthentication(token: CTAP2.ClientPin.Token) {
             self.uv = nil
-            self.pinUVAuthParam = pinToken.authenticate(message: clientDataHash)
-            self.pinUVAuthProtocol = pinToken.protocolVersion
+            self.pinUVAuthParam = token.authenticate(message: clientDataHash)
+            self.pinUVAuthProtocol = token.protocolVersion
         }
 
         public init(

--- a/YubiKit/YubiKit/FIDO/CTAP/GetAssertion/GetAssertionParameters.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/GetAssertion/GetAssertionParameters.swift
@@ -46,7 +46,7 @@ extension CTAP2.GetAssertion {
         /// Sets the PIN/UV authentication parameters.
         ///
         /// Clears `uv` since it must not coexist with `pinUvAuthParam`.
-        mutating func setAuthentication(token: CTAP2.ClientPin.Token) {
+        mutating func setAuthentication(token: CTAP2.Token) {
             self.uv = nil
             self.pinUVAuthParam = token.authenticate(message: clientDataHash)
             self.pinUVAuthProtocol = token.protocolVersion

--- a/YubiKit/YubiKit/FIDO/CTAP/GetAssertion/GetAssertionParameters.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/GetAssertion/GetAssertionParameters.swift
@@ -31,8 +31,11 @@ extension CTAP2.GetAssertion {
         /// Extension inputs for additional authenticator processing.
         public let extensions: [CTAP2.Extension.GetAssertion.Input]
 
-        /// Authenticator options.
-        public let options: Options?
+        /// Require user presence (default: true when omitted).
+        public internal(set) var up: Bool?
+
+        /// Require user verification during the command (ignored if pinToken is provided).
+        public internal(set) var uv: Bool?
 
         /// PIN/UV auth parameter (populated automatically when using PIN authentication).
         private(set) var pinUVAuthParam: Data?
@@ -40,8 +43,11 @@ extension CTAP2.GetAssertion {
         /// PIN/UV protocol version (populated automatically when using PIN authentication).
         private(set) var pinUVAuthProtocol: CTAP2.ClientPin.ProtocolVersion?
 
-        /// Sets the PIN/UV authentication parameters using a PIN token.
+        /// Sets the PIN/UV authentication parameters.
+        ///
+        /// Clears `uv` since it must not coexist with `pinUvAuthParam`.
         mutating func setAuthentication(pinToken: CTAP2.ClientPin.Token) {
+            self.uv = nil
             self.pinUVAuthParam = pinToken.authenticate(message: clientDataHash)
             self.pinUVAuthProtocol = pinToken.protocolVersion
         }
@@ -51,27 +57,15 @@ extension CTAP2.GetAssertion {
             clientDataHash: Data,
             allowList: [WebAuthn.PublicKeyCredential.Descriptor]? = nil,
             extensions: [CTAP2.Extension.GetAssertion.Input] = [],
-            options: Options? = nil
+            up: Bool? = nil,
+            uv: Bool? = nil
         ) {
             self.rpId = rpId
             self.clientDataHash = clientDataHash
             self.allowList = allowList
             self.extensions = extensions
-            self.options = options
-        }
-
-        /// Authenticator options for getAssertion.
-        public struct Options: Sendable {
-            /// Require user presence (default: true).
-            public let up: Bool?
-
-            /// Require user verification.
-            public let uv: Bool?
-
-            public init(up: Bool? = nil, uv: Bool? = nil) {
-                self.up = up
-                self.uv = uv
-            }
+            self.up = up
+            self.uv = uv
         }
     }
 }

--- a/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse.swift
@@ -250,6 +250,7 @@ extension CTAP2.GetInfo {
 // MARK: - Encrypted Field Decryption
 
 extension CTAP2.GetInfo.Encrypted where Value == CTAP2.GetInfo.Opaque128 {
+
     /// Decrypts the encrypted field to raw bytes using a persistent pinUvAuthToken.
     ///
     /// - Parameter token: A persistent pinUvAuthToken obtained with

--- a/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/GetInfo/GetInfoResponse.swift
@@ -257,7 +257,7 @@ extension CTAP2.GetInfo.Encrypted where Value == CTAP2.GetInfo.Opaque128 {
     ///   the `.persistentCredentialManagement` permission.
     /// - Returns: The decrypted 16-byte value.
     /// - Throws: `CryptoError` if decryption fails.
-    public func decryptedData(using token: CTAP2.ClientPin.Token) throws(CryptoError) -> Data {
+    public func decryptedData(using token: CTAP2.Token) throws(CryptoError) -> Data {
         let ivSize = Crypto.AES.blockSize
         guard encryptedData.count > ivSize else {
             throw .missingData
@@ -277,7 +277,7 @@ extension CTAP2.GetInfo.Encrypted where Value == CTAP2.GetInfo.Opaque128 {
     /// - Returns: The decrypted 128-bit value.
     /// - Throws: `CryptoError` if decryption fails.
     public func decrypted(
-        using token: CTAP2.ClientPin.Token
+        using token: CTAP2.Token
     ) throws(CryptoError) -> CTAP2.GetInfo.Opaque128 {
         let data = try decryptedData(using: token)
         guard let value = CTAP2.GetInfo.Opaque128(data) else { throw .missingData }

--- a/YubiKit/YubiKit/FIDO/CTAP/LargeBlobs/CTAPSession+LargeBlobs.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/LargeBlobs/CTAPSession+LargeBlobs.swift
@@ -67,7 +67,7 @@ extension CTAP2.Session {
     public func putBlob(
         key: Data,
         data: Data,
-        token: CTAP2.ClientPin.Token
+        token: CTAP2.Token
     ) async throws(CTAP2.SessionError) {
         var entries = try await readBlobArray()
 
@@ -94,7 +94,7 @@ extension CTAP2.Session {
     /// - Throws: `CTAP2.SessionError` if the operation fails.
     public func deleteBlob(
         key: Data,
-        token: CTAP2.ClientPin.Token
+        token: CTAP2.Token
     ) async throws(CTAP2.SessionError) {
         var entries = try await readBlobArray()
         let originalCount = entries.count
@@ -158,7 +158,7 @@ extension CTAP2.Session {
     // Writes the entire large blob array with automatic fragmentation.
     private func writeBlobArray(
         _ entries: [CTAP2.LargeBlobs.Entry],
-        token: CTAP2.ClientPin.Token
+        token: CTAP2.Token
     ) async throws(CTAP2.SessionError) {
         let info = try await cachedInfo
         let maxFragment = Int(info.maxMsgSize) - Self.maxFragmentLengthOverhead
@@ -216,7 +216,7 @@ extension CTAP2.Session {
         set: Data,
         offset: UInt,
         length: UInt?,
-        token: CTAP2.ClientPin.Token
+        token: CTAP2.Token
     ) async throws(CTAP2.SessionError) {
         let message = writeAuthMessage(fragment: set, offset: offset)
         let pinUVAuthParam = token.authenticate(message: message)

--- a/YubiKit/YubiKit/FIDO/CTAP/LargeBlobs/CTAPSession+LargeBlobs.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/LargeBlobs/CTAPSession+LargeBlobs.swift
@@ -62,12 +62,12 @@ extension CTAP2.Session {
     /// - Parameters:
     ///   - key: The 32-byte largeBlobKey for the credential.
     ///   - data: The data to store.
-    ///   - pinToken: PIN/UV auth token with largeBlobWrite permission.
+    ///   - token: PIN/UV auth token with largeBlobWrite permission.
     /// - Throws: `CTAP2.SessionError` if the operation fails.
     public func putBlob(
         key: Data,
         data: Data,
-        pinToken: CTAP2.ClientPin.Token
+        token: CTAP2.ClientPin.Token
     ) async throws(CTAP2.SessionError) {
         var entries = try await readBlobArray()
 
@@ -80,7 +80,7 @@ extension CTAP2.Session {
         let newEntry = try CTAP2.LargeBlobs.Entry(encrypting: data, key: key)
         entries.append(newEntry)
 
-        try await writeBlobArray(entries, pinToken: pinToken)
+        try await writeBlobArray(entries, token: token)
     }
 
     /// Deletes any blobs for a credential.
@@ -90,11 +90,11 @@ extension CTAP2.Session {
     ///
     /// - Parameters:
     ///   - key: The 32-byte largeBlobKey for the credential.
-    ///   - pinToken: PIN/UV auth token with largeBlobWrite permission.
+    ///   - token: PIN/UV auth token with largeBlobWrite permission.
     /// - Throws: `CTAP2.SessionError` if the operation fails.
     public func deleteBlob(
         key: Data,
-        pinToken: CTAP2.ClientPin.Token
+        token: CTAP2.ClientPin.Token
     ) async throws(CTAP2.SessionError) {
         var entries = try await readBlobArray()
         let originalCount = entries.count
@@ -104,7 +104,7 @@ extension CTAP2.Session {
         }
 
         if entries.count != originalCount {
-            try await writeBlobArray(entries, pinToken: pinToken)
+            try await writeBlobArray(entries, token: token)
         }
     }
 
@@ -158,7 +158,7 @@ extension CTAP2.Session {
     // Writes the entire large blob array with automatic fragmentation.
     private func writeBlobArray(
         _ entries: [CTAP2.LargeBlobs.Entry],
-        pinToken: CTAP2.ClientPin.Token
+        token: CTAP2.ClientPin.Token
     ) async throws(CTAP2.SessionError) {
         let info = try await cachedInfo
         let maxFragment = Int(info.maxMsgSize) - Self.maxFragmentLengthOverhead
@@ -189,7 +189,7 @@ extension CTAP2.Session {
                 set: fragment,
                 offset: offset,
                 length: length,
-                pinToken: pinToken
+                token: token
             )
 
             offset += UInt(fragmentSize)
@@ -216,17 +216,17 @@ extension CTAP2.Session {
         set: Data,
         offset: UInt,
         length: UInt?,
-        pinToken: CTAP2.ClientPin.Token
+        token: CTAP2.ClientPin.Token
     ) async throws(CTAP2.SessionError) {
         let message = writeAuthMessage(fragment: set, offset: offset)
-        let pinUVAuthParam = pinToken.authenticate(message: message)
+        let pinUVAuthParam = token.authenticate(message: message)
 
         let params = WriteParameters(
             set: set,
             offset: offset,
             length: length,
             pinUVAuthParam: pinUVAuthParam,
-            pinUVAuthProtocol: pinToken.protocolVersion
+            pinUVAuthProtocol: token.protocolVersion
         )
 
         let stream: CTAP2.StatusStream<Void> = await interface.send(

--- a/YubiKit/YubiKit/FIDO/CTAP/MakeCredential/MakeCredentialParameters+CBOR.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/MakeCredential/MakeCredentialParameters+CBOR.swift
@@ -44,21 +44,13 @@ extension CTAP2.MakeCredential.Parameters: CBOR.Encodable {
             }
             map[6] = .map(extMap)
         }
-        map[7] = options?.cbor()
+        var optionsMap: [CBOR.Value: CBOR.Value] = [:]
+        if rk { optionsMap["rk"] = true.cbor() }
+        optionsMap["uv"] = uv?.cbor()
+        if !optionsMap.isEmpty { map[7] = optionsMap.cbor() }
         map[8] = pinUVAuthParam?.cbor()
         map[9] = pinUVAuthProtocol?.cbor()
         map[10] = enterpriseAttestation?.cbor()
-        return map.cbor()
-    }
-}
-
-// MARK: - MakeCredentialParameters.Options + CBOR
-
-extension CTAP2.MakeCredential.Parameters.Options: CBOR.Encodable {
-    func cbor() -> CBOR.Value {
-        var map: [CBOR.Value: CBOR.Value] = [:]
-        map["rk"] = rk?.cbor()
-        map["uv"] = uv?.cbor()
         return map.cbor()
     }
 }

--- a/YubiKit/YubiKit/FIDO/CTAP/MakeCredential/MakeCredentialParameters.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/MakeCredential/MakeCredentialParameters.swift
@@ -55,7 +55,7 @@ extension CTAP2.MakeCredential {
         /// Sets the PIN/UV authentication parameters.
         ///
         /// Clears `uv` since it must not coexist with `pinUvAuthParam`.
-        mutating func setAuthentication(token: CTAP2.ClientPin.Token) {
+        mutating func setAuthentication(token: CTAP2.Token) {
             self.uv = nil
             self.pinUVAuthParam = token.authenticate(message: clientDataHash)
             self.pinUVAuthProtocol = token.protocolVersion

--- a/YubiKit/YubiKit/FIDO/CTAP/MakeCredential/MakeCredentialParameters.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/MakeCredential/MakeCredentialParameters.swift
@@ -40,25 +40,25 @@ extension CTAP2.MakeCredential {
         /// Require resident key (discoverable credential).
         public internal(set) var rk: Bool
 
-        /// Require user verification during the command (ignored if pinToken is provided).
+        /// Require user verification during the command (ignored if token is provided).
         public internal(set) var uv: Bool?
 
         /// Enterprise attestation level (1 or 2).
         public let enterpriseAttestation: Int?
 
-        /// PIN/UV auth parameter (populated automatically when using PIN authentication).
+        /// PIN/UV auth parameter (populated automatically when using a PIN/UV token).
         private(set) var pinUVAuthParam: Data?
 
-        /// PIN/UV protocol version (populated automatically when using PIN authentication).
+        /// PIN/UV protocol version (populated automatically when using a PIN/UV token).
         private(set) var pinUVAuthProtocol: CTAP2.ClientPin.ProtocolVersion?
 
         /// Sets the PIN/UV authentication parameters.
         ///
         /// Clears `uv` since it must not coexist with `pinUvAuthParam`.
-        mutating func setAuthentication(pinToken: CTAP2.ClientPin.Token) {
+        mutating func setAuthentication(token: CTAP2.ClientPin.Token) {
             self.uv = nil
-            self.pinUVAuthParam = pinToken.authenticate(message: clientDataHash)
-            self.pinUVAuthProtocol = pinToken.protocolVersion
+            self.pinUVAuthParam = token.authenticate(message: clientDataHash)
+            self.pinUVAuthProtocol = token.protocolVersion
         }
 
         public init(

--- a/YubiKit/YubiKit/FIDO/CTAP/MakeCredential/MakeCredentialParameters.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/MakeCredential/MakeCredentialParameters.swift
@@ -37,8 +37,11 @@ extension CTAP2.MakeCredential {
         /// Extension inputs for additional authenticator processing.
         public let extensions: [CTAP2.Extension.MakeCredential.Input]
 
-        /// Authenticator options.
-        public let options: Options?
+        /// Require resident key (discoverable credential).
+        public internal(set) var rk: Bool
+
+        /// Require user verification during the command (ignored if pinToken is provided).
+        public internal(set) var uv: Bool?
 
         /// Enterprise attestation level (1 or 2).
         public let enterpriseAttestation: Int?
@@ -49,8 +52,11 @@ extension CTAP2.MakeCredential {
         /// PIN/UV protocol version (populated automatically when using PIN authentication).
         private(set) var pinUVAuthProtocol: CTAP2.ClientPin.ProtocolVersion?
 
-        /// Sets the PIN/UV authentication parameters using a PIN token.
+        /// Sets the PIN/UV authentication parameters.
+        ///
+        /// Clears `uv` since it must not coexist with `pinUvAuthParam`.
         mutating func setAuthentication(pinToken: CTAP2.ClientPin.Token) {
+            self.uv = nil
             self.pinUVAuthParam = pinToken.authenticate(message: clientDataHash)
             self.pinUVAuthProtocol = pinToken.protocolVersion
         }
@@ -62,7 +68,8 @@ extension CTAP2.MakeCredential {
             pubKeyCredParams: [COSE.Algorithm],
             excludeList: [WebAuthn.PublicKeyCredential.Descriptor]? = nil,
             extensions: [CTAP2.Extension.MakeCredential.Input] = [],
-            options: Options? = nil,
+            rk: Bool,
+            uv: Bool? = nil,
             enterpriseAttestation: Int? = nil
         ) {
             self.clientDataHash = clientDataHash
@@ -71,22 +78,9 @@ extension CTAP2.MakeCredential {
             self.pubKeyCredParams = pubKeyCredParams
             self.excludeList = excludeList
             self.extensions = extensions
-            self.options = options
+            self.rk = rk
+            self.uv = uv
             self.enterpriseAttestation = enterpriseAttestation
-        }
-
-        /// Authenticator options for makeCredential.
-        public struct Options: Sendable {
-            /// Require resident key (discoverable credential).
-            public let rk: Bool?
-
-            /// Require user verification.
-            public let uv: Bool?
-
-            public init(rk: Bool? = nil, uv: Bool? = nil) {
-                self.rk = rk
-                self.uv = uv
-            }
         }
     }
 }

--- a/YubiKit/YubiKit/FIDO/Interfaces/FIDOInterface/FIDOInterface+CBORInterface.swift
+++ b/YubiKit/YubiKit/FIDO/Interfaces/FIDOInterface/FIDOInterface+CBORInterface.swift
@@ -111,7 +111,6 @@ extension FIDOInterface: CBORInterface where Error == CTAP2.SessionError {
                     // Parse CTAP response and yield final result
                     let result: O = try parse(responsePayload)
                     continuation.yield(.finished(result))
-                    continuation.finish()
                 } catch {
                     continuation.yield(error: error)
                 }

--- a/YubiKit/YubiKit/FIDO/Interfaces/SmartCardInterface+CBORInterface.swift
+++ b/YubiKit/YubiKit/FIDO/Interfaces/SmartCardInterface+CBORInterface.swift
@@ -138,8 +138,6 @@ extension SmartCardInterface: CBORInterface where Error == CTAP2.SessionError {
                     // Parse and yield final response
                     let result: O = try parse(response.data)
                     continuation.yield(.finished(result))
-                    continuation.finish()
-
                 } catch {
                     continuation.yield(error: error)
                 }

--- a/YubiKit/YubiKit/FIDO/Session/CTAPSession+BackwardsCompatibility.swift
+++ b/YubiKit/YubiKit/FIDO/Session/CTAPSession+BackwardsCompatibility.swift
@@ -18,6 +18,13 @@ import Foundation
 
 /// This file contains deprecated API overloads for backwards compatibility.
 
+// MARK: - Deprecated Token Type
+
+extension CTAP2.ClientPin {
+    @available(*, deprecated, renamed: "CTAP2.Token")
+    public typealias Token = CTAP2.Token
+}
+
 // MARK: - Deprecated Options Types
 
 extension CTAP2.MakeCredential.Parameters {
@@ -105,7 +112,7 @@ extension CTAP2.Session {
     @available(*, deprecated, message: "Set rk in Parameters init instead")
     public func makeCredential(
         parameters: CTAP2.MakeCredential.Parameters,
-        pinToken: CTAP2.ClientPin.Token,
+        pinToken: CTAP2.Token,
         requireResidentKey: Bool
     ) async -> CTAP2.StatusStream<CTAP2.MakeCredential.Response> {
         var params = parameters
@@ -118,7 +125,7 @@ extension CTAP2.Session {
     @available(*, deprecated, message: "Set up in Parameters init instead")
     public func getAssertion(
         parameters: CTAP2.GetAssertion.Parameters,
-        pinToken: CTAP2.ClientPin.Token,
+        pinToken: CTAP2.Token,
         requireUserPresence: Bool?
     ) async -> CTAP2.StatusStream<CTAP2.GetAssertion.Response> {
         var params = parameters
@@ -131,7 +138,7 @@ extension CTAP2.Session {
     @available(*, deprecated, message: "Set up in Parameters init instead")
     public func getAssertions(
         parameters: CTAP2.GetAssertion.Parameters,
-        pinToken: CTAP2.ClientPin.Token,
+        pinToken: CTAP2.Token,
         requireUserPresence: Bool?
     ) async -> CTAP2.GetAssertion.Sequence {
         var params = parameters
@@ -144,7 +151,7 @@ extension CTAP2.Session {
     @available(*, deprecated, renamed: "makeCredential(parameters:token:)")
     public func makeCredential(
         parameters: CTAP2.MakeCredential.Parameters,
-        pinToken: CTAP2.ClientPin.Token?
+        pinToken: CTAP2.Token?
     ) async -> CTAP2.StatusStream<CTAP2.MakeCredential.Response> {
         await makeCredential(parameters: parameters, token: pinToken)
     }
@@ -152,7 +159,7 @@ extension CTAP2.Session {
     @available(*, deprecated, renamed: "getAssertion(parameters:token:)")
     public func getAssertion(
         parameters: CTAP2.GetAssertion.Parameters,
-        pinToken: CTAP2.ClientPin.Token?
+        pinToken: CTAP2.Token?
     ) async -> CTAP2.StatusStream<CTAP2.GetAssertion.Response> {
         await getAssertion(parameters: parameters, token: pinToken)
     }
@@ -160,28 +167,28 @@ extension CTAP2.Session {
     @available(*, deprecated, renamed: "getAssertions(parameters:token:)")
     public func getAssertions(
         parameters: CTAP2.GetAssertion.Parameters,
-        pinToken: CTAP2.ClientPin.Token?
+        pinToken: CTAP2.Token?
     ) async -> CTAP2.GetAssertion.Sequence {
         await getAssertions(parameters: parameters, token: pinToken)
     }
 
     @available(*, deprecated, renamed: "config(token:)")
     public func config(
-        pinToken: CTAP2.ClientPin.Token
+        pinToken: CTAP2.Token
     ) async throws(CTAP2.SessionError) -> CTAP2.Config {
         try await config(token: pinToken)
     }
 
     @available(*, deprecated, renamed: "credentialManagement(token:)")
     public func credentialManagement(
-        pinToken: CTAP2.ClientPin.Token
+        pinToken: CTAP2.Token
     ) async throws(CTAP2.SessionError) -> CTAP2.CredentialManagement {
         try await credentialManagement(token: pinToken)
     }
 
     @available(*, deprecated, renamed: "bioEnrollment(token:)")
     public func bioEnrollment(
-        pinToken: CTAP2.ClientPin.Token
+        pinToken: CTAP2.Token
     ) async throws(CTAP2.SessionError) -> CTAP2.BioEnrollment {
         try await bioEnrollment(token: pinToken)
     }
@@ -190,7 +197,7 @@ extension CTAP2.Session {
     public func putBlob(
         key: Data,
         data: Data,
-        pinToken: CTAP2.ClientPin.Token
+        pinToken: CTAP2.Token
     ) async throws(CTAP2.SessionError) {
         try await putBlob(key: key, data: data, token: pinToken)
     }
@@ -198,7 +205,7 @@ extension CTAP2.Session {
     @available(*, deprecated, renamed: "deleteBlob(key:token:)")
     public func deleteBlob(
         key: Data,
-        pinToken: CTAP2.ClientPin.Token
+        pinToken: CTAP2.Token
     ) async throws(CTAP2.SessionError) {
         try await deleteBlob(key: key, token: pinToken)
     }

--- a/YubiKit/YubiKit/FIDO/Session/CTAPSession+BackwardsCompatibility.swift
+++ b/YubiKit/YubiKit/FIDO/Session/CTAPSession+BackwardsCompatibility.swift
@@ -110,7 +110,7 @@ extension CTAP2.Session {
     ) async -> CTAP2.StatusStream<CTAP2.MakeCredential.Response> {
         var params = parameters
         params.rk = requireResidentKey
-        return await makeCredential(parameters: params, pinToken: pinToken)
+        return await makeCredential(parameters: params, token: pinToken)
     }
 
     // MARK: - GetAssertion (Deprecated requireUserPresence parameter)
@@ -123,7 +123,7 @@ extension CTAP2.Session {
     ) async -> CTAP2.StatusStream<CTAP2.GetAssertion.Response> {
         var params = parameters
         params.up = requireUserPresence
-        return await getAssertion(parameters: params, pinToken: pinToken)
+        return await getAssertion(parameters: params, token: pinToken)
     }
 
     // MARK: - GetAssertions Sequence (Deprecated requireUserPresence parameter)
@@ -136,6 +136,70 @@ extension CTAP2.Session {
     ) async -> CTAP2.GetAssertion.Sequence {
         var params = parameters
         params.up = requireUserPresence
-        return await getAssertions(parameters: params, pinToken: pinToken)
+        return await getAssertions(parameters: params, token: pinToken)
+    }
+
+    // MARK: - Deprecated pinToken: parameter name
+
+    @available(*, deprecated, renamed: "makeCredential(parameters:token:)")
+    public func makeCredential(
+        parameters: CTAP2.MakeCredential.Parameters,
+        pinToken: CTAP2.ClientPin.Token?
+    ) async -> CTAP2.StatusStream<CTAP2.MakeCredential.Response> {
+        await makeCredential(parameters: parameters, token: pinToken)
+    }
+
+    @available(*, deprecated, renamed: "getAssertion(parameters:token:)")
+    public func getAssertion(
+        parameters: CTAP2.GetAssertion.Parameters,
+        pinToken: CTAP2.ClientPin.Token?
+    ) async -> CTAP2.StatusStream<CTAP2.GetAssertion.Response> {
+        await getAssertion(parameters: parameters, token: pinToken)
+    }
+
+    @available(*, deprecated, renamed: "getAssertions(parameters:token:)")
+    public func getAssertions(
+        parameters: CTAP2.GetAssertion.Parameters,
+        pinToken: CTAP2.ClientPin.Token?
+    ) async -> CTAP2.GetAssertion.Sequence {
+        await getAssertions(parameters: parameters, token: pinToken)
+    }
+
+    @available(*, deprecated, renamed: "config(token:)")
+    public func config(
+        pinToken: CTAP2.ClientPin.Token
+    ) async throws(CTAP2.SessionError) -> CTAP2.Config {
+        try await config(token: pinToken)
+    }
+
+    @available(*, deprecated, renamed: "credentialManagement(token:)")
+    public func credentialManagement(
+        pinToken: CTAP2.ClientPin.Token
+    ) async throws(CTAP2.SessionError) -> CTAP2.CredentialManagement {
+        try await credentialManagement(token: pinToken)
+    }
+
+    @available(*, deprecated, renamed: "bioEnrollment(token:)")
+    public func bioEnrollment(
+        pinToken: CTAP2.ClientPin.Token
+    ) async throws(CTAP2.SessionError) -> CTAP2.BioEnrollment {
+        try await bioEnrollment(token: pinToken)
+    }
+
+    @available(*, deprecated, renamed: "putBlob(key:data:token:)")
+    public func putBlob(
+        key: Data,
+        data: Data,
+        pinToken: CTAP2.ClientPin.Token
+    ) async throws(CTAP2.SessionError) {
+        try await putBlob(key: key, data: data, token: pinToken)
+    }
+
+    @available(*, deprecated, renamed: "deleteBlob(key:token:)")
+    public func deleteBlob(
+        key: Data,
+        pinToken: CTAP2.ClientPin.Token
+    ) async throws(CTAP2.SessionError) {
+        try await deleteBlob(key: key, token: pinToken)
     }
 }

--- a/YubiKit/YubiKit/FIDO/Session/CTAPSession+BackwardsCompatibility.swift
+++ b/YubiKit/YubiKit/FIDO/Session/CTAPSession+BackwardsCompatibility.swift
@@ -1,0 +1,141 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+// MARK: - Backwards Compatibility
+
+/// This file contains deprecated API overloads for backwards compatibility.
+
+// MARK: - Deprecated Options Types
+
+extension CTAP2.MakeCredential.Parameters {
+
+    /// Authenticator options for makeCredential.
+    ///
+    /// - Deprecated: Pass `rk` and `uv` directly to
+    /// ``init(clientDataHash:rp:user:pubKeyCredParams:excludeList:extensions:rk:uv:enterpriseAttestation:)``.
+    @available(*, deprecated, message: "Pass rk and uv directly to Parameters init")
+    public struct Options: Sendable {
+        public let rk: Bool?
+        public let uv: Bool?
+        public init(rk: Bool? = nil, uv: Bool? = nil) {
+            self.rk = rk
+            self.uv = uv
+        }
+    }
+
+    @available(*, deprecated, message: "Pass rk and uv directly to Parameters init")
+    public init(
+        clientDataHash: Data,
+        rp: WebAuthn.PublicKeyCredential.RPEntity,
+        user: WebAuthn.PublicKeyCredential.UserEntity,
+        pubKeyCredParams: [COSE.Algorithm],
+        excludeList: [WebAuthn.PublicKeyCredential.Descriptor]? = nil,
+        extensions: [CTAP2.Extension.MakeCredential.Input] = [],
+        options: Options? = nil,
+        enterpriseAttestation: Int? = nil
+    ) {
+        self.init(
+            clientDataHash: clientDataHash,
+            rp: rp,
+            user: user,
+            pubKeyCredParams: pubKeyCredParams,
+            excludeList: excludeList,
+            extensions: extensions,
+            rk: options?.rk ?? false,
+            uv: options?.uv,
+            enterpriseAttestation: enterpriseAttestation
+        )
+    }
+}
+
+extension CTAP2.GetAssertion.Parameters {
+
+    /// Authenticator options for getAssertion.
+    ///
+    /// - Deprecated: Pass `up` and `uv` directly to
+    /// ``init(rpId:clientDataHash:allowList:extensions:up:uv:)``.
+    @available(*, deprecated, message: "Pass up and uv directly to Parameters init")
+    public struct Options: Sendable {
+        public let up: Bool?
+        public let uv: Bool?
+        public init(up: Bool? = nil, uv: Bool? = nil) {
+            self.up = up
+            self.uv = uv
+        }
+    }
+
+    @available(*, deprecated, message: "Pass up and uv directly to Parameters init")
+    public init(
+        rpId: String,
+        clientDataHash: Data,
+        allowList: [WebAuthn.PublicKeyCredential.Descriptor]? = nil,
+        extensions: [CTAP2.Extension.GetAssertion.Input] = [],
+        options: Options? = nil
+    ) {
+        self.init(
+            rpId: rpId,
+            clientDataHash: clientDataHash,
+            allowList: allowList,
+            extensions: extensions,
+            up: options?.up,
+            uv: options?.uv
+        )
+    }
+}
+
+// MARK: - Deprecated Session Methods
+
+extension CTAP2.Session {
+
+    // MARK: - MakeCredential (Deprecated requireResidentKey parameter)
+
+    @available(*, deprecated, message: "Set rk in Parameters init instead")
+    public func makeCredential(
+        parameters: CTAP2.MakeCredential.Parameters,
+        pinToken: CTAP2.ClientPin.Token,
+        requireResidentKey: Bool
+    ) async -> CTAP2.StatusStream<CTAP2.MakeCredential.Response> {
+        var params = parameters
+        params.rk = requireResidentKey
+        return await makeCredential(parameters: params, pinToken: pinToken)
+    }
+
+    // MARK: - GetAssertion (Deprecated requireUserPresence parameter)
+
+    @available(*, deprecated, message: "Set up in Parameters init instead")
+    public func getAssertion(
+        parameters: CTAP2.GetAssertion.Parameters,
+        pinToken: CTAP2.ClientPin.Token,
+        requireUserPresence: Bool?
+    ) async -> CTAP2.StatusStream<CTAP2.GetAssertion.Response> {
+        var params = parameters
+        params.up = requireUserPresence
+        return await getAssertion(parameters: params, pinToken: pinToken)
+    }
+
+    // MARK: - GetAssertions Sequence (Deprecated requireUserPresence parameter)
+
+    @available(*, deprecated, message: "Set up in Parameters init instead")
+    public func getAssertions(
+        parameters: CTAP2.GetAssertion.Parameters,
+        pinToken: CTAP2.ClientPin.Token,
+        requireUserPresence: Bool?
+    ) async -> CTAP2.GetAssertion.Sequence {
+        var params = parameters
+        params.up = requireUserPresence
+        return await getAssertions(parameters: params, pinToken: pinToken)
+    }
+}

--- a/YubiKit/YubiKit/FIDO/Session/CTAPSession+ClientPIN.swift
+++ b/YubiKit/YubiKit/FIDO/Session/CTAPSession+ClientPIN.swift
@@ -43,7 +43,7 @@ extension CTAP2.Session {
     /// Get a PIN/UV auth token from the authenticator.
     ///
     /// The returned token can be used to authenticate subsequent CTAP operations
-    /// like ``makeCredential(parameters:pinToken:)`` and ``getAssertion(parameters:pinToken:)``.
+    /// like ``makeCredential(parameters:token:)`` and ``getAssertion(parameters:token:)``.
     ///
     /// - Parameters:
     ///   - method: The verification method to use (PIN or built-in UV).

--- a/YubiKit/YubiKit/FIDO/Session/CTAPSession+ClientPIN.swift
+++ b/YubiKit/YubiKit/FIDO/Session/CTAPSession+ClientPIN.swift
@@ -46,20 +46,11 @@ extension CTAP2.Session {
     /// like ``makeCredential(parameters:pinToken:)`` and ``getAssertion(parameters:pinToken:)``.
     ///
     /// - Parameters:
-    ///   - method: The authentication method to use (PIN or built-in UV).
+    ///   - method: The verification method to use (PIN or built-in UV).
     ///   - permissions: Permissions for the token.
     ///   - rpId: Optional relying party ID (required for mc/ga permissions).
     ///   - pinProtocol: The PIN/UV auth protocol version to use. If nil, auto-selects.
     /// - Returns: A PIN/UV auth token that can be used to authenticate CTAP operations.
-    ///
-    /// Example:
-    /// ```swift
-    /// // Using PIN
-    /// let token = try await session.getPinUVToken(using: .pin("1234"), permissions: .makeCredential, rpId: "example.com")
-    ///
-    /// // Using biometrics (YubiKey Bio)
-    /// let token = try await session.getPinUVToken(using: .uv, permissions: .makeCredential, rpId: "example.com")
-    /// ```
     public func getPinUVToken(
         using method: CTAP2.ClientPin.Method,
         permissions: CTAP2.ClientPin.Permission,
@@ -157,11 +148,6 @@ private struct ClientPinHandler: Sendable {
         permissions: CTAP2.ClientPin.Permission,
         rpId: String? = nil
     ) async throws(CTAP2.SessionError) -> CTAP2.ClientPin.Token {
-        // UV requires pinUvAuthToken support
-        if case .uv = method, !supportsTokenPermissions {
-            throw CTAP2.SessionError.featureNotSupported(source: .here())
-        }
-
         let authenticatorKey = try await getKeyAgreement()
 
         // Generate ephemeral key pair and derive shared secret
@@ -169,7 +155,6 @@ private struct ClientPinHandler: Sendable {
         let sharedSecret = secretResult.sharedSecret
         let platformKey = secretResult.platformKey
 
-        // Build command parameters and send based on auth method
         let response: CTAP2.ClientPin.GetToken.Response
         switch method {
         case .pin(let pin):
@@ -207,6 +192,11 @@ private struct ClientPinHandler: Sendable {
             }
 
         case .uv:
+            // UV requires pinUvAuthToken support
+            guard supportsTokenPermissions else {
+                throw CTAP2.SessionError.featureNotSupported(source: .here())
+            }
+
             // Use 0x06 (getPinUvAuthTokenUsingUvWithPermissions)
             let params = CTAP2.ClientPin.GetTokenUsingUV.Parameters(
                 pinUVAuthProtocol: pinProtocol,
@@ -220,19 +210,20 @@ private struct ClientPinHandler: Sendable {
             )
             response = try await stream.value
         }
-        let pinToken = try pinProtocol.decrypt(key: sharedSecret, ciphertext: response.pinUVAuthToken)
+
+        let tokenData = try pinProtocol.decrypt(key: sharedSecret, ciphertext: response.pinUVAuthToken)
 
         // Validate token size: V1 allows 16 or 32 bytes, V2 requires exactly 32 bytes
         let validSize =
-            pinProtocol == .v1 ? (pinToken.count == 16 || pinToken.count == 32) : pinToken.count == 32
+            pinProtocol == .v1 ? (tokenData.count == 16 || tokenData.count == 32) : tokenData.count == 32
         guard validSize else {
             throw CTAP2.SessionError.responseParseError(
-                "Invalid PIN token size: expected \(pinProtocol == .v1 ? "16 or 32" : "32") bytes, got \(pinToken.count)",
+                "Invalid token size: expected \(pinProtocol == .v1 ? "16 or 32" : "32") bytes, got \(tokenData.count)",
                 source: .here()
             )
         }
 
-        return CTAP2.ClientPin.Token(token: pinToken, protocolVersion: pinProtocol)
+        return CTAP2.ClientPin.Token(token: tokenData, protocolVersion: pinProtocol)
     }
 
     func set(_ pin: String) async throws(CTAP2.SessionError) {

--- a/YubiKit/YubiKit/FIDO/Session/CTAPSession+ClientPIN.swift
+++ b/YubiKit/YubiKit/FIDO/Session/CTAPSession+ClientPIN.swift
@@ -56,7 +56,7 @@ extension CTAP2.Session {
         permissions: CTAP2.ClientPin.Permission,
         rpId: String? = nil,
         protocol pinProtocol: CTAP2.ClientPin.ProtocolVersion? = nil
-    ) async throws(CTAP2.SessionError) -> CTAP2.ClientPin.Token {
+    ) async throws(CTAP2.SessionError) -> CTAP2.Token {
         let handler = try await clientPinHandler(protocol: pinProtocol)
         return try await handler.getToken(using: method, permissions: permissions, rpId: rpId)
     }
@@ -147,7 +147,7 @@ private struct ClientPinHandler: Sendable {
         using method: CTAP2.ClientPin.Method,
         permissions: CTAP2.ClientPin.Permission,
         rpId: String? = nil
-    ) async throws(CTAP2.SessionError) -> CTAP2.ClientPin.Token {
+    ) async throws(CTAP2.SessionError) -> CTAP2.Token {
         let authenticatorKey = try await getKeyAgreement()
 
         // Generate ephemeral key pair and derive shared secret
@@ -223,7 +223,7 @@ private struct ClientPinHandler: Sendable {
             )
         }
 
-        return CTAP2.ClientPin.Token(token: tokenData, protocolVersion: pinProtocol)
+        return CTAP2.Token(token: tokenData, protocolVersion: pinProtocol)
     }
 
     func set(_ pin: String) async throws(CTAP2.SessionError) {

--- a/YubiKit/YubiKit/FIDO/Session/CTAPSession+GetAssertion.swift
+++ b/YubiKit/YubiKit/FIDO/Session/CTAPSession+GetAssertion.swift
@@ -20,33 +20,33 @@ extension CTAP2.Session {
 
     /// Authenticate with a credential on the authenticator.
     ///
-    /// When a `pinToken` is provided, the `uv` option is automatically cleared.
+    /// When a `token` is provided, the `uv` option is automatically cleared.
     ///
     /// - Parameters:
     ///   - parameters: The assertion request parameters.
-    ///   - pinToken: Optional PIN/UV auth token obtained via ``getPinUVToken(using:permissions:rpId:protocol:)``.
+    ///   - token: Optional PIN/UV auth token obtained via ``getPinUVToken(using:permissions:rpId:protocol:)``.
     /// - Returns: AsyncStream of status updates, ending with `.finished(response)` containing the assertion data
     ///
     /// - SeeAlso: [CTAP 2.2 authenticatorGetAssertion](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorGetAssertion)
     public func getAssertion(
         parameters: CTAP2.GetAssertion.Parameters,
-        pinToken: CTAP2.ClientPin.Token? = nil
+        token: CTAP2.ClientPin.Token? = nil
     ) async -> CTAP2.StatusStream<CTAP2.GetAssertion.Response> {
-        guard let pinToken else {
+        guard let token else {
             return await interface.send(command: .getAssertion, payload: parameters)
         }
         var params = parameters
-        params.setAuthentication(pinToken: pinToken)
+        params.setAuthentication(token: token)
         return await interface.send(command: .getAssertion, payload: params)
     }
 
     /// Get the next assertion when multiple credentials are available.
     ///
-    /// After calling ``getAssertion(parameters:pinToken:)``, if the response contains `numberOfCredentials > 1`,
+    /// After calling ``getAssertion(parameters:token:)``, if the response contains `numberOfCredentials > 1`,
     /// call this method repeatedly to retrieve the remaining assertions. Each call returns the next
     /// available assertion until all have been retrieved.
     ///
-    /// > Important: This command must only be called after a successful ``getAssertion(parameters:pinToken:)`` call
+    /// > Important: This command must only be called after a successful ``getAssertion(parameters:token:)`` call
     /// > that returned `numberOfCredentials > 1`. Calling it at other times will result in an error.
     ///
     /// > Note: This functionality is available on YubiKey 5.0 or later.
@@ -63,26 +63,26 @@ extension CTAP2.Session {
     /// Get all assertions as an async sequence.
     ///
     /// Returns an async sequence that lazily fetches assertions one at a time. This automatically
-    /// handles calling ``getAssertion(parameters:pinToken:)`` for the first assertion and
+    /// handles calling ``getAssertion(parameters:token:)`` for the first assertion and
     /// ``getNextAssertion()`` for subsequent assertions based on `numberOfCredentials`.
     ///
-    /// When a `pinToken` is provided, the `uv` option is automatically cleared.
+    /// When a `token` is provided, the `uv` option is automatically cleared.
     ///
     /// - Parameters:
     ///   - parameters: The assertion request parameters.
-    ///   - pinToken: Optional PIN/UV auth token obtained via ``getPinUVToken(using:permissions:rpId:protocol:)``.
+    ///   - token: Optional PIN/UV auth token obtained via ``getPinUVToken(using:permissions:rpId:protocol:)``.
     /// - Returns: An async sequence of assertion responses.
     ///
-    /// - SeeAlso: ``getAssertion(parameters:pinToken:)`` for low-level access to a single assertion.
+    /// - SeeAlso: ``getAssertion(parameters:token:)`` for low-level access to a single assertion.
     public func getAssertions(
         parameters: CTAP2.GetAssertion.Parameters,
-        pinToken: CTAP2.ClientPin.Token? = nil
+        token: CTAP2.ClientPin.Token? = nil
     ) async -> CTAP2.GetAssertion.Sequence {
-        guard let pinToken else {
+        guard let token else {
             return .init(session: self, parameters: parameters)
         }
         var params = parameters
-        params.setAuthentication(pinToken: pinToken)
+        params.setAuthentication(token: token)
         return .init(session: self, parameters: params)
     }
 }
@@ -92,14 +92,14 @@ extension CTAP2.Session {
 /// An async sequence of assertion responses.
 ///
 /// This sequence lazily fetches assertions from the authenticator, calling
-/// ``CTAP2/Session/getAssertion(parameters:pinToken:)`` for the first assertion and
+/// ``CTAP2/Session/getAssertion(parameters:token:)`` for the first assertion and
 /// ``CTAP2/Session/getNextAssertion()`` for subsequent assertions.
 ///
-/// Use ``CTAP2/Session/getAssertions(parameters:pinToken:)`` to create instances of this type.
+/// Use ``CTAP2/Session/getAssertions(parameters:token:)`` to create instances of this type.
 ///
-/// > Note: When created with a `pinToken`, the PIN/UV auth fields are pre-set on the stored
+/// > Note: When created with a `token`, the PIN/UV auth fields are pre-set on the stored
 /// > parameters before the sequence is constructed. The iterator sends these pre-authenticated
-/// > parameters without a separate pinToken.
+/// > parameters without a separate token.
 extension CTAP2.GetAssertion {
     public struct Sequence: AsyncSequence {
         public typealias Element = CTAP2.GetAssertion.Response
@@ -125,7 +125,7 @@ extension CTAP2.GetAssertion {
 extension CTAP2.GetAssertion {
     /// Iterator that fetches assertions one at a time from the authenticator.
     ///
-    /// Created by ``Sequence/makeAsyncIterator()``. Use ``CTAP2/Session/getAssertions(parameters:pinToken:)`` instead of instantiating directly.
+    /// Created by ``Sequence/makeAsyncIterator()``. Use ``CTAP2/Session/getAssertions(parameters:token:)`` instead of instantiating directly.
     public actor Iterator: AsyncIteratorProtocol {
         public typealias Element = CTAP2.GetAssertion.Response
 

--- a/YubiKit/YubiKit/FIDO/Session/CTAPSession+GetAssertion.swift
+++ b/YubiKit/YubiKit/FIDO/Session/CTAPSession+GetAssertion.swift
@@ -18,19 +18,13 @@ import Foundation
 
 extension CTAP2.Session {
 
-    /// Authenticate with a credential.
+    /// Authenticate with a credential on the authenticator.
     ///
-    /// Generates an authentication assertion for an existing credential. This is used during
-    /// WebAuthn authentication to prove possession of the private key for a credential.
-    ///
-    /// The authenticator validates the request, locates the credential, and generates a signature
-    /// over the authenticator data and client data hash using the credential's private key.
-    ///
-    /// > Note: This functionality is available on YubiKey 5.0 or later.
+    /// When a `pinToken` is provided, the `uv` option is automatically cleared.
     ///
     /// - Parameters:
     ///   - parameters: The assertion request parameters.
-    ///   - pinToken: Optional PIN token for user verification. Obtain via ``getPinUVToken(using:permissions:rpId:protocol:)``.
+    ///   - pinToken: Optional PIN/UV auth token obtained via ``getPinUVToken(using:permissions:rpId:protocol:)``.
     /// - Returns: AsyncStream of status updates, ending with `.finished(response)` containing the assertion data
     ///
     /// - SeeAlso: [CTAP 2.2 authenticatorGetAssertion](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorGetAssertion)
@@ -38,22 +32,12 @@ extension CTAP2.Session {
         parameters: CTAP2.GetAssertion.Parameters,
         pinToken: CTAP2.ClientPin.Token? = nil
     ) async -> CTAP2.StatusStream<CTAP2.GetAssertion.Response> {
-
-        // If no PIN token provided, send parameters as-is
         guard let pinToken else {
-            return await interface.send(
-                command: .getAssertion,
-                payload: parameters
-            )
+            return await interface.send(command: .getAssertion, payload: parameters)
         }
-
-        var authenticatedParams = parameters
-        authenticatedParams.setAuthentication(pinToken: pinToken)
-
-        return await interface.send(
-            command: .getAssertion,
-            payload: authenticatedParams
-        )
+        var params = parameters
+        params.setAuthentication(pinToken: pinToken)
+        return await interface.send(command: .getAssertion, payload: params)
     }
 
     /// Get the next assertion when multiple credentials are available.
@@ -82,12 +66,11 @@ extension CTAP2.Session {
     /// handles calling ``getAssertion(parameters:pinToken:)`` for the first assertion and
     /// ``getNextAssertion()`` for subsequent assertions based on `numberOfCredentials`.
     ///
-    /// When only one credential matches, the sequence yields a single assertion. When multiple credentials
-    /// are available (resident key discovery with no allowList), the sequence yields all of them.
+    /// When a `pinToken` is provided, the `uv` option is automatically cleared.
     ///
     /// - Parameters:
     ///   - parameters: The assertion request parameters.
-    ///   - pinToken: Optional PIN token for user verification. Obtain via ``getPinUVToken(using:permissions:rpId:protocol:)``.
+    ///   - pinToken: Optional PIN/UV auth token obtained via ``getPinUVToken(using:permissions:rpId:protocol:)``.
     /// - Returns: An async sequence of assertion responses.
     ///
     /// - SeeAlso: ``getAssertion(parameters:pinToken:)`` for low-level access to a single assertion.
@@ -95,13 +78,12 @@ extension CTAP2.Session {
         parameters: CTAP2.GetAssertion.Parameters,
         pinToken: CTAP2.ClientPin.Token? = nil
     ) async -> CTAP2.GetAssertion.Sequence {
-        var authenticatedParams = parameters
-
-        if let pinToken {
-            authenticatedParams.setAuthentication(pinToken: pinToken)
+        guard let pinToken else {
+            return .init(session: self, parameters: parameters)
         }
-
-        return .init(session: self, parameters: authenticatedParams)
+        var params = parameters
+        params.setAuthentication(pinToken: pinToken)
+        return .init(session: self, parameters: params)
     }
 }
 
@@ -109,15 +91,21 @@ extension CTAP2.Session {
 
 /// An async sequence of assertion responses.
 ///
-/// This sequence lazily fetches assertions from the authenticator, calling ``CTAP2/Session/getAssertion(parameters:pinToken:)``
-/// for the first assertion and ``CTAP2/Session/getNextAssertion()`` for subsequent assertions.
+/// This sequence lazily fetches assertions from the authenticator, calling
+/// ``CTAP2/Session/getAssertion(parameters:pinToken:)`` for the first assertion and
+/// ``CTAP2/Session/getNextAssertion()`` for subsequent assertions.
 ///
 /// Use ``CTAP2/Session/getAssertions(parameters:pinToken:)`` to create instances of this type.
+///
+/// > Note: When created with a `pinToken`, the PIN/UV auth fields are pre-set on the stored
+/// > parameters before the sequence is constructed. The iterator sends these pre-authenticated
+/// > parameters without a separate pinToken.
 extension CTAP2.GetAssertion {
     public struct Sequence: AsyncSequence {
         public typealias Element = CTAP2.GetAssertion.Response
 
         let session: CTAP2.Session
+        /// Parameters with optional PIN/UV auth fields pre-set by the session method.
         let parameters: CTAP2.GetAssertion.Parameters
 
         fileprivate init(
@@ -157,7 +145,7 @@ extension CTAP2.GetAssertion {
 
         public func next() async throws(CTAP2.SessionError) -> CTAP2.GetAssertion.Response? {
             if currentIndex == 0 {
-                // Get first assertion (parameters already authenticated if PIN token was provided)
+                // Send parameters as-is (auth fields already set if pinToken was provided)
                 let stream = await session.getAssertion(parameters: parameters)
                 for try await status in stream {
                     if case .finished(let response) = status {

--- a/YubiKit/YubiKit/FIDO/Session/CTAPSession+GetAssertion.swift
+++ b/YubiKit/YubiKit/FIDO/Session/CTAPSession+GetAssertion.swift
@@ -30,7 +30,7 @@ extension CTAP2.Session {
     /// - SeeAlso: [CTAP 2.2 authenticatorGetAssertion](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorGetAssertion)
     public func getAssertion(
         parameters: CTAP2.GetAssertion.Parameters,
-        token: CTAP2.ClientPin.Token? = nil
+        token: CTAP2.Token? = nil
     ) async -> CTAP2.StatusStream<CTAP2.GetAssertion.Response> {
         guard let token else {
             return await interface.send(command: .getAssertion, payload: parameters)
@@ -76,7 +76,7 @@ extension CTAP2.Session {
     /// - SeeAlso: ``getAssertion(parameters:token:)`` for low-level access to a single assertion.
     public func getAssertions(
         parameters: CTAP2.GetAssertion.Parameters,
-        token: CTAP2.ClientPin.Token? = nil
+        token: CTAP2.Token? = nil
     ) async -> CTAP2.GetAssertion.Sequence {
         guard let token else {
             return .init(session: self, parameters: parameters)

--- a/YubiKit/YubiKit/FIDO/Session/CTAPSession+MakeCredential.swift
+++ b/YubiKit/YubiKit/FIDO/Session/CTAPSession+MakeCredential.swift
@@ -30,7 +30,7 @@ extension CTAP2.Session {
     /// - SeeAlso: [CTAP 2.2 authenticatorMakeCredential](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorMakeCredential)
     public func makeCredential(
         parameters: CTAP2.MakeCredential.Parameters,
-        token: CTAP2.ClientPin.Token? = nil
+        token: CTAP2.Token? = nil
     ) async -> CTAP2.StatusStream<CTAP2.MakeCredential.Response> {
         guard let token else {
             return await interface.send(command: .makeCredential, payload: parameters)

--- a/YubiKit/YubiKit/FIDO/Session/CTAPSession+MakeCredential.swift
+++ b/YubiKit/YubiKit/FIDO/Session/CTAPSession+MakeCredential.swift
@@ -20,18 +20,11 @@ extension CTAP2.Session {
 
     /// Create a new credential on the authenticator.
     ///
-    /// This command registers a new FIDO2 credential with the authenticator. The authenticator
-    /// will verify user presence (and optionally user verification via PIN/biometric), generate
-    /// a new credential keypair, and return attestation data.
-    ///
-    /// > Important: This operation requires user interaction (touch) and may require PIN entry
-    /// > if user verification is requested.
-    ///
-    /// > Note: This functionality is available on YubiKey 5.0 or later.
+    /// When a `pinToken` is provided, the `uv` option is automatically cleared.
     ///
     /// - Parameters:
     ///   - parameters: The credential creation parameters.
-    ///   - pinToken: Optional PIN token for user verification. Obtain via ``getPinUVToken(using:permissions:rpId:protocol:)``.
+    ///   - pinToken: Optional PIN/UV auth token obtained via ``getPinUVToken(using:permissions:rpId:protocol:)``.
     /// - Returns: AsyncSequence of status updates, ending with `.finished(response)` containing the credential data
     ///
     /// - SeeAlso: [CTAP 2.2 authenticatorMakeCredential](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorMakeCredential)
@@ -39,21 +32,11 @@ extension CTAP2.Session {
         parameters: CTAP2.MakeCredential.Parameters,
         pinToken: CTAP2.ClientPin.Token? = nil
     ) async -> CTAP2.StatusStream<CTAP2.MakeCredential.Response> {
-
-        // If no PIN token provided, send parameters as-is
         guard let pinToken else {
-            return await interface.send(
-                command: .makeCredential,
-                payload: parameters
-            )
+            return await interface.send(command: .makeCredential, payload: parameters)
         }
-
-        var authenticatedParams = parameters
-        authenticatedParams.setAuthentication(pinToken: pinToken)
-
-        return await interface.send(
-            command: .makeCredential,
-            payload: authenticatedParams
-        )
+        var params = parameters
+        params.setAuthentication(pinToken: pinToken)
+        return await interface.send(command: .makeCredential, payload: params)
     }
 }

--- a/YubiKit/YubiKit/FIDO/Session/CTAPSession+MakeCredential.swift
+++ b/YubiKit/YubiKit/FIDO/Session/CTAPSession+MakeCredential.swift
@@ -20,23 +20,23 @@ extension CTAP2.Session {
 
     /// Create a new credential on the authenticator.
     ///
-    /// When a `pinToken` is provided, the `uv` option is automatically cleared.
+    /// When a `token` is provided, the `uv` option is automatically cleared.
     ///
     /// - Parameters:
     ///   - parameters: The credential creation parameters.
-    ///   - pinToken: Optional PIN/UV auth token obtained via ``getPinUVToken(using:permissions:rpId:protocol:)``.
+    ///   - token: Optional PIN/UV auth token obtained via ``getPinUVToken(using:permissions:rpId:protocol:)``.
     /// - Returns: AsyncSequence of status updates, ending with `.finished(response)` containing the credential data
     ///
     /// - SeeAlso: [CTAP 2.2 authenticatorMakeCredential](https://fidoalliance.org/specs/fido-v2.2-ps-20250714/fido-client-to-authenticator-protocol-v2.2-ps-20250714.html#authenticatorMakeCredential)
     public func makeCredential(
         parameters: CTAP2.MakeCredential.Parameters,
-        pinToken: CTAP2.ClientPin.Token? = nil
+        token: CTAP2.ClientPin.Token? = nil
     ) async -> CTAP2.StatusStream<CTAP2.MakeCredential.Response> {
-        guard let pinToken else {
+        guard let token else {
             return await interface.send(command: .makeCredential, payload: parameters)
         }
         var params = parameters
-        params.setAuthentication(pinToken: pinToken)
+        params.setAuthentication(token: token)
         return await interface.send(command: .makeCredential, payload: params)
     }
 }

--- a/YubiKit/YubiKit/FIDO/Session/CTAPStatusStream.swift
+++ b/YubiKit/YubiKit/FIDO/Session/CTAPStatusStream.swift
@@ -124,10 +124,14 @@ extension CTAP2.StatusStream {
 
         func yield(_ status: CTAP2.Status<Response>) {
             continuation.yield(.success(status))
+            if case .finished = status {
+                continuation.finish()
+            }
         }
 
         func yield(error: CTAP2.SessionError) {
             continuation.yield(.failure(error))
+            continuation.finish()
         }
 
         func finish() {

--- a/YubiKit/YubiKit/YubiKit.docc/Resources/WebAuthnInterceptorSampleCode.md
+++ b/YubiKit/YubiKit/YubiKit.docc/Resources/WebAuthnInterceptorSampleCode.md
@@ -124,7 +124,7 @@ func handleCreate(_ data: Data) async throws -> String {
         options: options
     )
 
-    let response = try await session.makeCredential(parameters: params, pinToken: pinToken).value
+    let response = try await session.makeCredential(parameters: params, token: pinToken).value
     // Convert response back to WebAuthn format...
 }
 ```
@@ -148,7 +148,7 @@ func handleGet(_ data: Data) async throws -> String {
         options: options
     )
 
-    let response = try await session.getAssertion(parameters: params, pinToken: pinToken).value
+    let response = try await session.getAssertion(parameters: params, token: pinToken).value
     // Convert response back to WebAuthn format...
 }
 ```


### PR DESCRIPTION
Add CTAP2 Bio Enrollment API and flatten MakeCredential/GetAssertion options

- Add `CTAP2.BioEnrollment` API for fingerprint enrollment management
- Flatten `rk`, `up`, `uv` options from nested `Options` struct to direct parameters
- Enables `setAuthentication()` to clear `uv` when `pinUvAuthParam` is set
- Deprecate old `Options` struct with backwards-compatible overloads
