### PR TITLE
Add thirdPartyPayment WebAuthn extension support

### DIFF
--- a/FullStackTests/FullStackTests.xcodeproj/project.pbxproj
+++ b/FullStackTests/FullStackTests.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		6CMINPINLEN2F1116000000001 /* MinPinLengthTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CMINPINLEN2F1116000000000 /* MinPinLengthTests.swift */; };
 		6CPRFTESTS2F1117000000001 /* PRFTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CPRFTESTS2F1117000000000 /* PRFTests.swift */; };
 		779EBC62B6E784C5C1320407 /* PreviewSignTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC40A418A935EF93F6F5521 /* PreviewSignTests.swift */; };
+		EE0A8A7057516B37293D73DC /* ThirdPartyPaymentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A87E8C8C603A7CC6C29061C /* ThirdPartyPaymentTests.swift */; };
 		B2A73E5DE80348329B8FA710 /* EncryptedFieldsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E3FD736FBE49ECAAAFA28E /* EncryptedFieldsTests.swift */; };
 		B41B618C274443BE004C37BF /* XCTestCase+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B41B618A27444373004C37BF /* XCTestCase+Extensions.swift */; };
 		B4235A48297048FD00BCD126 /* ManagementFullStackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4235A47297048FD00BCD126 /* ManagementFullStackTests.swift */; };
@@ -78,6 +79,7 @@
 		6CMINPINLEN2F1116000000000 /* MinPinLengthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinPinLengthTests.swift; sourceTree = "<group>"; };
 		6CPRFTESTS2F1117000000000 /* PRFTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRFTests.swift; sourceTree = "<group>"; };
 		4BC40A418A935EF93F6F5521 /* PreviewSignTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewSignTests.swift; sourceTree = "<group>"; };
+		6A87E8C8C603A7CC6C29061C /* ThirdPartyPaymentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThirdPartyPaymentTests.swift; sourceTree = "<group>"; };
 		72D7C4A8CBA8427693C73A4D /* BioEnrollmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BioEnrollmentTests.swift; sourceTree = "<group>"; };
 		B41B618A27444373004C37BF /* XCTestCase+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Extensions.swift"; sourceTree = "<group>"; };
 		B4235A47297048FD00BCD126 /* ManagementFullStackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagementFullStackTests.swift; sourceTree = "<group>"; };
@@ -233,6 +235,7 @@
 				6CMINPINLEN2F1116000000000 /* MinPinLengthTests.swift */,
 				4BC40A418A935EF93F6F5521 /* PreviewSignTests.swift */,
 				6CPRFTESTS2F1117000000000 /* PRFTests.swift */,
+				6A87E8C8C603A7CC6C29061C /* ThirdPartyPaymentTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -370,6 +373,7 @@
 				6CCREDBLOB2F1115000000001 /* CredBlobTests.swift in Sources */,
 				6CMINPINLEN2F1116000000001 /* MinPinLengthTests.swift in Sources */,
 				779EBC62B6E784C5C1320407 /* PreviewSignTests.swift in Sources */,
+				EE0A8A7057516B37293D73DC /* ThirdPartyPaymentTests.swift in Sources */,
 				6CPRFTESTS2F1117000000001 /* PRFTests.swift in Sources */,
 				6C2B14552DC8CF4C00B5C482 /* XCTestCase+SCP.swift in Sources */,
 				6CDATAHEX2EF1234500000001 /* Data+Hex.swift in Sources */,

--- a/FullStackTests/Tests/WebAuthn/Extensions/ThirdPartyPaymentTests.swift
+++ b/FullStackTests/Tests/WebAuthn/Extensions/ThirdPartyPaymentTests.swift
@@ -62,7 +62,7 @@ struct WebAuthnThirdPartyPaymentExtensionTests {
                 residentKey: discoverable ? .required : .discouraged,
                 userVerification: .discouraged,
                 extensions: registerWithPayment
-                    ? .init(thirdPartyPayment: .init(isPayment: true))
+                    ? .init(thirdPartyPayment: .enabled)
                     : nil
             )
 
@@ -74,7 +74,7 @@ struct WebAuthnThirdPartyPaymentExtensionTests {
                 challenge: randomBytes(count: 32),
                 rpId: rpId,
                 allowCredentials: discoverable ? [] : [.init(id: createResponse.credentialId)],
-                extensions: .init(thirdPartyPayment: .init(isPayment: true))
+                extensions: .init(thirdPartyPayment: .enabled)
             )
 
             let authResponse = try await client.getAssertion(authOptions).value(pin: defaultTestPin)[0].select()

--- a/FullStackTests/Tests/WebAuthn/Extensions/ThirdPartyPaymentTests.swift
+++ b/FullStackTests/Tests/WebAuthn/Extensions/ThirdPartyPaymentTests.swift
@@ -1,0 +1,86 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Testing
+
+@testable import YubiKit
+
+@Suite("WebAuthn ThirdPartyPayment Extension Tests", .serialized)
+struct WebAuthnThirdPartyPaymentExtensionTests {
+
+    @Test(
+        "ThirdPartyPayment - Echoed false when credential not registered as payment",
+        arguments: [true, false]
+    )
+    func testEchoedFalseWithoutRegistration(discoverable: Bool) async throws {
+        try await runTest(registerWithPayment: false, discoverable: discoverable, expectedEcho: false)
+    }
+
+    @Test(
+        "ThirdPartyPayment - Echoed true when credential registered as payment",
+        arguments: [true, false]
+    )
+    func testEchoedTrueWithRegistration(discoverable: Bool) async throws {
+        try await runTest(registerWithPayment: true, discoverable: discoverable, expectedEcho: true)
+    }
+
+    private func runTest(
+        registerWithPayment: Bool,
+        discoverable: Bool,
+        expectedEcho: Bool
+    ) async throws {
+        try await withReconnectableWebAuthnClient { client, session, reconnect in
+            var client = client
+
+            guard try await CTAP2.Extension.ThirdPartyPayment.isSupported(by: session) else {
+                print("thirdPartyPayment not supported - skipping")
+                return
+            }
+
+            let rpId = "example.com"
+
+            let createOptions = WebAuthn.Registration.Options(
+                challenge: randomBytes(count: 32),
+                rp: .init(id: rpId, name: "ThirdPartyPayment Test"),
+                user: .init(
+                    id: randomBytes(count: 32),
+                    name: "tpp@example.com",
+                    displayName: "TPP User"
+                ),
+                residentKey: discoverable ? .required : .discouraged,
+                userVerification: .discouraged,
+                extensions: registerWithPayment
+                    ? .init(thirdPartyPayment: .init(isPayment: true))
+                    : nil
+            )
+
+            let createResponse = try await client.makeCredential(createOptions).value(pin: defaultTestPin)
+
+            client = try await reconnect().client
+
+            let authOptions = WebAuthn.Authentication.Options(
+                challenge: randomBytes(count: 32),
+                rpId: rpId,
+                allowCredentials: discoverable ? [] : [.init(id: createResponse.credentialId)],
+                extensions: .init(thirdPartyPayment: .init(isPayment: true))
+            )
+
+            let authResponse = try await client.getAssertion(authOptions).value(pin: defaultTestPin)[0].select()
+
+            let echoedBit = authResponse.clientExtensionResults.thirdPartyPayment?.isPaymentEnabled
+            #expect(echoedBit == expectedEcho)
+        }
+    }
+}

--- a/YubiKit/UnitTests/FIDO/WebAuthn/MockWebAuthnBackend.swift
+++ b/YubiKit/UnitTests/FIDO/WebAuthn/MockWebAuthnBackend.swift
@@ -106,6 +106,9 @@ actor MockWebAuthnBackend: WebAuthn.Backend {
 
     // previewSign
     func makePreviewSign() async throws(CTAP2.SessionError) -> CTAP2.Extension.PreviewSign { fatalError() }
+
+    // thirdPartyPayment
+    func makeThirdPartyPayment() async throws(CTAP2.SessionError) -> CTAP2.Extension.ThirdPartyPayment { fatalError() }
 }
 
 // MARK: - StatusStream Helpers

--- a/YubiKit/UnitTests/FIDO/WebAuthn/SerializationTests+JSON.swift
+++ b/YubiKit/UnitTests/FIDO/WebAuthn/SerializationTests+JSON.swift
@@ -205,6 +205,66 @@ extension SerializationTests {
             }
         }
 
+        @Test("Registration.Options JSON decoding - thirdPartyPayment (payment) extension")
+        func testRegistrationOptionsJSONThirdPartyPayment() throws {
+            let json = """
+                {
+                    "challenge": "Y2hhbGxlbmdl",
+                    "rp": {"id": "example.com", "name": "Example"},
+                    "user": {"id": "dXNlcl9pZA", "name": "user"},
+                    "extensions": {"payment": {"isPayment": true}}
+                }
+                """
+
+            let options = try WebAuthn.Registration.Options.from(json: Data(json.utf8))
+            #expect(options.extensions?.thirdPartyPayment?.isPayment == true)
+        }
+
+        @Test("Authentication.Options JSON decoding - thirdPartyPayment ignores SPC metadata")
+        func testAuthenticationOptionsJSONThirdPartyPayment() throws {
+            // RP servers may send the full SPC dictionary; decoding must accept the extra fields.
+            let json = """
+                {
+                    "challenge": "Y2hhbGxlbmdl",
+                    "rpId": "example.com",
+                    "extensions": {
+                        "payment": {
+                            "isPayment": true,
+                            "rpId": "example.com",
+                            "topOrigin": "https://shop.example",
+                            "payeeName": "Example Shop",
+                            "payeeOrigin": "https://shop.example",
+                            "total": {"currency": "USD", "value": "10.00"},
+                            "instrument": {
+                                "displayName": "Visa card",
+                                "icon": "https://example.com/icon.png"
+                            }
+                        }
+                    }
+                }
+                """
+
+            let options = try WebAuthn.Authentication.Options.from(json: Data(json.utf8))
+            let payment = try #require(options.extensions?.thirdPartyPayment)
+            #expect(payment.isPayment == true)
+        }
+
+        @Test("Registration.Options JSON decoding - thirdPartyPayment isPayment:false decodes to false")
+        func testRegistrationOptionsJSONThirdPartyPaymentFalse() throws {
+            let json = """
+                {
+                    "challenge": "Y2hhbGxlbmdl",
+                    "rp": {"id": "example.com", "name": "Example"},
+                    "user": {"id": "dXNlcl9pZA", "name": "user"},
+                    "extensions": {"payment": {"isPayment": false}}
+                }
+                """
+
+            let options = try WebAuthn.Registration.Options.from(json: Data(json.utf8))
+            let payment = try #require(options.extensions?.thirdPartyPayment)
+            #expect(payment.isPayment == false)
+        }
+
         @Test("Authentication.Options JSON decoding - {\"publicKey\": {...}} envelope")
         func testAuthenticationOptionsJSONPublicKeyEnvelope() throws {
             let json = """

--- a/YubiKit/UnitTests/FIDO/WebAuthn/ThirdPartyPaymentBuildingTests.swift
+++ b/YubiKit/UnitTests/FIDO/WebAuthn/ThirdPartyPaymentBuildingTests.swift
@@ -1,0 +1,46 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Testing
+
+@testable import YubiKit
+
+/// Verifies that `isPayment: false` (or absent) does NOT append a CTAP
+/// `thirdPartyPayment` input. Spec only defines `true` (CTAP 2.3 §12.9);
+/// matches python-fido2 behavior, diverges from yubikit-android (which
+/// forwards `false`).
+@Suite("ThirdPartyPayment Extension Input Building")
+struct ThirdPartyPaymentBuildingTests {
+
+    @Test("makeCredential: isPayment=false produces empty ctapInputs")
+    func testMakeCredentialIsPaymentFalse() async throws {
+        let mock = MockWebAuthnBackend()
+        let result = try await mock.buildMakeCredentialExtensions(
+            .init(thirdPartyPayment: .init(isPayment: false))
+        )
+        #expect(result.ctapInputs.isEmpty)
+    }
+
+    @Test("getAssertion: isPayment=false produces empty ctapInputs")
+    func testGetAssertionIsPaymentFalse() async throws {
+        let mock = MockWebAuthnBackend()
+        let result = try await mock.buildGetAssertionExtensions(
+            .init(thirdPartyPayment: .init(isPayment: false)),
+            allowCredentials: [],
+            selectedCredentialId: nil
+        )
+        #expect(result.ctapInputs.isEmpty)
+    }
+}

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Client/Backends/CTAP2Backend.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Client/Backends/CTAP2Backend.swift
@@ -90,6 +90,9 @@ extension WebAuthn {
 
         // previewSign
         func makePreviewSign() async throws(CTAP2.SessionError) -> CTAP2.Extension.PreviewSign
+
+        // thirdPartyPayment
+        func makeThirdPartyPayment() async throws(CTAP2.SessionError) -> CTAP2.Extension.ThirdPartyPayment
     }
 }
 
@@ -169,5 +172,10 @@ extension CTAP2.Session: WebAuthn.Backend {
     // previewSign
     func makePreviewSign() async throws(CTAP2.SessionError) -> CTAP2.Extension.PreviewSign {
         try await CTAP2.Extension.PreviewSign(session: self)
+    }
+
+    // thirdPartyPayment
+    func makeThirdPartyPayment() async throws(CTAP2.SessionError) -> CTAP2.Extension.ThirdPartyPayment {
+        try await CTAP2.Extension.ThirdPartyPayment(session: self)
     }
 }

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Client/Shared/Backend+Extensions.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Client/Shared/Backend+Extensions.swift
@@ -107,6 +107,12 @@ extension WebAuthn.Backend {
             }
         }
 
+        if let payment = inputs.thirdPartyPayment, payment.isPayment {
+            if let ext = try? await makeThirdPartyPayment() {
+                ctapInputs.append(ext.makeCredential.input())
+            }
+        }
+
         return (ctapInputs, prf, previewSign, largeBlobRequested)
     }
 
@@ -227,6 +233,12 @@ extension WebAuthn.Backend {
             }
         }
 
+        if let payment = inputs.thirdPartyPayment, payment.isPayment {
+            if let ext = try? await makeThirdPartyPayment() {
+                ctapInputs.append(ext.getAssertion.input())
+            }
+        }
+
         return (ctapInputs, prf, previewSign, largeBlobAction)
     }
 
@@ -283,6 +295,9 @@ extension WebAuthn.Backend {
         let credPropsOutput: WebAuthn.Extension.CredProps.Registration.Output? =
             credPropsRk.map { .init(rk: $0) }
 
+        let thirdPartyPaymentOutput: WebAuthn.Extension.ThirdPartyPayment.Registration.Output? =
+            extensions?[.thirdPartyPayment]?.boolValue.map { .init(isPaymentEnabled: $0) }
+
         return WebAuthn.Extension.RegistrationOutputs(
             prf: prfOutput,
             credProtect: credProtectOutput,
@@ -290,7 +305,8 @@ extension WebAuthn.Backend {
             minPinLength: minPinLengthOutput,
             largeBlob: largeBlobOutput,
             credProps: credPropsOutput,
-            previewSign: previewSignOutput
+            previewSign: previewSignOutput,
+            thirdPartyPayment: thirdPartyPaymentOutput
         )
     }
 
@@ -322,11 +338,16 @@ extension WebAuthn.Backend {
             }
         }
 
+        let thirdPartyPaymentOutput: WebAuthn.Extension.ThirdPartyPayment.Authentication.Output? =
+            response.authenticatorData.extensions?[.thirdPartyPayment]?.boolValue
+            .map { .init(isPaymentEnabled: $0) }
+
         return WebAuthn.Extension.AuthenticationOutputs(
             prf: prfOutput,
             credBlob: credBlobOutput,
             largeBlob: largeBlobOutput,
-            previewSign: previewSignOutput
+            previewSign: previewSignOutput,
+            thirdPartyPayment: thirdPartyPaymentOutput
         )
     }
 

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Extensions/ExtensionInputs.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Extensions/ExtensionInputs.swift
@@ -84,6 +84,9 @@ extension WebAuthn.Extension {
         /// during credential registration.
         public let previewSign: PreviewSign.Registration.Input?
 
+        /// Mark the credential as usable for Secure Payment Confirmation.
+        public let thirdPartyPayment: ThirdPartyPayment.Registration.Input?
+
         public init(
             prf: PRF.Registration.Input? = nil,
             credProtect: CredProtect.Registration.Input? = nil,
@@ -91,7 +94,8 @@ extension WebAuthn.Extension {
             minPinLength: MinPinLength.Registration.Input? = nil,
             largeBlob: LargeBlob.Registration.Input? = nil,
             credProps: CredProps.Registration.Input? = nil,
-            previewSign: PreviewSign.Registration.Input? = nil
+            previewSign: PreviewSign.Registration.Input? = nil,
+            thirdPartyPayment: ThirdPartyPayment.Registration.Input? = nil
         ) {
             self.prf = prf
             self.credProtect = credProtect
@@ -100,6 +104,7 @@ extension WebAuthn.Extension {
             self.largeBlob = largeBlob
             self.credProps = credProps
             self.previewSign = previewSign
+            self.thirdPartyPayment = thirdPartyPayment
         }
     }
 }
@@ -143,16 +148,21 @@ extension WebAuthn.Extension {
         /// Maps credential IDs to signing parameters for delegated signing.
         public let previewSign: PreviewSign.Authentication.Input?
 
+        /// Signal that this assertion is a Secure Payment Confirmation payment assertion.
+        public let thirdPartyPayment: ThirdPartyPayment.Authentication.Input?
+
         public init(
             prf: PRF.Authentication.Input? = nil,
             getCredBlob: CredBlob.Authentication.Input? = nil,
             largeBlob: LargeBlob.Authentication.Input? = nil,
-            previewSign: PreviewSign.Authentication.Input? = nil
+            previewSign: PreviewSign.Authentication.Input? = nil,
+            thirdPartyPayment: ThirdPartyPayment.Authentication.Input? = nil
         ) {
             self.prf = prf
             self.getCredBlob = getCredBlob
             self.largeBlob = largeBlob
             self.previewSign = previewSign
+            self.thirdPartyPayment = thirdPartyPayment
         }
     }
 }

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Extensions/ExtensionOutputs.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Extensions/ExtensionOutputs.swift
@@ -62,6 +62,13 @@ extension WebAuthn.Extension {
         /// Contains the generated signing key pair if previewSign was requested.
         public let previewSign: PreviewSign.Registration.Output?
 
+        /// ThirdPartyPayment extension result.
+        ///
+        /// `isPaymentEnabled` is `true` if the credential was registered as
+        /// third-party payment enabled, or `nil` if the authenticator did not
+        /// echo the bit.
+        public let thirdPartyPayment: ThirdPartyPayment.Registration.Output?
+
         public init(
             prf: PRF.Registration.Output? = nil,
             credProtect: CredProtect.Registration.Output? = nil,
@@ -69,7 +76,8 @@ extension WebAuthn.Extension {
             minPinLength: MinPinLength.Registration.Output? = nil,
             largeBlob: LargeBlob.Registration.Output? = nil,
             credProps: CredProps.Registration.Output? = nil,
-            previewSign: PreviewSign.Registration.Output? = nil
+            previewSign: PreviewSign.Registration.Output? = nil,
+            thirdPartyPayment: ThirdPartyPayment.Registration.Output? = nil
         ) {
             self.prf = prf
             self.credProtect = credProtect
@@ -78,6 +86,7 @@ extension WebAuthn.Extension {
             self.largeBlob = largeBlob
             self.credProps = credProps
             self.previewSign = previewSign
+            self.thirdPartyPayment = thirdPartyPayment
         }
 
         /// Empty extension outputs (no extensions requested or supported).
@@ -117,16 +126,26 @@ extension WebAuthn.Extension {
         /// Contains the signature if previewSign signing was requested.
         public let previewSign: PreviewSign.Authentication.Output?
 
+        /// ThirdPartyPayment extension result.
+        ///
+        /// `isPaymentEnabled` is `true` if the credential is third-party payment
+        /// enabled, `false` if the authenticator supports the extension but the
+        /// credential was not registered as such, or `nil` if the authenticator
+        /// did not echo the bit.
+        public let thirdPartyPayment: ThirdPartyPayment.Authentication.Output?
+
         public init(
             prf: PRF.Authentication.Output? = nil,
             credBlob: CredBlob.Authentication.Output? = nil,
             largeBlob: LargeBlob.Authentication.Output? = nil,
-            previewSign: PreviewSign.Authentication.Output? = nil
+            previewSign: PreviewSign.Authentication.Output? = nil,
+            thirdPartyPayment: ThirdPartyPayment.Authentication.Output? = nil
         ) {
             self.prf = prf
             self.credBlob = credBlob
             self.largeBlob = largeBlob
             self.previewSign = previewSign
+            self.thirdPartyPayment = thirdPartyPayment
         }
 
         /// Empty extension outputs (no extensions requested or supported).

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Extensions/Extensions+JSON.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Extensions/Extensions+JSON.swift
@@ -46,6 +46,10 @@ extension WebAuthn.Extension.RegistrationInputs: Decodable {
             previewSign: try container.decodeIfPresent(
                 WebAuthn.Extension.PreviewSign.Registration.Input.self,
                 forKey: .previewSign
+            ),
+            thirdPartyPayment: try container.decodeIfPresent(
+                WebAuthn.Extension.ThirdPartyPayment.Registration.Input.self,
+                forKey: .payment
             )
         )
     }
@@ -53,6 +57,7 @@ extension WebAuthn.Extension.RegistrationInputs: Decodable {
     private enum CodingKeys: String, CodingKey {
         case prf, credentialProtectionPolicy, enforceCredentialProtectionPolicy, credBlob, minPinLength, largeBlob
         case credProps, previewSign
+        case payment
     }
 }
 
@@ -72,12 +77,17 @@ extension WebAuthn.Extension.AuthenticationInputs: Decodable {
             previewSign: try container.decodeIfPresent(
                 WebAuthn.Extension.PreviewSign.Authentication.Input.self,
                 forKey: .previewSign
+            ),
+            thirdPartyPayment: try container.decodeIfPresent(
+                WebAuthn.Extension.ThirdPartyPayment.Authentication.Input.self,
+                forKey: .payment
             )
         )
     }
 
     private enum CodingKeys: String, CodingKey {
         case prf, getCredBlob, largeBlob, previewSign
+        case payment
     }
 }
 
@@ -552,5 +562,26 @@ extension WebAuthn.Extension.PreviewSign.Authentication.Output: Encodable {
 
     private enum CodingKeys: String, CodingKey {
         case signature
+    }
+}
+
+// MARK: - ThirdPartyPayment Codable
+
+extension WebAuthn.Extension.ThirdPartyPayment.Registration.Input: Decodable {
+    private enum CodingKeys: String, CodingKey { case isPayment }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        // Absent `isPayment` → inactive (parity with python-fido2 / yubikit-android).
+        self.init(isPayment: try container.decodeIfPresent(Bool.self, forKey: .isPayment) ?? false)
+    }
+}
+
+extension WebAuthn.Extension.ThirdPartyPayment.Authentication.Input: Decodable {
+    private enum CodingKeys: String, CodingKey { case isPayment }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(isPayment: try container.decodeIfPresent(Bool.self, forKey: .isPayment) ?? false)
     }
 }

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Extensions/WebAuthnThirdPartyPayment.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Extensions/WebAuthnThirdPartyPayment.swift
@@ -36,6 +36,9 @@ extension WebAuthn.Extension {
                 public init(isPayment: Bool) {
                     self.isPayment = isPayment
                 }
+
+                /// Mark the credential as usable for Secure Payment Confirmation.
+                public static let enabled = Self(isPayment: true)
             }
 
             /// Output from thirdPartyPayment extension at registration.
@@ -56,6 +59,9 @@ extension WebAuthn.Extension {
                 public init(isPayment: Bool) {
                     self.isPayment = isPayment
                 }
+
+                /// Signal that this assertion is a Secure Payment Confirmation payment assertion.
+                public static let enabled = Self(isPayment: true)
             }
 
             /// Output from thirdPartyPayment extension at authentication.

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Extensions/WebAuthnThirdPartyPayment.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Extensions/WebAuthnThirdPartyPayment.swift
@@ -1,0 +1,72 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+extension WebAuthn.Extension {
+
+    /// The `thirdPartyPayment` (WebAuthn JSON: `payment`) CTAP2 extension.
+    ///
+    /// Marks a credential as usable for Secure Payment Confirmation (SPC) and
+    /// reports back whether a credential was registered with that mark.
+    ///
+    /// This SDK forwards the `thirdPartyPayment` flag to the authenticator only.
+    /// It does **not** synthesize the SPC `clientDataJSON` (`type: "payment.get"`,
+    /// embedded `payment` member) required by W3C SPC; consumers wanting full
+    /// SPC support must build that out-of-band.
+    ///
+    /// - SeeAlso: [Secure Payment Confirmation](https://www.w3.org/TR/secure-payment-confirmation)
+    public enum ThirdPartyPayment {
+
+        public enum Registration {
+            public struct Input: Sendable, Equatable {
+                public let isPayment: Bool
+
+                public init(isPayment: Bool) {
+                    self.isPayment = isPayment
+                }
+            }
+
+            /// Output from thirdPartyPayment extension at registration.
+            public struct Output: Sendable, Equatable {
+                /// Whether the credential was registered as third-party payment enabled.
+                public let isPaymentEnabled: Bool
+
+                public init(isPaymentEnabled: Bool) {
+                    self.isPaymentEnabled = isPaymentEnabled
+                }
+            }
+        }
+
+        public enum Authentication {
+            public struct Input: Sendable, Equatable {
+                public let isPayment: Bool
+
+                public init(isPayment: Bool) {
+                    self.isPayment = isPayment
+                }
+            }
+
+            /// Output from thirdPartyPayment extension at authentication.
+            public struct Output: Sendable, Equatable {
+                /// Whether the credential is third-party payment enabled.
+                public let isPaymentEnabled: Bool
+
+                public init(isPaymentEnabled: Bool) {
+                    self.isPaymentEnabled = isPaymentEnabled
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds WebAuthn "payment" (CTAP2 `thirdPartyPayment`) extension plumbing so registration/authentication requests can carry the extension input, along with JSON decoding and test coverage.

## Changes

- Introduces `WebAuthn.Extension.ThirdPartyPayment` input/output types for registration and authentication, with a `.enabled` convenience.
- Decodes the WebAuthn JSON `extensions.payment` object into `thirdPartyPayment` inputs and sends the CTAP2 `thirdPartyPayment` extension in `makeCredential` / `getAssertion` flows.
- Adds unit + full-stack tests and wires the new full-stack test into the Xcode project.