### PR TITLE
Fix HID connection cleanup to cancel pending receives on device removal

### DIFF
--- a/YubiKit/YubiKit/Connection/FIDO/HIDFIDOConnection.swift
+++ b/YubiKit/YubiKit/Connection/FIDO/HIDFIDOConnection.swift
@@ -233,6 +233,8 @@ private final class HIDConnectionManager: @unchecked Sendable, HasFIDOLogger {
             let data = try await promise.value()
             /* Fix trace: trace(message: "received \(data.count) bytes") */
             return data
+        } catch let error as FIDOConnectionError {
+            throw error
         } catch {
             throw .receiveFailed("HID receive failed", error)
         }
@@ -278,17 +280,31 @@ private final class HIDConnectionManager: @unchecked Sendable, HasFIDOLogger {
                 guard let ctx = context else { return }
                 let me = Unmanaged<HIDConnectionManager>.fromOpaque(ctx).takeUnretainedValue()
 
-                // Cancel pending I/O operations
-                IOHIDDeviceCancel(device)
-
                 // Remove from open connections and notify
                 if let locationID = IOHIDDeviceGetProperty(device, kIOHIDLocationIDKey as CFString) as? Int {
                     if let connection = me.openConnections[locationID] {
-                        let promise = connection.didClose
-                        Task { @Sendable in
-                            await promise.fulfill(nil)
+                        // Unregister input report callback
+                        connection.inputBuffer.withUnsafeMutableBytes { bufferPtr in
+                            IOHIDDeviceRegisterInputReportCallback(
+                                device,
+                                bufferPtr.baseAddress!.assumingMemoryBound(to: UInt8.self),
+                                bufferPtr.count,
+                                nil,
+                                nil
+                            )
                         }
+
+                        // Unschedule from run loop
+                        IOHIDDeviceUnscheduleFromRunLoop(device, me.runloop!, CFRunLoopMode.defaultMode.rawValue)
+
+                        let didClose = connection.didClose
+                        let pendingReceive = connection.pendingReceive
+                        connection.pendingReceive = nil
                         me.openConnections[locationID] = nil
+                        Task { @Sendable in
+                            await pendingReceive?.cancel(with: FIDOConnectionError.connectionLost)
+                            await didClose.fulfill(nil)
+                        }
                     }
                 }
             },
@@ -384,10 +400,13 @@ private final class HIDConnectionManager: @unchecked Sendable, HasFIDOLogger {
         // Unschedule from run loop
         IOHIDDeviceUnscheduleFromRunLoop(connectionState.device, runloop!, CFRunLoopMode.defaultMode.rawValue)
 
-        // Fulfill the promise
-        let promise = connectionState.didClose
+        // Cancel any pending receive and fulfill the close promise
+        let didClose = connectionState.didClose
+        let pendingReceive = connectionState.pendingReceive
+        connectionState.pendingReceive = nil
         Task { @Sendable in
-            await promise.fulfill(error)
+            await pendingReceive?.cancel(with: FIDOConnectionError.connectionLost)
+            await didClose.fulfill(error)
         }
 
         // Close the device

--- a/YubiKit/YubiKit/Connection/FIDO/HIDFIDOConnection.swift
+++ b/YubiKit/YubiKit/Connection/FIDO/HIDFIDOConnection.swift
@@ -282,29 +282,8 @@ private final class HIDConnectionManager: @unchecked Sendable, HasFIDOLogger {
 
                 // Remove from open connections and notify
                 if let locationID = IOHIDDeviceGetProperty(device, kIOHIDLocationIDKey as CFString) as? Int {
-                    if let connection = me.openConnections[locationID] {
-                        // Unregister input report callback
-                        connection.inputBuffer.withUnsafeMutableBytes { bufferPtr in
-                            IOHIDDeviceRegisterInputReportCallback(
-                                device,
-                                bufferPtr.baseAddress!.assumingMemoryBound(to: UInt8.self),
-                                bufferPtr.count,
-                                nil,
-                                nil
-                            )
-                        }
-
-                        // Unschedule from run loop
-                        IOHIDDeviceUnscheduleFromRunLoop(device, me.runloop!, CFRunLoopMode.defaultMode.rawValue)
-
-                        let didClose = connection.didClose
-                        let pendingReceive = connection.pendingReceive
-                        connection.pendingReceive = nil
-                        me.openConnections[locationID] = nil
-                        Task { @Sendable in
-                            await pendingReceive?.cancel(with: FIDOConnectionError.connectionLost)
-                            await didClose.fulfill(nil)
-                        }
+                    if let connection = me.openConnections.removeValue(forKey: locationID) {
+                        me.teardownConnection(connection, closeError: nil)
                     }
                 }
             },
@@ -386,32 +365,29 @@ private final class HIDConnectionManager: @unchecked Sendable, HasFIDOLogger {
             return
         }
 
-        // Unregister input report callback
-        connectionState.inputBuffer.withUnsafeMutableBytes { bufferPtr in
+        teardownConnection(connectionState, closeError: error)
+        IOHIDDeviceClose(connectionState.device, IOOptionBits(kIOHIDOptionsTypeSeizeDevice))
+    }
+
+    private func teardownConnection(_ connection: HIDConnectionState, closeError: Error?) {
+        // Passing nil callback to IOHIDDeviceRegisterInputReportCallback unregisters it
+        connection.inputBuffer.withUnsafeMutableBytes { bufferPtr in
             IOHIDDeviceRegisterInputReportCallback(
-                connectionState.device,
+                connection.device,
                 bufferPtr.baseAddress!.assumingMemoryBound(to: UInt8.self),
                 bufferPtr.count,
-                nil,  // nil callback unregisters
+                nil,
                 nil
             )
         }
+        IOHIDDeviceUnscheduleFromRunLoop(connection.device, runloop!, CFRunLoopMode.defaultMode.rawValue)
 
-        // Unschedule from run loop
-        IOHIDDeviceUnscheduleFromRunLoop(connectionState.device, runloop!, CFRunLoopMode.defaultMode.rawValue)
-
-        // Cancel any pending receive and fulfill the close promise
-        let didClose = connectionState.didClose
-        let pendingReceive = connectionState.pendingReceive
-        connectionState.pendingReceive = nil
+        let didClose = connection.didClose
+        let pendingReceive = connection.pendingReceive
         Task { @Sendable in
             await pendingReceive?.cancel(with: FIDOConnectionError.connectionLost)
-            await didClose.fulfill(error)
+            await didClose.fulfill(closeError)
         }
-
-        // Close the device
-        IOHIDDeviceClose(connectionState.device, IOOptionBits(kIOHIDOptionsTypeSeizeDevice))
-        /* Fix trace: trace(message: "device closed") */
     }
 
     private func sendPacketInternal(_ packet: Data, to locationID: Int) -> Result<Void, FIDOConnectionError> {

--- a/YubiKit/YubiKit/Connection/FIDO/HIDFIDOConnection.swift
+++ b/YubiKit/YubiKit/Connection/FIDO/HIDFIDOConnection.swift
@@ -384,6 +384,7 @@ private final class HIDConnectionManager: @unchecked Sendable, HasFIDOLogger {
 
         let didClose = connection.didClose
         let pendingReceive = connection.pendingReceive
+        connection.pendingReceive = nil
         Task { @Sendable in
             await pendingReceive?.cancel(with: FIDOConnectionError.connectionLost)
             await didClose.fulfill(closeError)


### PR DESCRIPTION
## Summary
- Unplugging a YubiKey during a pending HID receive caused an assertion failure (crash!) from `IOHIDDeviceCancel` being called inside the device removal callback
- Now properly cleans up on device removal: unregisters input report callback, unschedules from run loop, and cancels pending receives with `.connectionLost`

## Tested
✅  - Connect YubiKey, start a FIDO operation, unplug mid-operation: should get `connectionLost` error instead of crash
