### PR TITLE
Groomed deprecations: callsites and file organisation 

### DIFF
--- a/FullStackTests/Tests/CTAP2/BioEnrollmentTests.swift
+++ b/FullStackTests/Tests/CTAP2/BioEnrollmentTests.swift
@@ -126,7 +126,7 @@ private func withBioEnrollment(
             permissions: [.bioEnrollment]
         )
 
-        let bio = try await session.bioEnrollment(pinToken: pinToken)
+        let bio = try await session.bioEnrollment(token: pinToken)
 
         try await body(bio)
     }

--- a/FullStackTests/Tests/CTAP2/BioUVTests.swift
+++ b/FullStackTests/Tests/CTAP2/BioUVTests.swift
@@ -46,7 +46,7 @@ struct BioUVTests {
 
             let credential = try await session.makeCredential(
                 parameters: params,
-                pinToken: uvToken
+                token: uvToken
             ).value
 
             // UV token should set BOTH UV and UP flags
@@ -112,7 +112,7 @@ struct BioUVTests {
 
             let credential = try await session.makeCredential(
                 parameters: params,
-                pinToken: pinToken
+                token: pinToken
             ).value
 
             // Per CTAP 2.2 §6.1.1: valid pinUvAuthParam sets UV flag regardless of token type
@@ -140,7 +140,7 @@ private func withEnrolledFingerprint(
             using: .pin(defaultTestPin),
             permissions: [.bioEnrollment]
         )
-        let bio = try await session.bioEnrollment(pinToken: pinToken)
+        let bio = try await session.bioEnrollment(token: pinToken)
 
         // Clean up any existing enrollments
         let existing = try await bio.enrollments.enumerate()
@@ -179,7 +179,7 @@ private func withEnrolledFingerprint(
             using: .pin(defaultTestPin),
             permissions: [.bioEnrollment]
         )
-        let cleanupBio = try await session.bioEnrollment(pinToken: cleanupToken)
+        let cleanupBio = try await session.bioEnrollment(token: cleanupToken)
 
         // Clean up
         try await cleanupBio.removeEnrollment(enrolledTemplateId)

--- a/FullStackTests/Tests/CTAP2/ConfigTests.swift
+++ b/FullStackTests/Tests/CTAP2/ConfigTests.swift
@@ -30,7 +30,7 @@ struct ConfigFullStackTests {
             )
 
             do {
-                _ = try await session.config(pinToken: pinToken)
+                _ = try await session.config(token: pinToken)
                 print("✅ authenticatorConfig is supported")
             } catch CTAP2.SessionError.featureNotSupported {
                 print("ℹ️ authenticatorConfig is not supported by this authenticator")
@@ -61,7 +61,7 @@ struct ConfigFullStackTests {
                 permissions: [.authenticatorConfig]
             )
 
-            let config = try await session.config(pinToken: pinToken)
+            let config = try await session.config(token: pinToken)
             try await config.toggleAlwaysUV()
 
             let newInfo = try await session.getInfo()
@@ -100,7 +100,7 @@ struct ConfigFullStackTests {
                 permissions: [.authenticatorConfig]
             )
 
-            try await session.config(pinToken: pinToken).enableEnterpriseAttestation()
+            try await session.config(token: pinToken).enableEnterpriseAttestation()
 
             let newInfo = try await session.getInfo()
             #expect(newInfo.options.enterpriseAttestation == true)
@@ -130,7 +130,7 @@ struct ConfigFullStackTests {
                 permissions: [.authenticatorConfig]
             )
 
-            try await session.config(pinToken: pinToken).setMinPINLength(forceChangePin: true)
+            try await session.config(token: pinToken).setMinPINLength(forceChangePin: true)
 
             let newInfo = try await session.getInfo()
             #expect(newInfo.forcePinChange == true)
@@ -171,7 +171,7 @@ struct ConfigFullStackTests {
                 permissions: [.authenticatorConfig]
             )
 
-            let config = try await session.config(pinToken: pinToken)
+            let config = try await session.config(token: pinToken)
             try await config.setMinPINLength(newMinPINLength: newMinPinLength)
 
             let newInfo = try await session.getInfo()

--- a/FullStackTests/Tests/CTAP2/CredentialManagementTests.swift
+++ b/FullStackTests/Tests/CTAP2/CredentialManagementTests.swift
@@ -160,7 +160,7 @@ struct CredentialManagementTests {
         // First session: setup and get PPUAT
         let testData:
             (
-                ppuat: CTAP2.ClientPin.Token,
+                ppuat: CTAP2.Token,
                 credentialId: WebAuthn.PublicKeyCredential.Descriptor,
                 rpIdHash: Data,
                 identifier: Opaque128?,
@@ -269,7 +269,7 @@ private func getCredentialManagement(_ session: CTAP2.Session) async throws -> C
         using: .pin(defaultTestPin),
         permissions: [.credentialManagement]
     )
-    return try await session.credentialManagement(pinToken: token)
+    return try await session.credentialManagement(token: token)
 }
 
 private func createTestCredential(_ session: CTAP2.Session) async throws {
@@ -286,7 +286,7 @@ private func createTestCredential(_ session: CTAP2.Session) async throws {
         rk: true
     )
     print("👆 Touch YubiKey: creating test credential...")
-    _ = try await session.makeCredential(parameters: params, pinToken: pinToken).value
+    _ = try await session.makeCredential(parameters: params, token: pinToken).value
 }
 
 private func deleteAllCredentials(_ session: CTAP2.Session) async throws {
@@ -300,10 +300,10 @@ private func deleteAllCredentials(_ session: CTAP2.Session) async throws {
 
 private func verifyReadOnlyOperations(
     session: CTAP2.Session,
-    ppuat: CTAP2.ClientPin.Token,
+    ppuat: CTAP2.Token,
     rpIdHash: Data
 ) async throws {
-    let credMgmt = try await session.credentialManagement(pinToken: ppuat)
+    let credMgmt = try await session.credentialManagement(token: ppuat)
 
     // Read operations should work
     let metadata = try await credMgmt.getMetadata()

--- a/FullStackTests/Tests/CTAP2/EncryptedFieldsTests.swift
+++ b/FullStackTests/Tests/CTAP2/EncryptedFieldsTests.swift
@@ -75,7 +75,7 @@ struct EncryptedFieldsTests {
     func testPersistentTokenAcrossReconnects() async throws {
         // First session: get PPUAT and decrypt fields
         typealias Opaque128 = CTAP2.GetInfo.Opaque128
-        let (ppuat, identifier1, credStoreState1): (CTAP2.ClientPin.Token, Opaque128, Opaque128?) =
+        let (ppuat, identifier1, credStoreState1): (CTAP2.Token, Opaque128, Opaque128?) =
             try await withCTAP2Session { session in
                 let info = try await session.getInfo()
                 try #require(info.encIdentifier != nil, "encIdentifier not supported")
@@ -139,7 +139,7 @@ struct EncryptedFieldsTests {
                 using: .pin(defaultTestPin),
                 permissions: [.credentialManagement]
             )
-            let credMgmt = try await session.credentialManagement(pinToken: cmToken)
+            let credMgmt = try await session.credentialManagement(token: cmToken)
             for try await rp in credMgmt.rps {
                 for try await cred in credMgmt.credentials(for: rp.rpIdHash) {
                     try await credMgmt.deleteCredential(cred.credentialId)
@@ -170,7 +170,7 @@ struct EncryptedFieldsTests {
                 rk: true
             )
             print("👆 Touch YubiKey: creating credential...")
-            _ = try await session.makeCredential(parameters: params, pinToken: makeCredToken).value
+            _ = try await session.makeCredential(parameters: params, token: makeCredToken).value
 
             // Verify state changed after credential creation
             let info2 = try await session.getInfo()
@@ -183,7 +183,7 @@ struct EncryptedFieldsTests {
                 using: .pin(defaultTestPin),
                 permissions: [.credentialManagement]
             )
-            let credMgmt2 = try await session.credentialManagement(pinToken: deleteToken)
+            let credMgmt2 = try await session.credentialManagement(token: deleteToken)
             let rps = try await credMgmt2.rps.enumerate()
             let creds = try await credMgmt2.credentials(for: rps[0].rpIdHash).enumerate()
             try await credMgmt2.deleteCredential(creds[0].credentialId)

--- a/FullStackTests/Tests/CTAP2/Extensions/CredBlobTests.swift
+++ b/FullStackTests/Tests/CTAP2/Extensions/CredBlobTests.swift
@@ -199,5 +199,4 @@ struct CredBlobFullStackTests {
             }
         }
     }
-
 }

--- a/FullStackTests/Tests/CTAP2/Extensions/CredBlobTests.swift
+++ b/FullStackTests/Tests/CTAP2/Extensions/CredBlobTests.swift
@@ -65,7 +65,7 @@ struct CredBlobFullStackTests {
             )
 
             print("👆 Touch YubiKey: creating credential with credBlob...")
-            let credential = try await session.makeCredential(parameters: makeCredParams, pinToken: pinToken).value
+            let credential = try await session.makeCredential(parameters: makeCredParams, token: pinToken).value
 
             let stored = credBlob.makeCredential.output(from: credential)
             #expect(stored == true, "credBlob should indicate successful storage")
@@ -87,7 +87,7 @@ struct CredBlobFullStackTests {
             )
 
             print("👆 Touch YubiKey: authenticating to retrieve credBlob...")
-            let assertion = try await session.getAssertion(parameters: getAssertionParams, pinToken: gaToken).value
+            let assertion = try await session.getAssertion(parameters: getAssertionParams, token: gaToken).value
 
             let retrievedBlob = credBlobGA.getAssertion.output(from: assertion)
             #expect(retrievedBlob == testBlob, "Retrieved blob should match stored blob")
@@ -141,7 +141,7 @@ struct CredBlobFullStackTests {
             )
 
             print("👆 Touch YubiKey: creating credential with credBlob...")
-            _ = try await session.makeCredential(parameters: makeCredParams, pinToken: pinToken).value
+            _ = try await session.makeCredential(parameters: makeCredParams, token: pinToken).value
             print("✅ Credential created")
 
             // 2. GetAssertion WITHOUT credBlob extension
@@ -159,7 +159,7 @@ struct CredBlobFullStackTests {
             )
 
             print("👆 Touch YubiKey: authenticating without credBlob extension...")
-            let assertion = try await session.getAssertion(parameters: getAssertionParams, pinToken: gaToken).value
+            let assertion = try await session.getAssertion(parameters: getAssertionParams, token: gaToken).value
 
             let credBlobGA = try await CTAP2.Extension.CredBlob(session: session)
             let retrievedBlob = credBlobGA.getAssertion.output(from: assertion)

--- a/FullStackTests/Tests/CTAP2/Extensions/CredProtectTests.swift
+++ b/FullStackTests/Tests/CTAP2/Extensions/CredProtectTests.swift
@@ -130,7 +130,7 @@ struct CTAP2ExtensionFullStackTests {
                 extensions: [credProtect3.input()],
                 rk: true
             )
-            let level3Response = try await session.makeCredential(parameters: level3Params, pinToken: pinToken).value
+            let level3Response = try await session.makeCredential(parameters: level3Params, token: pinToken).value
             #expect(credProtect3.output(from: level3Response) == .userVerificationRequired)
             print("✅ CredProtect level 3 confirmed")
         }
@@ -223,7 +223,7 @@ struct CTAP2ExtensionFullStackTests {
             )
 
             print("👆 Touch the YubiKey to create credential with hmac-secret-mc...")
-            let response = try await session.makeCredential(parameters: params, pinToken: pinToken).value
+            let response = try await session.makeCredential(parameters: params, token: pinToken).value
 
             if let result = try hmacSecret.makeCredential.output(from: response) {
                 switch result {

--- a/FullStackTests/Tests/CTAP2/Extensions/LargeBlobsTests.swift
+++ b/FullStackTests/Tests/CTAP2/Extensions/LargeBlobsTests.swift
@@ -66,7 +66,7 @@ struct LargeBlobsFullStackTests {
             )
 
             print("👆 Touch YubiKey: creating credential with largeBlobKey...")
-            let credential = try await session.makeCredential(parameters: makeCredParams, pinToken: pinToken).value
+            let credential = try await session.makeCredential(parameters: makeCredParams, token: pinToken).value
 
             guard let key = largeBlobKey.makeCredential.output(from: credential) else {
                 Issue.record("Expected largeBlobKey in response")
@@ -77,7 +77,7 @@ struct LargeBlobsFullStackTests {
 
             // 2. Store a blob
             session = try await reconnectWhenOverNFC()
-            try await session.putBlob(key: key, data: testData, pinToken: pinToken)
+            try await session.putBlob(key: key, data: testData, token: pinToken)
             print("✅ Blob stored successfully")
 
             // 3. Read back the blob
@@ -95,7 +95,7 @@ struct LargeBlobsFullStackTests {
                 rpId: nil
             )
 
-            try await session.deleteBlob(key: key, pinToken: deleteToken)
+            try await session.deleteBlob(key: key, token: deleteToken)
             print("✅ Blob deleted")
 
             // 5. Verify blob is gone
@@ -153,7 +153,7 @@ struct LargeBlobsFullStackTests {
             )
 
             print("👆 Touch YubiKey: creating credential...")
-            let credential = try await session.makeCredential(parameters: makeCredParams, pinToken: mcToken).value
+            let credential = try await session.makeCredential(parameters: makeCredParams, token: mcToken).value
 
             guard let mcKey = largeBlobKey.makeCredential.output(from: credential) else {
                 Issue.record("Expected largeBlobKey from MakeCredential")
@@ -163,7 +163,7 @@ struct LargeBlobsFullStackTests {
 
             // 2. Store blob
             session = try await reconnectWhenOverNFC()
-            try await session.putBlob(key: mcKey, data: testData, pinToken: mcToken)
+            try await session.putBlob(key: mcKey, data: testData, token: mcToken)
             print("✅ Blob stored")
 
             // 3. GetAssertion with largeBlobKey extension to get the key again
@@ -182,7 +182,7 @@ struct LargeBlobsFullStackTests {
             )
 
             print("👆 Touch YubiKey: authenticating with largeBlobKey...")
-            let assertion = try await session.getAssertion(parameters: getAssertionParams, pinToken: gaToken).value
+            let assertion = try await session.getAssertion(parameters: getAssertionParams, token: gaToken).value
 
             guard let gaKey = largeBlobKey.getAssertion.output(from: assertion) else {
                 Issue.record("Expected largeBlobKey from GetAssertion")
@@ -199,7 +199,7 @@ struct LargeBlobsFullStackTests {
 
             // 5. Cleanup
             session = try await reconnectWhenOverNFC()
-            try await session.deleteBlob(key: gaKey, pinToken: gaToken)
+            try await session.deleteBlob(key: gaKey, token: gaToken)
             print("✅ Cleanup complete")
         }
     }
@@ -251,7 +251,7 @@ struct LargeBlobsFullStackTests {
             )
 
             print("👆 Touch YubiKey: creating first credential...")
-            let cred1 = try await session.makeCredential(parameters: params1, pinToken: pinToken1).value
+            let cred1 = try await session.makeCredential(parameters: params1, token: pinToken1).value
             guard let key1 = largeBlobKey.makeCredential.output(from: cred1) else {
                 Issue.record("Expected largeBlobKey for credential 1")
                 return
@@ -259,7 +259,7 @@ struct LargeBlobsFullStackTests {
             print("✅ First credential created")
 
             session = try await reconnectWhenOverNFC()
-            try await session.putBlob(key: key1, data: testData1, pinToken: pinToken1)
+            try await session.putBlob(key: key1, data: testData1, token: pinToken1)
             print("✅ First blob stored")
 
             // Create second credential and store its blob
@@ -284,7 +284,7 @@ struct LargeBlobsFullStackTests {
             )
 
             print("👆 Touch YubiKey: creating second credential...")
-            let cred2 = try await session.makeCredential(parameters: params2, pinToken: pinToken2).value
+            let cred2 = try await session.makeCredential(parameters: params2, token: pinToken2).value
             guard let key2 = largeBlobKey.makeCredential.output(from: cred2) else {
                 Issue.record("Expected largeBlobKey for credential 2")
                 return
@@ -292,7 +292,7 @@ struct LargeBlobsFullStackTests {
             print("✅ Second credential created")
 
             session = try await reconnectWhenOverNFC()
-            try await session.putBlob(key: key2, data: testData2, pinToken: pinToken2)
+            try await session.putBlob(key: key2, data: testData2, token: pinToken2)
             print("✅ Second blob stored")
 
             // Retrieve and verify each blob
@@ -311,8 +311,8 @@ struct LargeBlobsFullStackTests {
                 permissions: [.largeBlobWrite],
                 rpId: nil
             )
-            try await session.deleteBlob(key: key1, pinToken: cleanupToken)
-            try await session.deleteBlob(key: key2, pinToken: cleanupToken)
+            try await session.deleteBlob(key: key1, token: cleanupToken)
+            try await session.deleteBlob(key: key2, token: cleanupToken)
             print("✅ Cleanup complete")
         }
     }
@@ -355,7 +355,7 @@ struct LargeBlobsFullStackTests {
 
             // Try to store oversized blob - should fail with largeBlobStorageFull
             do {
-                try await session.putBlob(key: randomKey, data: oversizedData, pinToken: pinToken)
+                try await session.putBlob(key: randomKey, data: oversizedData, token: pinToken)
                 Issue.record("Expected largeBlobStorageFull error")
             } catch let error as CTAP2.SessionError {
                 guard case .ctapError(.largeBlobStorageFull, _) = error else {

--- a/FullStackTests/Tests/CTAP2/Extensions/MinPinLengthTests.swift
+++ b/FullStackTests/Tests/CTAP2/Extensions/MinPinLengthTests.swift
@@ -47,7 +47,7 @@ struct MinPinLengthFullStackTests {
                 using: .pin(defaultTestPin),
                 permissions: [.authenticatorConfig]
             )
-            let config = try await session.config(pinToken: configToken)
+            let config = try await session.config(token: configToken)
             try await config.setMinPINLength(rpIDs: [rpId])
 
             // Create credential with minPinLength extension
@@ -75,7 +75,7 @@ struct MinPinLengthFullStackTests {
             print("👆 Touch YubiKey: creating credential with minPinLength extension...")
             let credential = try await session.makeCredential(
                 parameters: makeCredParams,
-                pinToken: makeCredToken
+                token: makeCredToken
             ).value
 
             let length = minPinLength.makeCredential.output(from: credential)

--- a/FullStackTests/Tests/CTAP2/Extensions/PRFTests.swift
+++ b/FullStackTests/Tests/CTAP2/Extensions/PRFTests.swift
@@ -71,7 +71,7 @@ struct WebAuthnExtensionFullStackTests {
             print("👆 Touch the YubiKey to create credential with PRF support...")
             let makeCredResponse = try await session.makeCredential(
                 parameters: makeCredParams,
-                pinToken: pinToken
+                token: pinToken
             ).value
 
             // Verify hmac-secret is enabled (PRF enabled = hmac-secret enabled)
@@ -112,7 +112,7 @@ struct WebAuthnExtensionFullStackTests {
             print("👆 Touch the YubiKey for PRF assertion (one secret)...")
             let assertionResponse1 = try await session.getAssertion(
                 parameters: getAssertionParams1,
-                pinToken: pinToken2
+                token: pinToken2
             ).value
 
             guard let secrets1 = try prf.getAssertion.output(from: assertionResponse1) else {
@@ -153,7 +153,7 @@ struct WebAuthnExtensionFullStackTests {
             print("👆 Touch the YubiKey for PRF assertion (two secrets, evalByCredential)...")
             let assertionResponse2 = try await session.getAssertion(
                 parameters: getAssertionParams2,
-                pinToken: pinToken3
+                token: pinToken3
             ).value
 
             guard let secrets2 = try prf2.getAssertion.output(from: assertionResponse2) else {
@@ -227,7 +227,7 @@ struct WebAuthnExtensionFullStackTests {
             print("👆 Touch the YubiKey to create credential with PRF secrets...")
             let makeCredResponse = try await session.makeCredential(
                 parameters: makeCredParams,
-                pinToken: pinToken
+                token: pinToken
             ).value
 
             // Verify we got secrets back at registration
@@ -276,7 +276,7 @@ struct WebAuthnExtensionFullStackTests {
             print("👆 Touch the YubiKey for PRF assertion (verifying determinism)...")
             let assertionResponse = try await session.getAssertion(
                 parameters: getAssertionParams,
-                pinToken: pinToken2
+                token: pinToken2
             ).value
 
             guard let gaSecrets = try prfGa.getAssertion.output(from: assertionResponse) else {

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnClientLogic.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnClientLogic.swift
@@ -135,7 +135,7 @@ func extractGetExtensionResults(
     state: GetExtensionState,
     response: CTAP2.GetAssertion.Response,
     session: CTAP2.Session,
-    pinToken: CTAP2.ClientPin.Token?
+    token: CTAP2.Token?
 ) async throws -> ExtensionResults {
     var results = ExtensionResults()
 
@@ -151,7 +151,7 @@ func extractGetExtensionResults(
             let blob = try await session.getBlob(key: key)
             results.largeBlob = .read(blob)
         } else if let writeData = state.largeBlobWrite, let pinToken {
-            try await session.putBlob(key: key, data: writeData, pinToken: pinToken)
+            try await session.putBlob(key: key, data: writeData, token: pinToken)
             results.largeBlob = .written(true)
         }
     } else if state.largeBlobKey != nil {

--- a/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnHandler.swift
+++ b/Samples/WebAuthnInterceptorSample/WebAuthnInterceptorSample/WebAuthnHandler.swift
@@ -69,7 +69,7 @@ actor WebAuthnHandler {
 
         let response =
             if let pinToken {
-                try await session.makeCredential(parameters: params, pinToken: pinToken).value
+                try await session.makeCredential(parameters: params, token: pinToken).value
             } else {
                 try await session.makeCredential(parameters: params).value
             }
@@ -116,7 +116,7 @@ actor WebAuthnHandler {
 
         let response =
             if let pinToken {
-                try await session.getAssertion(parameters: params, pinToken: pinToken).value
+                try await session.getAssertion(parameters: params, token: pinToken).value
             } else {
                 try await session.getAssertion(parameters: params).value
             }
@@ -124,7 +124,7 @@ actor WebAuthnHandler {
             state: extState,
             response: response,
             session: session,
-            pinToken: pinToken
+            token: pinToken
         )
 
         let credentials = CredentialResponse(
@@ -172,7 +172,7 @@ actor WebAuthnHandler {
         session: CTAP2.Session,
         permissions: CTAP2.ClientPin.Permission,
         rpId: String
-    ) async throws -> (session: CTAP2.Session, pinToken: CTAP2.ClientPin.Token?) {
+    ) async throws -> (session: CTAP2.Session, token: CTAP2.Token?) {
         let info = try await session.getInfo()
         guard info.options.clientPin == true else {
             return (session, nil)

--- a/YubiKit/UnitTests/FIDO/WebAuthn/AuthenticatorDataTests.swift
+++ b/YubiKit/UnitTests/FIDO/WebAuthn/AuthenticatorDataTests.swift
@@ -208,7 +208,7 @@ struct AuthenticatorDataTests {
         )
 
         // Verify unknown format is preserved
-        if case let .unknown(format) = credData.attestationStatement {
+        if case let .unknown(format) = credData.attestationObject.statement {
             #expect(format == "unknown-format")
         } else {
             Issue.record("Expected .unknown case for unknown format")

--- a/YubiKit/YubiKit/BackwardsCompatibility.swift
+++ b/YubiKit/YubiKit/BackwardsCompatibility.swift
@@ -147,7 +147,7 @@ extension CTAP2.MakeCredential.Parameters {
         pubKeyCredParams: [COSE.Algorithm],
         excludeList: [WebAuthn.PublicKeyCredential.Descriptor]? = nil,
         extensions: [CTAP2.Extension.MakeCredential.Input] = [],
-        options: Options? = nil,
+        options: Options?,
         enterpriseAttestation: Int? = nil
     ) {
         self.init(
@@ -188,7 +188,7 @@ extension CTAP2.GetAssertion.Parameters {
         clientDataHash: Data,
         allowList: [WebAuthn.PublicKeyCredential.Descriptor]? = nil,
         extensions: [CTAP2.Extension.GetAssertion.Input] = [],
-        options: Options? = nil
+        options: Options?
     ) {
         self.init(
             rpId: rpId,

--- a/YubiKit/YubiKit/BackwardsCompatibility.swift
+++ b/YubiKit/YubiKit/BackwardsCompatibility.swift
@@ -16,16 +16,112 @@ import Foundation
 
 // MARK: - Backwards Compatibility
 
-/// This file contains deprecated API overloads for backwards compatibility.
+/// This file contains deprecated API for backwards compatibility.
+/// These APIs will be removed in the next major version.
 
-// MARK: - Deprecated Token Type
+// MARK: - EC.PublicKey Deprecated API
+
+extension EC.PublicKey {
+
+    /// Initialize a public key from SEC1 uncompressed EC point format (0x04 || X || Y).
+    /// - Parameters:
+    ///   - uncompressedPoint: Data in SEC1 format.
+    ///   - curve: The elliptic curve type (secp256r1 or secp384r1).
+    /// - Returns: PublicKey if valid, otherwise nil.
+    @available(*, deprecated, renamed: "init(x963Representation:curve:)")
+    public init?(uncompressedPoint: Data, curve: EC.Curve) {
+        self.init(x963Representation: uncompressedPoint, curve: curve)
+    }
+
+    /// SEC1 uncompressed EC point representation (0x04 || X || Y).
+    @available(*, deprecated, renamed: "x963Representation")
+    public var uncompressedPoint: Data { x963Representation }
+}
+
+// MARK: - EC.PrivateKey Deprecated API
+
+extension EC.PrivateKey {
+
+    /// Uncompressed representation of private key as 0x04 || X || Y || K.
+    @available(*, deprecated, renamed: "x963Representation")
+    public var uncompressedRepresentation: Data { x963Representation }
+
+    /// Initialize a private key from 0x04 || X || Y || K
+    /// - Parameters:
+    ///   - uncompressedRepresentation: uncompressedPoint + K
+    ///   - curve: The elliptic curve type (secp256r1 or secp384r1).
+    /// - Returns: PrivateKey if valid, otherwise nil.
+    @available(*, deprecated, renamed: "init(x963Representation:curve:)")
+    public init?(uncompressedRepresentation: Data, curve: EC.Curve) {
+        self.init(x963Representation: uncompressedRepresentation, curve: curve)
+    }
+}
+
+// MARK: - Response Deprecated API
+
+extension Response {
+
+    /// Convenience property to access sw1 directly
+    @available(*, deprecated, message: "Use responseStatus.sw1 instead")
+    public var sw1: UInt8 {
+        responseStatus.sw1
+    }
+
+    /// Convenience property to access sw2 directly
+    @available(*, deprecated, message: "Use responseStatus.sw2 instead")
+    public var sw2: UInt8 {
+        responseStatus.sw2
+    }
+}
+
+@available(*, deprecated, renamed: "Response.Status")
+public typealias ResponseStatus = Response.Status
+
+extension Response.Status {
+    @available(*, deprecated, renamed: "Response.Status.Code")
+    public typealias StatusCode = Code
+}
+
+// MARK: - Management Deprecated API
+
+@available(*, deprecated, renamed: "Management.Session")
+public typealias ManagementSession = Management.Session
+
+@available(*, deprecated, renamed: "Management.Feature")
+public typealias ManagementFeature = Management.Feature
+
+// MARK: - PIVSessionError Deprecated API
+
+extension PIVSessionError {
+
+    /// Gzip compression/decompression failed.
+    @available(*, deprecated, renamed: "compression")
+    public static func gzip(_ error: Error, source: SourceLocation) -> PIVSessionError {
+        .compression(error, source: source)
+    }
+}
+
+// MARK: - CTAP2.MakeCredential.Response Deprecated API
+
+extension CTAP2.MakeCredential.Response {
+
+    /// Attestation statement format identifier.
+    @available(*, deprecated, renamed: "attestationObject.format")
+    public var format: String { attestationObject.format }
+
+    /// Parsed attestation statement.
+    @available(*, deprecated, renamed: "attestationObject.statement")
+    public var attestationStatement: WebAuthn.AttestationStatement { attestationObject.statement }
+}
+
+// MARK: - CTAP2.ClientPin Deprecated Token Type
 
 extension CTAP2.ClientPin {
     @available(*, deprecated, renamed: "CTAP2.Token")
     public typealias Token = CTAP2.Token
 }
 
-// MARK: - Deprecated Options Types
+// MARK: - CTAP2.MakeCredential.Parameters Deprecated Options
 
 extension CTAP2.MakeCredential.Parameters {
 
@@ -68,6 +164,8 @@ extension CTAP2.MakeCredential.Parameters {
     }
 }
 
+// MARK: - CTAP2.GetAssertion.Parameters Deprecated Options
+
 extension CTAP2.GetAssertion.Parameters {
 
     /// Authenticator options for getAssertion.
@@ -103,7 +201,7 @@ extension CTAP2.GetAssertion.Parameters {
     }
 }
 
-// MARK: - Deprecated Session Methods
+// MARK: - CTAP2.Session Deprecated Methods
 
 extension CTAP2.Session {
 

--- a/YubiKit/YubiKit/Crypto/Keys+Crypto.swift
+++ b/YubiKit/YubiKit/Crypto/Keys+Crypto.swift
@@ -25,7 +25,7 @@ extension EC.PrivateKey {
     /// - Returns: A new random EC private key.
     /// - Throws: `CryptoError.keyCreationFailed` if generation fails.
     internal static func random(curve: EC.Curve) throws(CryptoError) -> EC.PrivateKey {
-        let keyData = try Crypto.EC.generateRandomPrivateKey(curve: curve)
+        let keyData = Crypto.EC.generateRandomPrivateKey(curve: curve)
         guard let key = EC.PrivateKey(x963Representation: keyData, curve: curve) else {
             throw .keyCreationFailed(nil)
         }

--- a/YubiKit/YubiKit/Errors/Session/PIVSessionError.swift
+++ b/YubiKit/YubiKit/Errors/Session/PIVSessionError.swift
@@ -57,11 +57,5 @@ public enum PIVSessionError: SmartCardSessionError, Sendable {
     /// Certificate decompression failed (gzip or GIDS zlib).
     case compression(Error, source: SourceLocation)
 
-    /// Gzip compression/decompression failed.
-    @available(*, deprecated, renamed: "compression")
-    static func gzip(_ error: Error, source: SourceLocation) -> PIVSessionError {
-        .compression(error, source: source)
-    }
-
     case other(Error, source: SourceLocation)
 }

--- a/YubiKit/YubiKit/FIDO/CTAP/MakeCredential/MakeCredentialResponse.swift
+++ b/YubiKit/YubiKit/FIDO/CTAP/MakeCredential/MakeCredentialResponse.swift
@@ -47,15 +47,5 @@ extension CTAP2.MakeCredential {
         ///
         /// Use extension-specific `result(from:)` methods for typed access to extension outputs.
         internal let unsignedExtensionOutputs: [String: CBOR.Value]?
-
-        // MARK: - Deprecated
-
-        /// Attestation statement format identifier.
-        @available(*, deprecated, renamed: "attestationObject.format")
-        public var format: String { attestationObject.format }
-
-        /// Parsed attestation statement.
-        @available(*, deprecated, renamed: "attestationObject.statement")
-        public var attestationStatement: WebAuthn.AttestationStatement { attestationObject.statement }
     }
 }

--- a/YubiKit/YubiKit/Management/ManagementSession.swift
+++ b/YubiKit/YubiKit/Management/ManagementSession.swift
@@ -16,13 +16,6 @@ import CryptoTokenKit
 import Foundation
 import OSLog
 
-// NEXTMAJOR: Remove these typealiases
-@available(*, deprecated, renamed: "Management.Session")
-public typealias ManagementSession = Management.Session
-
-@available(*, deprecated, renamed: "Management.Feature")
-public typealias ManagementFeature = Management.Feature
-
 public enum Management {
 
     /// Management session features.

--- a/YubiKit/YubiKit/Response.swift
+++ b/YubiKit/YubiKit/Response.swift
@@ -46,19 +46,6 @@ public struct Response: Sendable {
     public var rawStatus: UInt16 {
         responseStatus.rawStatus
     }
-
-    // NEXTMAJOR: Remove these deprecated properties
-    /// Convenience property to access sw1 directly
-    @available(*, deprecated, message: "Use responseStatus.sw1 instead")
-    public var sw1: UInt8 {
-        responseStatus.sw1
-    }
-
-    /// Convenience property to access sw2 directly
-    @available(*, deprecated, message: "Use responseStatus.sw2 instead")
-    public var sw2: UInt8 {
-        responseStatus.sw2
-    }
 }
 
 extension Response {
@@ -107,13 +94,4 @@ extension Response {
             self.init(sw1: UInt8((value & 0xff00) >> 8), sw2: UInt8(value & 0x00ff))
         }
     }
-}
-
-// NEXTMAJOR: Remove these typealiases
-@available(*, deprecated, renamed: "Response.Status")
-public typealias ResponseStatus = Response.Status
-
-extension Response.Status {
-    @available(*, deprecated, renamed: "Response.Status.Code")
-    public typealias StatusCode = Code
 }


### PR DESCRIPTION
Update all callsites to use new `token:` parameter (replacing `pinToken:`) and consolidate all deprecated API into a single `BackwardsCompatibility.swift` file for easier maintenance before 1.2.0 release.
