### PR TITLE
Accept {"publicKey": {...}} envelope in WebAuthn options JSON

### DIFF
--- a/YubiKit/UnitTests/FIDO/WebAuthn/SerializationTests+JSON.swift
+++ b/YubiKit/UnitTests/FIDO/WebAuthn/SerializationTests+JSON.swift
@@ -192,23 +192,15 @@ extension SerializationTests {
             #expect(options.user.id == Data("user_id".utf8))
         }
 
-        @Test("Registration.Options JSON decoding - strict envelope rejects extra top-level keys")
-        func testRegistrationOptionsJSONStrictEnvelopeRejectsExtras() throws {
-            // Envelope with a sibling key — must NOT be treated as an envelope.
-            // The bare parser will then also fail because the root has no
-            // required fields, so from(json:) should throw.
+        @Test("Registration.Options JSON decoding - envelope inner DecodingError is preserved")
+        func testRegistrationOptionsJSONEnvelopeInnerError() throws {
+            // Envelope shape is valid; inner publicKey is missing required `challenge`.
+            // The inner DecodingError must surface, not a vague "envelope failed".
             let json = """
-                {
-                    "publicKey": {
-                        "challenge": "Y2hhbGxlbmdl",
-                        "rp": {"id": "example.com", "name": "Example"},
-                        "user": {"id": "dXNlcl9pZA", "name": "user"}
-                    },
-                    "stray": "x"
-                }
+                {"publicKey": {"rp": {"id": "example.com"}}}
                 """
 
-            #expect(throws: (any Error).self) {
+            #expect(throws: DecodingError.self) {
                 try WebAuthn.Registration.Options.from(json: Data(json.utf8))
             }
         }
@@ -221,6 +213,23 @@ extension SerializationTests {
                         "challenge": "Y2hhbGxlbmdl",
                         "rpId": "example.com"
                     }
+                }
+                """
+
+            let options = try WebAuthn.Authentication.Options.from(json: Data(json.utf8))
+            #expect(options.challenge == Data("challenge".utf8))
+            #expect(options.rpId == "example.com")
+        }
+
+        @Test("Authentication.Options JSON decoding - envelope tolerates siblings (mediation)")
+        func testAuthenticationOptionsJSONEnvelopeWithSiblings() throws {
+            let json = """
+                {
+                    "publicKey": {
+                        "challenge": "Y2hhbGxlbmdl",
+                        "rpId": "example.com"
+                    },
+                    "mediation": "conditional"
                 }
                 """
 

--- a/YubiKit/UnitTests/FIDO/WebAuthn/SerializationTests+JSON.swift
+++ b/YubiKit/UnitTests/FIDO/WebAuthn/SerializationTests+JSON.swift
@@ -174,6 +174,61 @@ extension SerializationTests {
             #expect(options.excludeCredentials.isEmpty)
         }
 
+        @Test("Registration.Options JSON decoding - {\"publicKey\": {...}} envelope")
+        func testRegistrationOptionsJSONPublicKeyEnvelope() throws {
+            let json = """
+                {
+                    "publicKey": {
+                        "challenge": "Y2hhbGxlbmdl",
+                        "rp": {"id": "example.com", "name": "Example"},
+                        "user": {"id": "dXNlcl9pZA", "name": "user"}
+                    }
+                }
+                """
+
+            let options = try WebAuthn.Registration.Options.from(json: Data(json.utf8))
+            #expect(options.challenge == Data("challenge".utf8))
+            #expect(options.rp.id == "example.com")
+            #expect(options.user.id == Data("user_id".utf8))
+        }
+
+        @Test("Registration.Options JSON decoding - strict envelope rejects extra top-level keys")
+        func testRegistrationOptionsJSONStrictEnvelopeRejectsExtras() throws {
+            // Envelope with a sibling key — must NOT be treated as an envelope.
+            // The bare parser will then also fail because the root has no
+            // required fields, so from(json:) should throw.
+            let json = """
+                {
+                    "publicKey": {
+                        "challenge": "Y2hhbGxlbmdl",
+                        "rp": {"id": "example.com", "name": "Example"},
+                        "user": {"id": "dXNlcl9pZA", "name": "user"}
+                    },
+                    "stray": "x"
+                }
+                """
+
+            #expect(throws: (any Error).self) {
+                try WebAuthn.Registration.Options.from(json: Data(json.utf8))
+            }
+        }
+
+        @Test("Authentication.Options JSON decoding - {\"publicKey\": {...}} envelope")
+        func testAuthenticationOptionsJSONPublicKeyEnvelope() throws {
+            let json = """
+                {
+                    "publicKey": {
+                        "challenge": "Y2hhbGxlbmdl",
+                        "rpId": "example.com"
+                    }
+                }
+                """
+
+            let options = try WebAuthn.Authentication.Options.from(json: Data(json.utf8))
+            #expect(options.challenge == Data("challenge".utf8))
+            #expect(options.rpId == "example.com")
+        }
+
         @Test("Registration.Options JSON decoding - requireResidentKey fallback")
         func testRegistrationOptionsJSONRequireResidentKey() throws {
             let json = """

--- a/YubiKit/YubiKit/FIDO/WebAuthn/WebAuthn+JSON.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/WebAuthn+JSON.swift
@@ -18,16 +18,10 @@ import Foundation
 
 extension WebAuthn.Registration.Options {
     /// Parses registration options from JSON data received from a relying party.
-    ///
-    /// Accepts either the bare `PublicKeyCredentialCreationOptions` JSON
-    /// (as consumed by `PublicKeyCredential.parseCreationOptionsFromJSON`)
-    /// or the `{"publicKey": {...}}` envelope used as the argument to
-    /// `navigator.credentials.create()`.
+    /// Accepts the bare `PublicKeyCredentialCreationOptions` JSON or the
+    /// `{"publicKey": {...}}` envelope passed to `navigator.credentials.create()`.
     public static func from(json data: Data) throws -> Self {
-        if let wrapped = try? JSONDecoder().decode(PublicKeyEnvelope<Self>.self, from: data) {
-            return wrapped.publicKey
-        }
-        return try JSONDecoder().decode(Self.self, from: data)
+        try decodeOptions(from: data)
     }
 }
 
@@ -40,47 +34,10 @@ extension WebAuthn.Registration.Response {
 
 extension WebAuthn.Authentication.Options {
     /// Parses authentication options from JSON data received from a relying party.
-    ///
-    /// Accepts either the bare `PublicKeyCredentialRequestOptions` JSON
-    /// (as consumed by `PublicKeyCredential.parseRequestOptionsFromJSON`)
-    /// or the `{"publicKey": {...}}` envelope used as the argument to
-    /// `navigator.credentials.get()`.
+    /// Accepts the bare `PublicKeyCredentialRequestOptions` JSON or the
+    /// `{"publicKey": {...}}` envelope passed to `navigator.credentials.get()`.
     public static func from(json data: Data) throws -> Self {
-        if let wrapped = try? JSONDecoder().decode(PublicKeyEnvelope<Self>.self, from: data) {
-            return wrapped.publicKey
-        }
-        return try JSONDecoder().decode(Self.self, from: data)
-    }
-}
-
-/// Unwraps a `{"publicKey": {...}}` envelope. Strict: the root object must
-/// contain *only* the `publicKey` key, so a bare options blob that happens
-/// to have a stray `publicKey` field alongside others cannot be mis-detected.
-///
-/// Uses a dynamic-keys container to see *every* key present in the JSON
-/// (a static CodingKeys enum would silently drop unknown keys and let
-/// non-envelope JSON pass the guard).
-private struct PublicKeyEnvelope<T: Decodable>: Decodable {
-    let publicKey: T
-
-    private struct AnyKey: CodingKey {
-        let stringValue: String
-        var intValue: Int? { nil }
-        init(stringValue: String) { self.stringValue = stringValue }
-        init?(intValue: Int) { nil }
-    }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: AnyKey.self)
-        guard container.allKeys.count == 1,
-            let key = container.allKeys.first,
-            key.stringValue == "publicKey"
-        else {
-            throw DecodingError.dataCorrupted(
-                .init(codingPath: [], debugDescription: "not a publicKey envelope")
-            )
-        }
-        self.publicKey = try container.decode(T.self, forKey: key)
+        try decodeOptions(from: data)
     }
 }
 
@@ -120,6 +77,21 @@ private struct Milliseconds: Decodable {
         let ms = try decoder.singleValueContainer().decode(Int.self)
         duration = .milliseconds(ms)
     }
+}
+
+// MARK: - Options Envelope
+
+private func decodeOptions<T: Decodable>(from data: Data) throws -> T {
+    let decoder = JSONDecoder()
+    let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    if root?["publicKey"] is [String: Any] {
+        return try decoder.decode(PublicKeyEnvelope<T>.self, from: data).publicKey
+    }
+    return try decoder.decode(T.self, from: data)
+}
+
+private struct PublicKeyEnvelope<T: Decodable>: Decodable {
+    let publicKey: T
 }
 
 // MARK: - Entity Decodable

--- a/YubiKit/YubiKit/FIDO/WebAuthn/WebAuthn+JSON.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/WebAuthn+JSON.swift
@@ -18,8 +18,16 @@ import Foundation
 
 extension WebAuthn.Registration.Options {
     /// Parses registration options from JSON data received from a relying party.
+    ///
+    /// Accepts either the bare `PublicKeyCredentialCreationOptions` JSON
+    /// (as consumed by `PublicKeyCredential.parseCreationOptionsFromJSON`)
+    /// or the `{"publicKey": {...}}` envelope used as the argument to
+    /// `navigator.credentials.create()`.
     public static func from(json data: Data) throws -> Self {
-        try JSONDecoder().decode(Self.self, from: data)
+        if let wrapped = try? JSONDecoder().decode(PublicKeyEnvelope<Self>.self, from: data) {
+            return wrapped.publicKey
+        }
+        return try JSONDecoder().decode(Self.self, from: data)
     }
 }
 
@@ -32,8 +40,47 @@ extension WebAuthn.Registration.Response {
 
 extension WebAuthn.Authentication.Options {
     /// Parses authentication options from JSON data received from a relying party.
+    ///
+    /// Accepts either the bare `PublicKeyCredentialRequestOptions` JSON
+    /// (as consumed by `PublicKeyCredential.parseRequestOptionsFromJSON`)
+    /// or the `{"publicKey": {...}}` envelope used as the argument to
+    /// `navigator.credentials.get()`.
     public static func from(json data: Data) throws -> Self {
-        try JSONDecoder().decode(Self.self, from: data)
+        if let wrapped = try? JSONDecoder().decode(PublicKeyEnvelope<Self>.self, from: data) {
+            return wrapped.publicKey
+        }
+        return try JSONDecoder().decode(Self.self, from: data)
+    }
+}
+
+/// Unwraps a `{"publicKey": {...}}` envelope. Strict: the root object must
+/// contain *only* the `publicKey` key, so a bare options blob that happens
+/// to have a stray `publicKey` field alongside others cannot be mis-detected.
+///
+/// Uses a dynamic-keys container to see *every* key present in the JSON
+/// (a static CodingKeys enum would silently drop unknown keys and let
+/// non-envelope JSON pass the guard).
+private struct PublicKeyEnvelope<T: Decodable>: Decodable {
+    let publicKey: T
+
+    private struct AnyKey: CodingKey {
+        let stringValue: String
+        var intValue: Int? { nil }
+        init(stringValue: String) { self.stringValue = stringValue }
+        init?(intValue: Int) { nil }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: AnyKey.self)
+        guard container.allKeys.count == 1,
+            let key = container.allKeys.first,
+            key.stringValue == "publicKey"
+        else {
+            throw DecodingError.dataCorrupted(
+                .init(codingPath: [], debugDescription: "not a publicKey envelope")
+            )
+        }
+        self.publicKey = try container.decode(T.self, forKey: key)
     }
 }
 

--- a/YubiKit/YubiKit/FIDO/WebAuthn/WebAuthn+JSON.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/WebAuthn+JSON.swift
@@ -83,11 +83,13 @@ private struct Milliseconds: Decodable {
 
 private func decodeOptions<T: Decodable>(from data: Data) throws -> T {
     let decoder = JSONDecoder()
-    let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-    if root?["publicKey"] is [String: Any] {
+    do {
         return try decoder.decode(PublicKeyEnvelope<T>.self, from: data).publicKey
+    } catch DecodingError.keyNotFound(let key, let context)
+        where key.stringValue == "publicKey" && context.codingPath.isEmpty
+    {
+        return try decoder.decode(T.self, from: data)
     }
-    return try decoder.decode(T.self, from: data)
 }
 
 private struct PublicKeyEnvelope<T: Decodable>: Decodable {


### PR DESCRIPTION

`WebAuthn.Registration.Options.from(json:)` and `WebAuthn.Authentication.Options.from(json:)` now accepts either:

- the bare `PublicKeyCredential{Creation,Request}OptionsJSON` blob, or
- the `{ "publicKey": { ... } }` envelope passed to `navigator.credentials.create()` / `.get()`.

Envelope detection uses a `JSONSerialization` probe so inner `DecodingError`s surface unchanged when the envelope is well-formed but the inner body is not. Per the Credential Management spec, sibling keys such as `mediation` are tolerated alongside `publicKey`.