### PR TITLE
Updating swift-public-api-diff

### DIFF
--- a/.github/workflows/public-api-diff.yml
+++ b/.github/workflows/public-api-diff.yml
@@ -35,14 +35,14 @@ jobs:
         echo "NEW_VERSION=$NEW" >> $GITHUB_ENV
     
     - name: Detect YubiKit Public API Changes (macOS)
-      uses: Adyen/adyen-swift-public-api-diff@61d3be134cfdd1a8b6f2165e23a74a0086460234 # 0.10.1
+      uses: Adyen/adyen-swift-public-api-diff@9ed54d9884b1a8f0e2c1ecde353793ea8ce7132b # 0.11.2
       with:
         platform: macOS
         new: ${{ env.NEW_VERSION }}
         old: ${{ env.OLD_VERSION }}
 
     - name: Detect YubiKit Public API Changes (iOS)
-      uses: Adyen/adyen-swift-public-api-diff@61d3be134cfdd1a8b6f2165e23a74a0086460234 # 0.10.1
+      uses: Adyen/adyen-swift-public-api-diff@9ed54d9884b1a8f0e2c1ecde353793ea8ce7132b # 0.11.2
       with:
         platform: iOS
         new: ${{ env.NEW_VERSION }}


### PR DESCRIPTION
This fixes the `No analyzable targets detected` issue