### PR TITLE
Fix continuation APDU to use ISO 7816-4 Case 2 Short encoding

### DIFF
--- a/YubiKit/YubiKit/Session/SmartCard/SmartCardInterface.swift
+++ b/YubiKit/YubiKit/Session/SmartCard/SmartCardInterface.swift
@@ -204,7 +204,9 @@ public final actor SmartCardInterface<Error: SmartCardSessionError>: Sendable {
         return response.data
     }
 
-    // Send APDU and handle continuation responses (0x61).
+    // Send APDU and handle continuation responses (SW1=0x61).
+    // When a card responds with 0x61, SW2 indicates the number of remaining bytes.
+    // We issue a GET RESPONSE APDU (ISO 7816-4 Case 2 Short) with Le=SW2 to retrieve them.
     // Used during actor init before instance methods are available.
     private static func sendWithContinuationStatic(
         connection: SmartCardConnection,
@@ -213,12 +215,12 @@ public final actor SmartCardInterface<Error: SmartCardSessionError>: Sendable {
         readMoreData: Bool,
         insSendRemaining: UInt8
     ) async throws(Error) -> Response {
-        // Send APDU or continuation command
         let responseData: Data
         do {
             if readMoreData {
-                let continueApdu = APDU(cla: 0, ins: insSendRemaining, p1: 0, p2: 0, command: nil)
-                responseData = try await connection.send(data: continueApdu.data)
+                // Continuation APDU (Case 2 Short): CLA=00 INS P1=00 P2=00 Le=00
+                let getResponse = Data([0x00, insSendRemaining, 0x00, 0x00, 0x00])
+                responseData = try await connection.send(data: getResponse)
             } else {
                 responseData = try await connection.send(data: apdu.data)
             }


### PR DESCRIPTION
## Summary

- Fix continuation APDUs to use ISO 7816-4 Case 2 Short encoding (5 bytes with Le=0x00) instead of Case 1 (4 bytes without Le)
- Applies to both ISO GET RESPONSE (0xC0) and OATH SEND REMAINING (0xA5) continuation paths

Should fix #99 and replaces #108

## Context

The previous implementation sent a Case 1 APDU `(CLA INS P1 P2)` for continuation, which semantically means "I expect zero response bytes." The correct encoding for a command that expects data back is Case 2 Short `(CLA INS P1 P2 Le)`. This aligns with [yubikit-android](https://github.com/Yubico/yubikit-android/blob/main/core/src/main/java/com/yubico/yubikit/core/smartcard/ChainedResponseProcessor.java#L32-L33) and [yubikit-python](https://github.com/Yubico/yubikey-manager/blob/main/yubikit/core/smartcard/__init__.py#L208-L212).