### PR TITLE
Add allowedExtensions allowlist to WebAuthn.Client

### DIFF
--- a/FullStackTests/Tests/WebAuthn/Extensions/CredBlobTests.swift
+++ b/FullStackTests/Tests/WebAuthn/Extensions/CredBlobTests.swift
@@ -130,6 +130,7 @@ struct WebAuthnCredBlobExtensionTests {
             let client = WebAuthn.Client(
                 session: session,
                 origin: try WebAuthn.Origin("https://\(rpId)"),
+                allowedExtensions: [.credBlob],
                 isPublicSuffix: { _ in false }
             )
 

--- a/FullStackTests/Tests/WebAuthn/Extensions/CredPropsTests.swift
+++ b/FullStackTests/Tests/WebAuthn/Extensions/CredPropsTests.swift
@@ -100,6 +100,7 @@ private func withWebAuthnClient<T>(
         let client = WebAuthn.Client(
             session: session,
             origin: try WebAuthn.Origin("https://example.com"),
+            allowedExtensions: [.credProps],
             isPublicSuffix: { _ in false }
         )
         return try await body(client)

--- a/FullStackTests/Tests/WebAuthn/Extensions/MinPinLengthTests.swift
+++ b/FullStackTests/Tests/WebAuthn/Extensions/MinPinLengthTests.swift
@@ -59,6 +59,7 @@ struct WebAuthnMinPinLengthExtensionTests {
             let client = WebAuthn.Client(
                 session: session,
                 origin: try WebAuthn.Origin("https://\(rpId)"),
+                allowedExtensions: [.minPinLength],
                 isPublicSuffix: { _ in false }
             )
 

--- a/YubiKit/UnitTests/FIDO/WebAuthn/CredentialPreprocessingTests.swift
+++ b/YubiKit/UnitTests/FIDO/WebAuthn/CredentialPreprocessingTests.swift
@@ -651,6 +651,7 @@ private func makeClient(
     WebAuthn.Client(
         backend: mock,
         origin: try WebAuthn.Origin("https://\(rpId)"),
+        allowedExtensions: .all,
         isPublicSuffix: { _ in false }
     )
 }

--- a/YubiKit/UnitTests/FIDO/WebAuthn/ExtensionAllowlistTests.swift
+++ b/YubiKit/UnitTests/FIDO/WebAuthn/ExtensionAllowlistTests.swift
@@ -1,0 +1,147 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Testing
+
+@testable import YubiKit
+
+@Suite("Extension Allowlist Tests")
+struct ExtensionAllowlistTests {
+
+    @Test("Empty allowlist drops every extension on build + parse")
+    func testEmptyAllowlist() async throws {
+        let mock = MockWebAuthnBackend()
+
+        let (mcInputs, mcPrf, mcPreviewSign, mcLargeBlob) = try await mock.buildMakeCredentialExtensions(
+            .init(
+                prf: .enable,
+                credProtect: .init(policy: .userVerificationRequired),
+                credBlob: Data([0xAA]),
+                minPinLength: true,
+                largeBlob: .required,
+                credProps: true,
+                thirdPartyPayment: .init(isPayment: true)
+            ),
+            allowedExtensions: []
+        )
+        #expect(mcInputs.isEmpty && mcPrf == nil && mcPreviewSign == nil && mcLargeBlob == false)
+
+        let regOutputs = try await mock.parseRegistrationOutputs(
+            from: .stubWithExtensions(),
+            prf: nil,
+            previewSign: nil,
+            largeBlobRequested: true,
+            credPropsRk: true,
+            allowedExtensions: []
+        )
+        let authOutputs = try await mock.parseAuthenticationOutputs(
+            from: .stubWithExtensions(),
+            prf: nil,
+            previewSign: nil,
+            largeBlobOutput: nil,
+            allowedExtensions: []
+        )
+
+        // Exhaustive: a new Identifier case forces a new arm here, which forces
+        // wiring the allowlist filter in Backend+Extensions.swift before this test passes.
+        for id in WebAuthn.Extension.Identifier.allCases {
+            switch id {
+            case .prf:
+                #expect(regOutputs.prf == nil)
+                #expect(authOutputs.prf == nil)
+            case .credProtect:
+                #expect(regOutputs.credProtect == nil)
+            case .credBlob:
+                #expect(regOutputs.credBlob == nil)
+                #expect(authOutputs.credBlob == nil)
+            case .credProps:
+                #expect(regOutputs.credProps == nil)
+            case .largeBlob:
+                #expect(regOutputs.largeBlob == nil)
+                #expect(authOutputs.largeBlob == nil)
+            case .minPinLength:
+                #expect(regOutputs.minPinLength == nil)
+            case .thirdPartyPayment:
+                #expect(regOutputs.thirdPartyPayment == nil)
+                #expect(authOutputs.thirdPartyPayment == nil)
+            case .previewSign:
+                #expect(regOutputs.previewSign == nil)
+                #expect(authOutputs.previewSign == nil)
+            }
+        }
+    }
+
+    @Test("Specific allowlist surfaces only listed extensions")
+    func testSpecificAllowlist() async throws {
+        let mock = MockWebAuthnBackend()
+
+        let outputs = try await mock.parseRegistrationOutputs(
+            from: .stubWithExtensions(),
+            prf: nil,
+            previewSign: nil,
+            largeBlobRequested: false,
+            credPropsRk: true,
+            allowedExtensions: [.credProps]
+        )
+        #expect(outputs.credBlob == nil)
+        #expect(outputs.minPinLength == nil)
+        #expect(outputs.credProps?.rk == true)
+    }
+}
+
+// MARK: - CBOR-encoded authenticator-data helpers
+
+private func authData(extensions: [CBOR.Value: CBOR.Value]) -> Data {
+    var data = Data(count: 32)  // rpIdHash
+    data.append(0x81)  // flags: UP + ED
+    data.append(contentsOf: [0x00, 0x00, 0x00, 0x01])  // signCount
+    data.append(CBOR.Value.map(extensions).encode())
+    return data
+}
+
+extension CTAP2.MakeCredential.Response {
+    fileprivate static func stubWithExtensions() -> CTAP2.MakeCredential.Response {
+        let response: [CBOR.Value: CBOR.Value] = [
+            .int(0x01): .textString("none"),
+            .int(0x02): .byteString(
+                authData(extensions: [
+                    .textString("credBlob"): .boolean(true),
+                    .textString("minPinLength"): .int(4),
+                    .textString("thirdPartyPayment"): .boolean(true),
+                ])
+            ),
+            .int(0x03): .map([:]),
+        ]
+        return CTAP2.MakeCredential.Response(cbor: try! CBOR.Value.map(response).encode().decode()!)!
+    }
+}
+
+extension CTAP2.GetAssertion.Response {
+    fileprivate static func stubWithExtensions() -> CTAP2.GetAssertion.Response {
+        let data = authData(extensions: [
+            .textString("credBlob"): .byteString(Data([0x11, 0x22])),
+            .textString("thirdPartyPayment"): .boolean(true),
+        ])
+        return Self(
+            credential: WebAuthn.CredentialDescriptor(id: Data([0xAA])),
+            authenticatorData: WebAuthn.AuthenticatorData(data: data)!,
+            signature: Data([0x30, 0x44]),
+            user: nil,
+            numberOfCredentials: 1,
+            userSelected: nil,
+            largeBlobKey: nil
+        )
+    }
+}

--- a/YubiKit/UnitTests/FIDO/WebAuthn/ThirdPartyPaymentBuildingTests.swift
+++ b/YubiKit/UnitTests/FIDO/WebAuthn/ThirdPartyPaymentBuildingTests.swift
@@ -28,7 +28,8 @@ struct ThirdPartyPaymentBuildingTests {
     func testMakeCredentialIsPaymentFalse() async throws {
         let mock = MockWebAuthnBackend()
         let result = try await mock.buildMakeCredentialExtensions(
-            .init(thirdPartyPayment: .init(isPayment: false))
+            .init(thirdPartyPayment: .init(isPayment: false)),
+            allowedExtensions: [.thirdPartyPayment]
         )
         #expect(result.ctapInputs.isEmpty)
     }
@@ -39,7 +40,8 @@ struct ThirdPartyPaymentBuildingTests {
         let result = try await mock.buildGetAssertionExtensions(
             .init(thirdPartyPayment: .init(isPayment: false)),
             allowCredentials: [],
-            selectedCredentialId: nil
+            selectedCredentialId: nil,
+            allowedExtensions: [.thirdPartyPayment]
         )
         #expect(result.ctapInputs.isEmpty)
     }

--- a/YubiKit/YubiKit/FIDO/WebAuthn/AuthenticatorData.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/AuthenticatorData.swift
@@ -125,7 +125,7 @@ extension WebAuthn.AuthenticatorData {
             else {
                 return nil
             }
-            // Convert CBOR map to [Identifier: CBOR.Value]
+            // Convert CBOR map to [CTAP2.Extension.Identifier: CBOR.Value]
             var extensions: [CTAP2.Extension.Identifier: CBOR.Value] = [:]
             for (key, value) in map {
                 guard let identifier: CTAP2.Extension.Identifier = key.cborDecoded() else {

--- a/YubiKit/YubiKit/FIDO/WebAuthn/AuthenticatorData.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/AuthenticatorData.swift
@@ -41,7 +41,7 @@ extension WebAuthn {
         /// Raw extension outputs map (present when ED flag is set).
         ///
         /// Use extension-specific `result(from:)` methods for typed access to extension outputs.
-        internal let extensions: [WebAuthn.Extension.Identifier: CBOR.Value]?
+        internal let extensions: [CTAP2.Extension.Identifier: CBOR.Value]?
 
         /// Authenticator data flags.
         public struct Flags: OptionSet, Sendable {
@@ -126,9 +126,9 @@ extension WebAuthn.AuthenticatorData {
                 return nil
             }
             // Convert CBOR map to [Identifier: CBOR.Value]
-            var extensions: [WebAuthn.Extension.Identifier: CBOR.Value] = [:]
+            var extensions: [CTAP2.Extension.Identifier: CBOR.Value] = [:]
             for (key, value) in map {
-                guard let identifier: WebAuthn.Extension.Identifier = key.cborDecoded() else {
+                guard let identifier: CTAP2.Extension.Identifier = key.cborDecoded() else {
                     return nil  // Extension keys must be strings
                 }
                 extensions[identifier] = value

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Client/Authentication/Client+GetAssertion.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Client/Authentication/Client+GetAssertion.swift
@@ -150,7 +150,8 @@ extension WebAuthn.Client {
             let (ctapExtensions, prf, previewSign, largeBlobAction) = try await backend.buildGetAssertionExtensions(
                 options.extensions,
                 allowCredentials: options.allowCredentials,
-                selectedCredentialId: selectedCred?.id
+                selectedCredentialId: selectedCred?.id,
+                allowedExtensions: allowedExtensions
             )
 
             let parameters = CTAP2.GetAssertion.Parameters(
@@ -254,12 +255,13 @@ extension WebAuthn.Client {
         }
 
         let backend = self.backend
+        let allowedExtensions = self.allowedExtensions
 
         return WebAuthn.Authentication.MatchedCredential(
             id: credentialId,
             user: ctapResponse.user,
             select: {
-                [ctapResponse, prf, previewSign, largeBlobAction, clientData]
+                [ctapResponse, prf, previewSign, largeBlobAction, clientData, allowedExtensions]
                 () async throws(WebAuthn.ClientError) in
                 let largeBlobOutput = try await backend.processLargeBlob(
                     from: ctapResponse,
@@ -270,7 +272,8 @@ extension WebAuthn.Client {
                     from: ctapResponse,
                     prf: prf,
                     previewSign: previewSign,
-                    largeBlobOutput: largeBlobOutput
+                    largeBlobOutput: largeBlobOutput,
+                    allowedExtensions: allowedExtensions
                 )
                 let authenticatorData = ctapResponse.authenticatorData
                 return WebAuthn.Authentication.Response(

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Client/Client.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Client/Client.swift
@@ -53,6 +53,7 @@ extension WebAuthn {
         let backend: any Backend
         let origin: Origin
         let enterpriseRpIds: Set<String>
+        let allowedExtensions: Set<WebAuthn.Extension.Identifier>
         let isPublicSuffix: PublicSuffixChecker
 
         // MARK: - Initialization
@@ -66,31 +67,43 @@ extension WebAuthn {
         ///     When a credential is created with `.enterprise` attestation for an RP ID in this set,
         ///     the client uses platform-facilitated mode (value 2). For other RP IDs, it uses
         ///     vendor-facilitated mode (value 1). See CTAP 2.2 §6.1.1.
+        ///   - allowedExtensions: Extensions this client will process. Anything the RP sends
+        ///     that isn't in this list is silently dropped. Defaults to `.standard`
+        ///     (every extension except `thirdPartyPayment` and `previewSign`).
+        ///     Pass `.all` for every supported extension, `[]` to ignore them all,
+        ///     or a custom subset.
         ///   - isPublicSuffix: Returns `true` if the domain is in the Public Suffix List.
         public init(
             session: CTAP2.Session,
             origin: Origin,
             enterpriseRpIds: Set<String> = [],
+            allowedExtensions: Set<WebAuthn.Extension.Identifier> = .standard,
             isPublicSuffix: @escaping PublicSuffixChecker
         ) {
             self.init(
                 backend: session,
                 origin: origin,
                 enterpriseRpIds: enterpriseRpIds,
+                allowedExtensions: allowedExtensions,
                 isPublicSuffix: isPublicSuffix
             )
         }
 
         /// Internal initializer for testing with a mock backend.
+        ///
+        /// `allowedExtensions` has no default here on purpose: tests must opt in
+        /// explicitly so the suite never silently drifts from the public `.standard`.
         init(
             backend: any Backend,
             origin: Origin,
             enterpriseRpIds: Set<String> = [],
+            allowedExtensions: Set<WebAuthn.Extension.Identifier>,
             isPublicSuffix: @escaping PublicSuffixChecker
         ) {
             self.backend = backend
             self.origin = origin
             self.enterpriseRpIds = enterpriseRpIds
+            self.allowedExtensions = allowedExtensions
             self.isPublicSuffix = isPublicSuffix
         }
     }

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Client/Registration/Client+MakeCredential.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Client/Registration/Client+MakeCredential.swift
@@ -126,6 +126,7 @@ extension WebAuthn.Client {
             let (ctapExtensions, prf, previewSign, largeBlobRequested) =
                 try await backend.buildMakeCredentialExtensions(
                     options.extensions,
+                    allowedExtensions: allowedExtensions,
                     userVerification: options.userVerification
                 )
 
@@ -185,7 +186,8 @@ extension WebAuthn.Client {
                 prf: prf,
                 previewSign: previewSign,
                 largeBlobRequested: largeBlobRequested,
-                credPropsRk: credPropsRk
+                credPropsRk: credPropsRk,
+                allowedExtensions: allowedExtensions
             )
             return WebAuthn.Registration.Response(
                 credentialId: attestedCredentialData.credentialId,

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Client/Shared/Backend+Extensions.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Client/Shared/Backend+Extensions.swift
@@ -22,6 +22,7 @@ extension WebAuthn.Backend {
 
     func buildMakeCredentialExtensions(
         _ inputs: WebAuthn.Extension.RegistrationInputs?,
+        allowedExtensions: Set<WebAuthn.Extension.Identifier>,
         userVerification: WebAuthn.UserVerificationPreference = .preferred
     ) async throws(WebAuthn.ClientError) -> (
         ctapInputs: [CTAP2.Extension.MakeCredential.Input],
@@ -39,7 +40,7 @@ extension WebAuthn.Backend {
         var largeBlobRequested = false
 
         do throws(CTAP2.SessionError) {
-            if let prfInput = inputs.prf {
+            if let prfInput = allowedExtensions.allow(.prf, inputs.prf) {
                 if let p = try? await makePRF() {
                     if let eval = prfInput.eval {
                         ctapInputs.append(
@@ -52,7 +53,7 @@ extension WebAuthn.Backend {
                 }
             }
 
-            if let credProtectInput = inputs.credProtect {
+            if let credProtectInput = allowedExtensions.allow(.credProtect, inputs.credProtect) {
                 let credProtect = try await makeCredProtect(
                     level: credProtectInput.policy,
                     enforce: credProtectInput.enforce
@@ -60,13 +61,13 @@ extension WebAuthn.Backend {
                 ctapInputs.append(credProtect.input())
             }
 
-            if let credBlobData = inputs.credBlob {
+            if let credBlobData = allowedExtensions.allow(.credBlob, inputs.credBlob) {
                 if let credBlob = try? await makeCredBlob() {
                     ctapInputs.append(try credBlob.makeCredential.input(blob: credBlobData))
                 }
             }
 
-            if let largeBlobInput = inputs.largeBlob {
+            if let largeBlobInput = allowedExtensions.allow(.largeBlob, inputs.largeBlob) {
                 let supported = try await isLargeBlobSupported()
                 if largeBlobInput.support == .required && !supported {
                     throw CTAP2.SessionError.extensionNotSupported(.largeBlobKey, source: .here())
@@ -80,7 +81,7 @@ extension WebAuthn.Backend {
                 largeBlobRequested = true
             }
 
-            if let previewSignInput = inputs.previewSign {
+            if let previewSignInput = allowedExtensions.allow(.previewSign, inputs.previewSign) {
                 if let ps = try? await makePreviewSign() {
                     let flags: UInt8 = userVerification == .required ? 0b101 : 0b001
                     ctapInputs.append(
@@ -96,7 +97,7 @@ extension WebAuthn.Backend {
             throw WebAuthn.ClientError(error)
         }
 
-        if inputs.minPinLength == true {
+        if allowedExtensions.allow(.minPinLength, inputs.minPinLength) == true {
             do {
                 if try await isMinPinLengthSupported() {
                     let minPinLength = try await makeMinPinLength()
@@ -107,7 +108,9 @@ extension WebAuthn.Backend {
             }
         }
 
-        if let payment = inputs.thirdPartyPayment, payment.isPayment {
+        if let payment = allowedExtensions.allow(.thirdPartyPayment, inputs.thirdPartyPayment),
+            payment.isPayment
+        {
             if let ext = try? await makeThirdPartyPayment() {
                 ctapInputs.append(ext.makeCredential.input())
             }
@@ -121,7 +124,8 @@ extension WebAuthn.Backend {
     func buildGetAssertionExtensions(
         _ inputs: WebAuthn.Extension.AuthenticationInputs?,
         allowCredentials: [WebAuthn.CredentialDescriptor],
-        selectedCredentialId: Data?
+        selectedCredentialId: Data?,
+        allowedExtensions: Set<WebAuthn.Extension.Identifier>
     ) async throws(WebAuthn.ClientError) -> (
         ctapInputs: [CTAP2.Extension.GetAssertion.Input],
         prf: WebAuthn.Extension.PRF?,
@@ -137,7 +141,7 @@ extension WebAuthn.Backend {
         var previewSign: CTAP2.Extension.PreviewSign?
         var largeBlobAction: WebAuthn.Extension.LargeBlob.Authentication.Input?
 
-        if let prfInput = inputs.prf {
+        if let prfInput = allowedExtensions.allow(.prf, inputs.prf) {
             let evalByCredential: [Data: (first: Data, second: Data?)] = prfInput.evalByCredential.mapValues {
                 ($0.first, $0.second)
             }
@@ -184,13 +188,13 @@ extension WebAuthn.Backend {
             }
         }
 
-        if inputs.getCredBlob == true {
+        if allowedExtensions.allow(.credBlob, inputs.getCredBlob) == true {
             if let credBlob = try? await makeCredBlob() {
                 ctapInputs.append(credBlob.getAssertion.input())
             }
         }
 
-        if let largeBlobInput = inputs.largeBlob {
+        if let largeBlobInput = allowedExtensions.allow(.largeBlob, inputs.largeBlob) {
             do throws(CTAP2.SessionError) {
                 let largeBlobKey = try await makeLargeBlobKey()
                 ctapInputs.append(largeBlobKey.getAssertion.input())
@@ -204,7 +208,7 @@ extension WebAuthn.Backend {
             }
         }
 
-        if let previewSignInput = inputs.previewSign {
+        if let previewSignInput = allowedExtensions.allow(.previewSign, inputs.previewSign) {
             if allowCredentials.isEmpty {
                 throw .invalidRequest(
                     "sign requires allowCredentials",
@@ -233,7 +237,9 @@ extension WebAuthn.Backend {
             }
         }
 
-        if let payment = inputs.thirdPartyPayment, payment.isPayment {
+        if let payment = allowedExtensions.allow(.thirdPartyPayment, inputs.thirdPartyPayment),
+            payment.isPayment
+        {
             if let ext = try? await makeThirdPartyPayment() {
                 ctapInputs.append(ext.getAssertion.input())
             }
@@ -249,11 +255,12 @@ extension WebAuthn.Backend {
         prf: WebAuthn.Extension.PRF?,
         previewSign: CTAP2.Extension.PreviewSign?,
         largeBlobRequested: Bool,
-        credPropsRk: Bool?
+        credPropsRk: Bool?,
+        allowedExtensions: Set<WebAuthn.Extension.Identifier>
     ) throws(WebAuthn.ClientError) -> WebAuthn.Extension.RegistrationOutputs {
         var prfOutput: WebAuthn.Extension.PRF.Registration.Output?
 
-        if let prf {
+        if let prf = allowedExtensions.allow(.prf, prf) {
             do throws(CTAP2.SessionError) {
                 if let ctapResult = try prf.makeCredential.output(from: response) {
                     prfOutput = .init(ctapResult: ctapResult)
@@ -264,7 +271,7 @@ extension WebAuthn.Backend {
         }
 
         var previewSignOutput: WebAuthn.Extension.PreviewSign.Registration.Output?
-        if let previewSign {
+        if let previewSign = allowedExtensions.allow(.previewSign, previewSign) {
             do throws(CTAP2.SessionError) {
                 if let generatedKey = try previewSign.makeCredential.output(from: response) {
                     previewSignOutput = .init(generatedKey: generatedKey)
@@ -276,27 +283,28 @@ extension WebAuthn.Backend {
 
         let extensions = response.authenticatorData.extensions
 
-        let credProtectOutput: WebAuthn.Extension.CredProtect.Registration.Output? =
-            extensions?[.credProtect]
+        let credProtectOutput = allowedExtensions.allow(.credProtect, extensions?[.credProtect])
             .flatMap { WebAuthn.Extension.CredProtect.Policy(cbor: $0) }
-            .map { .init(policy: $0) }
+            .map { WebAuthn.Extension.CredProtect.Registration.Output(policy: $0) }
 
-        let credBlobOutput: WebAuthn.Extension.CredBlob.Registration.Output? =
-            extensions?[.credBlob]?.boolValue.map { .init(stored: $0) }
+        let credBlobOutput = allowedExtensions.allow(.credBlob, extensions?[.credBlob]?.boolValue)
+            .map { WebAuthn.Extension.CredBlob.Registration.Output(stored: $0) }
 
-        let minPinLengthOutput: WebAuthn.Extension.MinPinLength.Registration.Output? =
-            extensions?[.minPinLength]?.uint64Value.map { .init(length: UInt($0)) }
+        let minPinLengthOutput = allowedExtensions.allow(.minPinLength, extensions?[.minPinLength]?.uint64Value)
+            .map { WebAuthn.Extension.MinPinLength.Registration.Output(length: UInt($0)) }
 
         let largeBlobOutput: WebAuthn.Extension.LargeBlob.Registration.Output? =
-            largeBlobRequested
+            allowedExtensions.contains(.largeBlob) && largeBlobRequested
             ? .init(supported: response.largeBlobKey != nil)
             : nil
 
-        let credPropsOutput: WebAuthn.Extension.CredProps.Registration.Output? =
-            credPropsRk.map { .init(rk: $0) }
+        let credPropsOutput = allowedExtensions.allow(.credProps, credPropsRk)
+            .map { WebAuthn.Extension.CredProps.Registration.Output(rk: $0) }
 
-        let thirdPartyPaymentOutput: WebAuthn.Extension.ThirdPartyPayment.Registration.Output? =
-            extensions?[.thirdPartyPayment]?.boolValue.map { .init(isPaymentEnabled: $0) }
+        let thirdPartyPaymentOutput =
+            allowedExtensions
+            .allow(.thirdPartyPayment, extensions?[.thirdPartyPayment]?.boolValue)
+            .map { WebAuthn.Extension.ThirdPartyPayment.Registration.Output(isPaymentEnabled: $0) }
 
         return WebAuthn.Extension.RegistrationOutputs(
             prf: prfOutput,
@@ -314,11 +322,12 @@ extension WebAuthn.Backend {
         from response: CTAP2.GetAssertion.Response,
         prf: WebAuthn.Extension.PRF?,
         previewSign: CTAP2.Extension.PreviewSign?,
-        largeBlobOutput: WebAuthn.Extension.LargeBlob.Authentication.Output?
+        largeBlobOutput: WebAuthn.Extension.LargeBlob.Authentication.Output?,
+        allowedExtensions: Set<WebAuthn.Extension.Identifier>
     ) throws(WebAuthn.ClientError) -> WebAuthn.Extension.AuthenticationOutputs {
         var prfOutput: WebAuthn.Extension.PRF.Authentication.Output?
 
-        if let prf {
+        if let prf = allowedExtensions.allow(.prf, prf) {
             do throws(CTAP2.SessionError) {
                 if let ctapSecrets = try prf.getAssertion.output(from: response) {
                     prfOutput = .init(ctapSecrets: ctapSecrets)
@@ -328,24 +337,27 @@ extension WebAuthn.Backend {
             }
         }
 
-        let credBlobOutput: WebAuthn.Extension.CredBlob.Authentication.Output? =
-            response.authenticatorData.extensions?[.credBlob]?.dataValue.map { .init(blob: $0) }
+        let credBlobOutput =
+            allowedExtensions
+            .allow(.credBlob, response.authenticatorData.extensions?[.credBlob]?.dataValue)
+            .map { WebAuthn.Extension.CredBlob.Authentication.Output(blob: $0) }
 
         var previewSignOutput: WebAuthn.Extension.PreviewSign.Authentication.Output?
-        if let previewSign {
+        if let previewSign = allowedExtensions.allow(.previewSign, previewSign) {
             if let signature = previewSign.getAssertion.output(from: response) {
                 previewSignOutput = .init(signature: signature)
             }
         }
 
-        let thirdPartyPaymentOutput: WebAuthn.Extension.ThirdPartyPayment.Authentication.Output? =
-            response.authenticatorData.extensions?[.thirdPartyPayment]?.boolValue
-            .map { .init(isPaymentEnabled: $0) }
+        let thirdPartyPaymentOutput =
+            allowedExtensions
+            .allow(.thirdPartyPayment, response.authenticatorData.extensions?[.thirdPartyPayment]?.boolValue)
+            .map { WebAuthn.Extension.ThirdPartyPayment.Authentication.Output(isPaymentEnabled: $0) }
 
         return WebAuthn.Extension.AuthenticationOutputs(
             prf: prfOutput,
             credBlob: credBlobOutput,
-            largeBlob: largeBlobOutput,
+            largeBlob: allowedExtensions.allow(.largeBlob, largeBlobOutput),
             previewSign: previewSignOutput,
             thirdPartyPayment: thirdPartyPaymentOutput
         )
@@ -376,5 +388,11 @@ extension WebAuthn.Backend {
                 throw WebAuthn.ClientError(error)
             }
         }
+    }
+}
+
+extension Set where Element == WebAuthn.Extension.Identifier {
+    fileprivate func allow<T>(_ id: Element, _ value: T?) -> T? {
+        contains(id) ? value : nil
     }
 }

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Client/Shared/Backend+Extensions.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Client/Shared/Backend+Extensions.swift
@@ -293,10 +293,10 @@ extension WebAuthn.Backend {
         let minPinLengthOutput = allowedExtensions.allow(.minPinLength, extensions?[.minPinLength]?.uint64Value)
             .map { WebAuthn.Extension.MinPinLength.Registration.Output(length: UInt($0)) }
 
-        let largeBlobOutput: WebAuthn.Extension.LargeBlob.Registration.Output? =
-            allowedExtensions.contains(.largeBlob) && largeBlobRequested
-            ? .init(supported: response.largeBlobKey != nil)
-            : nil
+        let largeBlobOutput =
+            allowedExtensions
+            .allow(.largeBlob, largeBlobRequested ? response.largeBlobKey != nil : nil)
+            .map { WebAuthn.Extension.LargeBlob.Registration.Output(supported: $0) }
 
         let credPropsOutput = allowedExtensions.allow(.credProps, credPropsRk)
             .map { WebAuthn.Extension.CredProps.Registration.Output(rk: $0) }

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Extensions/ExtensionInputs.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Extensions/ExtensionInputs.swift
@@ -21,9 +21,8 @@ extension WebAuthn {
     public enum Extension {
         /// Identifier for a WebAuthn-level extension.
         ///
-        /// One case per typed field on ``RegistrationInputs`` /
-        /// ``AuthenticationInputs``. Distinct from the CTAP wire vocabulary
-        /// in ``CTAP2/Extension/Identifier``.
+        /// One case per supported WebAuthn extension. Distinct from the CTAP
+        /// wire vocabulary in ``CTAP2/Extension/Identifier``.
         public enum Identifier: Hashable, Sendable, CaseIterable {
             /// WebAuthn wrapper over CTAP2 hmac-secret.
             case prf

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Extensions/ExtensionInputs.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Extensions/ExtensionInputs.swift
@@ -19,9 +19,40 @@ import Foundation
 extension WebAuthn {
     /// Namespace for WebAuthn extensions.
     public enum Extension {
-        /// Extension identifier type (shared with CTAP2).
-        public typealias Identifier = CTAP2.Extension.Identifier
+        /// Identifier for a WebAuthn-level extension.
+        ///
+        /// One case per typed field on ``RegistrationInputs`` /
+        /// ``AuthenticationInputs``. Distinct from the CTAP wire vocabulary
+        /// in ``CTAP2/Extension/Identifier``.
+        public enum Identifier: Hashable, Sendable, CaseIterable {
+            /// WebAuthn wrapper over CTAP2 hmac-secret.
+            case prf
+            case credProtect
+            case credBlob
+            /// Client-side only; not echoed by the authenticator.
+            case credProps
+            case largeBlob
+            case minPinLength
+            /// WebAuthn JSON key is `payment`.
+            case thirdPartyPayment
+            /// Experimental; see ``WebAuthn/Extension/PreviewSign``.
+            case previewSign
+        }
     }
+}
+
+extension Set where Element == WebAuthn.Extension.Identifier {
+    /// Every WebAuthn extension identifier the SDK supports.
+    public static var all: Set<Element> { Set(Element.allCases) }
+
+    /// Extensions enabled by default.
+    ///
+    /// Excludes ``WebAuthn/Extension/Identifier/thirdPartyPayment`` (payment
+    /// semantics — opt in explicitly) and ``WebAuthn/Extension/Identifier/previewSign``
+    /// (experimental).
+    public static let standard: Set<Element> = [
+        .prf, .credProtect, .credBlob, .credProps, .largeBlob, .minPinLength,
+    ]
 }
 
 // MARK: - Registration Extension Inputs


### PR DESCRIPTION
## Summary

Adds an `allowedExtensions` allowlist to `WebAuthn.Client` so callers can explicitly control which WebAuthn extensions are built into CTAP requests and surfaced in results. Anything not on the list is dropped at both the build and parse stages.

Promotes `WebAuthn.Extension.Identifier` from a typealias of `CTAP2.Extension.Identifier` to its own enum — CTAP is the wire vocabulary, WebAuthn is the API surface.

## API

```swift
WebAuthn.Client(session: …, origin: …, allowedExtensions: .standard, isPublicSuffix: …)
```

- `.all` — every supported extension
- `.standard` (default) — everything except `thirdPartyPayment` and `previewSign`
- `[]` — disable all
- custom — any subset