### PR TITLE
Lift WebAuthn PIN/UV into a per-ceremony Authorization

### DIFF
--- a/FullStackTests/Tests/CTAP2/TestHelpers.swift
+++ b/FullStackTests/Tests/CTAP2/TestHelpers.swift
@@ -20,6 +20,14 @@ import Foundation
 // MARK: - CTAP2 Test Configuration
 let defaultTestPin = "11234567"
 
+/// Reference-typed state container for `@Sendable` closures (e.g. PIN/UV
+/// callbacks supplied to a WebAuthn ceremony) that need to mutate
+/// captured state across invocations.
+final class Box<T>: @unchecked Sendable {
+    var value: T
+    init(_ value: T) { self.value = value }
+}
+
 #if os(macOS)
 let ctap2Transport: CTAP2Transport = .hid
 #elseif os(iOS)

--- a/FullStackTests/Tests/WebAuthn/Extensions/CredBlobTests.swift
+++ b/FullStackTests/Tests/WebAuthn/Extensions/CredBlobTests.swift
@@ -41,7 +41,8 @@ struct WebAuthnCredBlobExtensionTests {
             )
 
             print("Creating credential with credBlob...")
-            let createResponse = try await client.makeCredential(createOptions).value(pin: defaultTestPin)
+            let createResponse = try await client.makeCredential(createOptions, authorization: .pin(defaultTestPin))
+                .value()
 
             guard createResponse.clientExtensionResults.credBlob?.stored == true else {
                 print("credBlob not supported - skipping")
@@ -59,7 +60,9 @@ struct WebAuthnCredBlobExtensionTests {
             )
 
             print("Authenticating to retrieve credBlob...")
-            let authResponse = try await client.getAssertion(authOptions).value(pin: defaultTestPin)[0].select()
+            let authResponse = try await client.getAssertion(authOptions, authorization: .pin(defaultTestPin)).value()[
+                0
+            ]
 
             #expect(authResponse.clientExtensionResults.credBlob?.blob == testBlob)
             print("CredBlob retrieved and verified")
@@ -87,7 +90,8 @@ struct WebAuthnCredBlobExtensionTests {
             )
 
             print("Creating credential with credBlob...")
-            let createResponse = try await client.makeCredential(createOptions).value(pin: defaultTestPin)
+            let createResponse = try await client.makeCredential(createOptions, authorization: .pin(defaultTestPin))
+                .value()
 
             guard createResponse.clientExtensionResults.credBlob?.stored == true else {
                 print("credBlob not supported - skipping")
@@ -103,7 +107,9 @@ struct WebAuthnCredBlobExtensionTests {
             )
 
             print("Authenticating without credBlob extension...")
-            let authResponse = try await client.getAssertion(authOptions).value(pin: defaultTestPin)[0].select()
+            let authResponse = try await client.getAssertion(authOptions, authorization: .pin(defaultTestPin)).value()[
+                0
+            ]
 
             #expect(authResponse.clientExtensionResults.credBlob?.blob == nil)
             print("CredBlob not returned without extension")
@@ -148,7 +154,7 @@ struct WebAuthnCredBlobExtensionTests {
 
             print("Attempting credential with oversized credBlob (\(oversizedBlob.count) > \(maxLength))...")
             do {
-                _ = try await client.makeCredential(createOptions).value(pin: defaultTestPin)
+                _ = try await client.makeCredential(createOptions, authorization: .pin(defaultTestPin)).value()
                 Issue.record("Expected error for oversized credBlob")
             } catch {
                 print("Correctly rejected oversized credBlob: \(error)")

--- a/FullStackTests/Tests/WebAuthn/Extensions/CredPropsTests.swift
+++ b/FullStackTests/Tests/WebAuthn/Extensions/CredPropsTests.swift
@@ -36,7 +36,7 @@ struct WebAuthnCredPropsExtensionTests {
             )
 
             print("Making discoverable credential with credProps...")
-            let response = try await client.makeCredential(options).value(pin: defaultTestPin)
+            let response = try await client.makeCredential(options, authorization: .pin(defaultTestPin)).value()
 
             #expect(response.clientExtensionResults.credProps != nil, "credProps should be present")
             #expect(response.clientExtensionResults.credProps?.rk == true, "rk should be true for discoverable")
@@ -60,7 +60,7 @@ struct WebAuthnCredPropsExtensionTests {
             )
 
             print("Making non-discoverable credential with credProps...")
-            let response = try await client.makeCredential(options).value(pin: defaultTestPin)
+            let response = try await client.makeCredential(options, authorization: .pin(defaultTestPin)).value()
 
             #expect(response.clientExtensionResults.credProps != nil, "credProps should be present")
             #expect(response.clientExtensionResults.credProps?.rk == false, "rk should be false for non-discoverable")
@@ -83,7 +83,7 @@ struct WebAuthnCredPropsExtensionTests {
             )
 
             print("Making credential without credProps extension...")
-            let response = try await client.makeCredential(options).value(pin: defaultTestPin)
+            let response = try await client.makeCredential(options, authorization: .pin(defaultTestPin)).value()
 
             #expect(response.clientExtensionResults.credProps == nil, "credProps should be nil when not requested")
             print("credProps correctly nil")

--- a/FullStackTests/Tests/WebAuthn/Extensions/CredProtectTests.swift
+++ b/FullStackTests/Tests/WebAuthn/Extensions/CredProtectTests.swift
@@ -39,7 +39,10 @@ struct WebAuthnCredProtectExtensionTests {
             )
 
             print("Creating credential without credProtect extension...")
-            let createResponseNone = try await client.makeCredential(createOptionsNone).value(pin: defaultTestPin)
+            let createResponseNone = try await client.makeCredential(
+                createOptionsNone,
+                authorization: .pin(defaultTestPin)
+            ).value()
             #expect(createResponseNone.clientExtensionResults.credProtect?.policy == nil)
             print("No credProtect in response when not requested")
 
@@ -59,7 +62,8 @@ struct WebAuthnCredProtectExtensionTests {
             )
 
             print("Creating credential with credProtect level 1...")
-            let createResponse1 = try await client.makeCredential(createOptions1).value(pin: defaultTestPin)
+            let createResponse1 = try await client.makeCredential(createOptions1, authorization: .pin(defaultTestPin))
+                .value()
 
             if createResponse1.clientExtensionResults.credProtect?.policy == nil {
                 print("credProtect not supported - skipping")
@@ -84,7 +88,8 @@ struct WebAuthnCredProtectExtensionTests {
             )
 
             print("Creating credential with credProtect level 2...")
-            let createResponse2 = try await client.makeCredential(createOptions2).value(pin: defaultTestPin)
+            let createResponse2 = try await client.makeCredential(createOptions2, authorization: .pin(defaultTestPin))
+                .value()
 
             #expect(
                 createResponse2.clientExtensionResults.credProtect?.policy
@@ -108,7 +113,8 @@ struct WebAuthnCredProtectExtensionTests {
             )
 
             print("Creating credential with credProtect level 3...")
-            let createResponse3 = try await client.makeCredential(createOptions3).value(pin: defaultTestPin)
+            let createResponse3 = try await client.makeCredential(createOptions3, authorization: .pin(defaultTestPin))
+                .value()
 
             #expect(createResponse3.clientExtensionResults.credProtect?.policy == .userVerificationRequired)
             print("CredProtect level 3 confirmed")

--- a/FullStackTests/Tests/WebAuthn/Extensions/LargeBlobsTests.swift
+++ b/FullStackTests/Tests/WebAuthn/Extensions/LargeBlobsTests.swift
@@ -41,7 +41,8 @@ struct WebAuthnLargeBlobExtensionTests {
             )
 
             print("Creating credential with largeBlob support...")
-            let createResponse = try await client.makeCredential(createOptions).value(pin: defaultTestPin)
+            let createResponse = try await client.makeCredential(createOptions, authorization: .pin(defaultTestPin))
+                .value()
 
             guard createResponse.clientExtensionResults.largeBlob?.supported == true else {
                 print("LargeBlob not supported - skipping")
@@ -61,7 +62,8 @@ struct WebAuthnLargeBlobExtensionTests {
             )
 
             print("Writing blob...")
-            let writeResponse = try await client.getAssertion(writeOptions).value(pin: defaultTestPin)[0].select()
+            let writeResponse = try await client.getAssertion(writeOptions, authorization: .pin(defaultTestPin))
+                .value()[0]
 
             #expect(writeResponse.clientExtensionResults.largeBlob?.written == true)
             print("Blob written")
@@ -77,7 +79,9 @@ struct WebAuthnLargeBlobExtensionTests {
             )
 
             print("Reading blob...")
-            let readResponse = try await client.getAssertion(readOptions).value(pin: defaultTestPin)[0].select()
+            let readResponse = try await client.getAssertion(readOptions, authorization: .pin(defaultTestPin)).value()[
+                0
+            ]
 
             #expect(readResponse.clientExtensionResults.largeBlob?.blob == testData)
             print("Blob retrieved and verified")
@@ -153,7 +157,8 @@ struct WebAuthnLargeBlobExtensionTests {
             )
 
             print("Creating first credential...")
-            let createResponse1 = try await client.makeCredential(createOptions1).value(pin: defaultTestPin)
+            let createResponse1 = try await client.makeCredential(createOptions1, authorization: .pin(defaultTestPin))
+                .value()
 
             guard createResponse1.clientExtensionResults.largeBlob?.supported == true else {
                 print("LargeBlob not supported - skipping")
@@ -170,7 +175,7 @@ struct WebAuthnLargeBlobExtensionTests {
                 allowCredentials: [.init(id: credentialId1)],
                 extensions: .init(largeBlob: .write(testData1))
             )
-            _ = try await client.getAssertion(writeOptions1).value(pin: defaultTestPin)[0].select()
+            _ = try await client.getAssertion(writeOptions1, authorization: .pin(defaultTestPin)).value()[0]
             print("First blob written")
 
             client = try await reconnect().client
@@ -189,7 +194,8 @@ struct WebAuthnLargeBlobExtensionTests {
             )
 
             print("Creating second credential...")
-            let createResponse2 = try await client.makeCredential(createOptions2).value(pin: defaultTestPin)
+            let createResponse2 = try await client.makeCredential(createOptions2, authorization: .pin(defaultTestPin))
+                .value()
             let credentialId2 = createResponse2.credentialId
             client = try await reconnect().client
 
@@ -200,7 +206,7 @@ struct WebAuthnLargeBlobExtensionTests {
                 allowCredentials: [.init(id: credentialId2)],
                 extensions: .init(largeBlob: .write(testData2))
             )
-            _ = try await client.getAssertion(writeOptions2).value(pin: defaultTestPin)[0].select()
+            _ = try await client.getAssertion(writeOptions2, authorization: .pin(defaultTestPin)).value()[0]
             print("Second blob written")
 
             client = try await reconnect().client
@@ -212,7 +218,8 @@ struct WebAuthnLargeBlobExtensionTests {
                 allowCredentials: [.init(id: credentialId1)],
                 extensions: .init(largeBlob: .read)
             )
-            let readResponse1 = try await client.getAssertion(readOptions1).value(pin: defaultTestPin)[0].select()
+            let readResponse1 = try await client.getAssertion(readOptions1, authorization: .pin(defaultTestPin))
+                .value()[0]
             #expect(readResponse1.clientExtensionResults.largeBlob?.blob == testData1)
 
             client = try await reconnect().client
@@ -223,7 +230,8 @@ struct WebAuthnLargeBlobExtensionTests {
                 allowCredentials: [.init(id: credentialId2)],
                 extensions: .init(largeBlob: .read)
             )
-            let readResponse2 = try await client.getAssertion(readOptions2).value(pin: defaultTestPin)[0].select()
+            let readResponse2 = try await client.getAssertion(readOptions2, authorization: .pin(defaultTestPin))
+                .value()[0]
             #expect(readResponse2.clientExtensionResults.largeBlob?.blob == testData2)
 
             print("Both blobs retrieved and verified independently")
@@ -250,7 +258,8 @@ struct WebAuthnLargeBlobExtensionTests {
             )
 
             print("Creating credential with largeBlob support...")
-            let createResponse = try await client.makeCredential(createOptions).value(pin: defaultTestPin)
+            let createResponse = try await client.makeCredential(createOptions, authorization: .pin(defaultTestPin))
+                .value()
 
             guard createResponse.clientExtensionResults.largeBlob?.supported == true else {
                 print("LargeBlob not supported - skipping")
@@ -273,7 +282,7 @@ struct WebAuthnLargeBlobExtensionTests {
 
             print("Attempting to write oversized blob (\(oversizedData.count) bytes)...")
             do {
-                _ = try await client.getAssertion(writeOptions).value(pin: defaultTestPin)[0].select()
+                _ = try await client.getAssertion(writeOptions, authorization: .pin(defaultTestPin)).value()[0]
                 Issue.record("Expected storageFull error for oversized blob")
             } catch let error as WebAuthn.ClientError {
                 guard case .storageFull = error else {

--- a/FullStackTests/Tests/WebAuthn/Extensions/MinPinLengthTests.swift
+++ b/FullStackTests/Tests/WebAuthn/Extensions/MinPinLengthTests.swift
@@ -76,7 +76,8 @@ struct WebAuthnMinPinLengthExtensionTests {
             )
 
             print("Creating credential with minPinLength extension...")
-            let createResponse = try await client.makeCredential(createOptions).value(pin: defaultTestPin)
+            let createResponse = try await client.makeCredential(createOptions, authorization: .pin(defaultTestPin))
+                .value()
 
             guard let length = createResponse.clientExtensionResults.minPinLength?.length else {
                 Issue.record("minPinLength should be returned for configured RP")

--- a/FullStackTests/Tests/WebAuthn/Extensions/PRFTests.swift
+++ b/FullStackTests/Tests/WebAuthn/Extensions/PRFTests.swift
@@ -40,7 +40,8 @@ struct WebAuthnPRFExtensionTests {
             )
 
             print("Creating credential with PRF enabled...")
-            let createResponse = try await client.makeCredential(createOptions).value(pin: defaultTestPin)
+            let createResponse = try await client.makeCredential(createOptions, authorization: .pin(defaultTestPin))
+                .value()
 
             guard createResponse.clientExtensionResults.prf?.enabled == true else {
                 print("PRF not supported - skipping")
@@ -62,7 +63,8 @@ struct WebAuthnPRFExtensionTests {
             )
 
             print("Authenticating with PRF (one secret)...")
-            let authResponse1 = try await client.getAssertion(authOptions1).value(pin: defaultTestPin)[0].select()
+            let authResponse1 = try await client.getAssertion(authOptions1, authorization: .pin(defaultTestPin))
+                .value()[0]
 
             guard let prfOutput1 = authResponse1.clientExtensionResults.prf else {
                 Issue.record("Expected PRF output in first assertion")
@@ -89,7 +91,8 @@ struct WebAuthnPRFExtensionTests {
             )
 
             print("Authenticating with PRF (two secrets, evalByCredential)...")
-            let authResponse2 = try await client.getAssertion(authOptions2).value(pin: defaultTestPin)[0].select()
+            let authResponse2 = try await client.getAssertion(authOptions2, authorization: .pin(defaultTestPin))
+                .value()[0]
 
             guard let prfOutput2 = authResponse2.clientExtensionResults.prf else {
                 Issue.record("Expected PRF output in second assertion")
@@ -131,7 +134,8 @@ struct WebAuthnPRFExtensionTests {
             )
 
             print("Creating credential with PRF secrets...")
-            let createResponse = try await client.makeCredential(createOptions).value(pin: defaultTestPin)
+            let createResponse = try await client.makeCredential(createOptions, authorization: .pin(defaultTestPin))
+                .value()
 
             guard let prfOutput = createResponse.clientExtensionResults.prf,
                 let mcSecrets = prfOutput.results
@@ -156,7 +160,9 @@ struct WebAuthnPRFExtensionTests {
             )
 
             print("Authenticating with PRF (verifying determinism)...")
-            let authResponse = try await client.getAssertion(authOptions).value(pin: defaultTestPin)[0].select()
+            let authResponse = try await client.getAssertion(authOptions, authorization: .pin(defaultTestPin)).value()[
+                0
+            ]
 
             guard let gaOutput = authResponse.clientExtensionResults.prf else {
                 Issue.record("Expected PRF output in assertion")

--- a/FullStackTests/Tests/WebAuthn/Extensions/PreviewSignTests.swift
+++ b/FullStackTests/Tests/WebAuthn/Extensions/PreviewSignTests.swift
@@ -45,8 +45,7 @@ struct WebAuthnPreviewSignExtensionTests {
                 userVerification: .discouraged
             )
 
-            let response = try await client.makeCredential(createOptions)
-                .value(pin: defaultTestPin)
+            let response = try await client.makeCredential(createOptions, authorization: .pin(defaultTestPin)).value()
 
             #expect(response.clientExtensionResults.previewSign == nil)
         }
@@ -75,8 +74,7 @@ struct WebAuthnPreviewSignExtensionTests {
                 )
             )
 
-            let response = try await client.makeCredential(createOptions)
-                .value(pin: defaultTestPin)
+            let response = try await client.makeCredential(createOptions, authorization: .pin(defaultTestPin)).value()
 
             let generatedKey = try assertGeneratedKey(response)
             #expect(

--- a/FullStackTests/Tests/WebAuthn/Extensions/ThirdPartyPaymentTests.swift
+++ b/FullStackTests/Tests/WebAuthn/Extensions/ThirdPartyPaymentTests.swift
@@ -66,7 +66,8 @@ struct WebAuthnThirdPartyPaymentExtensionTests {
                     : nil
             )
 
-            let createResponse = try await client.makeCredential(createOptions).value(pin: defaultTestPin)
+            let createResponse = try await client.makeCredential(createOptions, authorization: .pin(defaultTestPin))
+                .value()
 
             client = try await reconnect().client
 
@@ -77,7 +78,8 @@ struct WebAuthnThirdPartyPaymentExtensionTests {
                 extensions: .init(thirdPartyPayment: .enabled)
             )
 
-            let authResponse = try await client.getAssertion(authOptions).value(pin: defaultTestPin)[0].select()
+            let authResponse = try await client.getAssertion(authOptions, authorization: .pin(defaultTestPin))
+                .value()[0]
 
             let echoedBit = authResponse.clientExtensionResults.thirdPartyPayment?.isPaymentEnabled
             #expect(echoedBit == expectedEcho)

--- a/FullStackTests/Tests/WebAuthn/WebAuthnClientTests.swift
+++ b/FullStackTests/Tests/WebAuthn/WebAuthnClientTests.swift
@@ -59,7 +59,8 @@ struct WebAuthnClientFullStackTests {
             )
 
             print("Making credential...")
-            let createResponse = try await client.makeCredential(createOptions).value(pin: defaultTestPin)
+            let createResponse = try await client.makeCredential(createOptions, authorization: .pin(defaultTestPin))
+                .value()
 
             #expect(createResponse.credentialId.count > 0)
             #expect(createResponse.authenticatorData.attestedCredentialData != nil)
@@ -73,8 +74,8 @@ struct WebAuthnClientFullStackTests {
             )
 
             print("Getting assertion...")
-            let matches = try await client.getAssertion(requestOptions).value(pin: defaultTestPin)
-            let assertResponse = try await matches[0].select()
+            let matches = try await client.getAssertion(requestOptions, authorization: .pin(defaultTestPin)).value()
+            let assertResponse = matches[0]
 
             #expect(assertResponse.rawAuthenticatorData.count > 0)
             #expect(assertResponse.signature.count > 0)
@@ -102,7 +103,8 @@ struct WebAuthnClientFullStackTests {
             )
 
             print("Making credential...")
-            let createResponse = try await client.makeCredential(createOptions).value(pin: defaultTestPin)
+            let createResponse = try await client.makeCredential(createOptions, authorization: .pin(defaultTestPin))
+                .value()
 
             client = try await reconnect().client
 
@@ -113,8 +115,8 @@ struct WebAuthnClientFullStackTests {
             )
 
             print("Getting assertion with allow credentials...")
-            let matches = try await client.getAssertion(requestOptions).value(pin: defaultTestPin)
-            let assertResponse = try await matches[0].select()
+            let matches = try await client.getAssertion(requestOptions, authorization: .pin(defaultTestPin)).value()
+            let assertResponse = matches[0]
 
             #expect(assertResponse.credentialId == createResponse.credentialId)
             #expect(assertResponse.signature.count > 0)
@@ -133,7 +135,7 @@ struct WebAuthnClientFullStackTests {
 
             print("Getting assertion with non-existent credential...")
             do {
-                _ = try await client.getAssertion(requestOptions).value(pin: defaultTestPin)
+                _ = try await client.getAssertion(requestOptions, authorization: .pin(defaultTestPin)).value()
                 Issue.record("Should have thrown noCredentials error")
             } catch let error as WebAuthn.ClientError {
                 guard case .noCredentials = error else {
@@ -164,7 +166,8 @@ struct WebAuthnClientFullStackTests {
             )
 
             print("Making initial credential...")
-            let createResponse = try await client.makeCredential(createOptions).value(pin: defaultTestPin)
+            let createResponse = try await client.makeCredential(createOptions, authorization: .pin(defaultTestPin))
+                .value()
 
             client = try await reconnect().client
 
@@ -182,7 +185,7 @@ struct WebAuthnClientFullStackTests {
 
             print("Making credential with exclude list...")
             do {
-                _ = try await client.makeCredential(excludeOptions).value(pin: defaultTestPin)
+                _ = try await client.makeCredential(excludeOptions, authorization: .pin(defaultTestPin)).value()
                 Issue.record("Should have thrown credentialExcluded error")
             } catch let error as WebAuthn.ClientError {
                 guard case .credentialExcluded = error else {
@@ -219,7 +222,7 @@ struct WebAuthnClientFullStackTests {
                 )
 
                 print("Making credential \(i + 1)/\(credentialCount)...")
-                _ = try await client.makeCredential(createOptions).value(pin: defaultTestPin)
+                _ = try await client.makeCredential(createOptions, authorization: .pin(defaultTestPin)).value()
                 client = try await reconnect().client
             }
 
@@ -229,14 +232,14 @@ struct WebAuthnClientFullStackTests {
             )
 
             print("Getting matched credentials for selection...")
-            let matches = try await client.getAssertion(requestOptions).value(pin: defaultTestPin)
+            let matches = try await client.getAssertion(requestOptions, authorization: .pin(defaultTestPin)).value()
 
             #expect(matches.count >= credentialCount, "Should have at least \(credentialCount) matched credentials")
             print("Found \(matches.count) matched credentials")
 
             // Verify each match has credential info for selection UI
             for match in matches {
-                #expect(match.id.count > 0, "Credential ID should be present")
+                #expect(match.credentialId.count > 0, "Credential ID should be present")
                 #expect(match.user != nil, "User info should be present for discoverable credentials")
             }
 
@@ -245,12 +248,8 @@ struct WebAuthnClientFullStackTests {
             let chosen = matches[chosenIndex]
             print("Selecting credential at index \(chosenIndex): \(chosen.user?.name ?? "unknown")")
 
-            let response = try await chosen.select()
-
-            #expect(response.signature.count > 0)
-            #expect(response.rawAuthenticatorData.count > 0)
-            #expect(response.credentialId == chosen.id)
-            #expect(response.user?.id == chosen.user?.id)
+            #expect(chosen.signature.count > 0)
+            #expect(chosen.rawAuthenticatorData.count > 0)
             print("Selection completed successfully")
         }
     }
@@ -279,7 +278,7 @@ struct WebAuthnClientFullStackTests {
 
             print("Attempting credential with mismatched RP ID...")
             do {
-                _ = try await client.makeCredential(options).value(pin: defaultTestPin)
+                _ = try await client.makeCredential(options, authorization: .pin(defaultTestPin)).value()
                 Issue.record("Should have thrown invalidRequest error")
             } catch let error as WebAuthn.ClientError {
                 guard case .invalidRequest(let message, _) = error else {
@@ -314,7 +313,7 @@ struct WebAuthnClientFullStackTests {
 
             print("Attempting credential with public suffix RP ID...")
             do {
-                _ = try await client.makeCredential(options).value(pin: defaultTestPin)
+                _ = try await client.makeCredential(options, authorization: .pin(defaultTestPin)).value()
                 Issue.record("Should have thrown invalidRequest error")
             } catch let error as WebAuthn.ClientError {
                 guard case .invalidRequest(let message, _) = error else {
@@ -351,15 +350,15 @@ struct WebAuthnClientFullStackTests {
 
             print("Attempting credential with wrong PIN...")
             do {
-                _ = try await client.makeCredential(options).value(pin: "wrongpin123")
-                Issue.record("Should have thrown invalidPIN error")
+                _ = try await client.makeCredential(options, authorization: .pin("wrongpin123")).value()
+                Issue.record("Should have thrown pinRejected error")
             } catch let error as WebAuthn.ClientError {
-                guard case .invalidPIN(let retries, _) = error else {
-                    Issue.record("Expected invalidPIN error, got: \(error)")
+                guard case .pinRejected(let retries, _) = error else {
+                    Issue.record("Expected pinRejected error, got: \(error)")
                     return
                 }
                 #expect(retries < 8, "Retry counter should have decremented")
-                print("Correctly received invalidPIN with \(retries) retries remaining")
+                print("Correctly received pinRejected with \(retries) retries remaining")
             }
         }
     }
@@ -391,7 +390,11 @@ struct WebAuthnClientFullStackTests {
             )
 
             print("Making credential to verify clientDataJSON...")
-            let response = try await client.makeCredential(options, clientData: clientData).value(pin: defaultTestPin)
+            let response = try await client.makeCredential(
+                options,
+                clientData: clientData,
+                authorization: .pin(defaultTestPin)
+            ).value()
 
             guard let clientDataJSON = response.clientDataJSON else {
                 Issue.record("clientDataJSON should not be nil for client-initiated flows")
@@ -425,7 +428,7 @@ struct WebAuthnClientFullStackTests {
 
     // MARK: - Status Stream
 
-    @Test("Get Assertions - Status Stream delivers PIN and user presence events")
+    @Test("Get Assertions - Status Stream delivers user-presence events; closures supply PIN")
     func testGetAssertionStatusStream() async throws {
         try await withReconnectableWebAuthnClient { client, _, reconnect in
             var client = client
@@ -442,7 +445,7 @@ struct WebAuthnClientFullStackTests {
             )
 
             print("Making credential...")
-            _ = try await client.makeCredential(createOptions).value(pin: defaultTestPin)
+            _ = try await client.makeCredential(createOptions, authorization: .pin(defaultTestPin)).value()
             client = try await reconnect().client
 
             let requestOptions = WebAuthn.Authentication.Options(
@@ -451,30 +454,36 @@ struct WebAuthnClientFullStackTests {
             )
 
             print("Iterating getAssertions status stream...")
-            var sawPINRequest = false
+            let pinAsks = Box(0)
             var sawWaitingForUser = false
-            var matches: [WebAuthn.Authentication.MatchedCredential]?
+            var matches: [WebAuthn.Authentication.Response]?
 
-            for try await status in await client.getAssertion(requestOptions) {
+            let stream = await client.getAssertion(
+                requestOptions,
+                authorization: .init(
+                    providePIN: {
+                        print("PIN requested via closure - submitting")
+                        pinAsks.value += 1
+                        return .pin(defaultTestPin)
+                    },
+                    uv: .skipped
+                )
+            )
+            for try await status in stream {
                 switch status {
                 case .processing:
                     print("Processing...")
                 case .waitingForUser:
                     print("Waiting for user...")
                     sawWaitingForUser = true
-                case .requestingUV(let useUV):
-                    print("Requesting UV - declining to force PIN path")
-                    useUV(false)
-                case .requestingPIN(let submitPIN):
-                    print("PIN requested - submitting")
-                    sawPINRequest = true
-                    submitPIN(defaultTestPin)
+                case .waitingForUserVerification:
+                    Issue.record("UV should be skipped under .pin authorization")
                 case .finished(let result):
                     matches = result
                 }
             }
 
-            #expect(sawPINRequest, "Stream should have delivered a PIN request")
+            #expect(pinAsks.value == 1, "PIN closure should have been invoked exactly once")
             #expect(sawWaitingForUser, "Stream should have delivered waitingForUser")
             guard let matches else {
                 Issue.record("Stream should have delivered .finished with matches")
@@ -482,7 +491,7 @@ struct WebAuthnClientFullStackTests {
             }
             #expect(!matches.isEmpty, "Should have at least one matched credential")
 
-            let response = try await matches[0].select()
+            let response = matches[0]
             #expect(response.signature.count > 0)
             print("Status stream assertion completed successfully")
         }
@@ -509,7 +518,7 @@ struct WebAuthnClientFullStackTests {
 
             print("Getting discoverable assertions for RP with no credentials...")
             do {
-                _ = try await client.getAssertion(requestOptions).value(pin: defaultTestPin)
+                _ = try await client.getAssertion(requestOptions, authorization: .pin(defaultTestPin)).value()
                 Issue.record("Should have thrown noCredentials error")
             } catch let error as WebAuthn.ClientError {
                 guard case .noCredentials = error else {
@@ -518,6 +527,91 @@ struct WebAuthnClientFullStackTests {
                 }
                 print("Correctly received noCredentials error for discoverable path")
             }
+        }
+    }
+
+    // MARK: - Pre-supplied PIN
+
+    @Test("Make Credential - Pre-supplied PIN consumed silently")
+    func testMakeCredentialPrefetchedPIN() async throws {
+        try await withWebAuthnClient { client in
+            let options = WebAuthn.Registration.Options(
+                challenge: randomBytes(count: 32),
+                rp: .init(id: testRpId, name: testRpName),
+                user: .init(
+                    id: randomBytes(count: 32),
+                    name: "prefetched-pin@example.com",
+                    displayName: "Prefetched PIN User"
+                ),
+                residentKey: .discouraged
+            )
+
+            print("Iterating makeCredential stream with pre-supplied PIN...")
+            var sawWaitingForUser = false
+            var finished = false
+
+            for try await status in await client.makeCredential(
+                options,
+                authorization: .pin(defaultTestPin)
+            ) {
+                switch status {
+                case .processing:
+                    break
+                case .waitingForUser:
+                    sawWaitingForUser = true
+                case .waitingForUserVerification:
+                    Issue.record("UV should be skipped under .pin authorization")
+                case .finished:
+                    finished = true
+                }
+            }
+
+            #expect(sawWaitingForUser, "Stream should still deliver waitingForUser")
+            #expect(finished, "Stream should reach .finished")
+        }
+    }
+
+    @Test("Get Assertion - Pre-supplied PIN consumed silently")
+    func testGetAssertionPrefetchedPIN() async throws {
+        try await withReconnectableWebAuthnClient { client, _, reconnect in
+            var client = client
+
+            let createOptions = WebAuthn.Registration.Options(
+                challenge: randomBytes(count: 32),
+                rp: .init(id: testRpId, name: testRpName),
+                user: .init(
+                    id: randomBytes(count: 32),
+                    name: "prefetched-ga@example.com",
+                    displayName: "Prefetched GA User"
+                ),
+                residentKey: .required
+            )
+
+            _ = try await client.makeCredential(createOptions, authorization: .pin(defaultTestPin)).value()
+            client = try await reconnect().client
+
+            let requestOptions = WebAuthn.Authentication.Options(
+                challenge: randomBytes(count: 32),
+                rpId: testRpId
+            )
+
+            print("Iterating getAssertion stream with pre-supplied PIN...")
+            var matches: [WebAuthn.Authentication.Response]?
+
+            for try await status in await client.getAssertion(
+                requestOptions,
+                authorization: .pin(defaultTestPin)
+            ) {
+                if case .finished(let result) = status { matches = result }
+            }
+
+            guard let matches else {
+                Issue.record("Stream should have delivered .finished with matches")
+                return
+            }
+            #expect(!matches.isEmpty)
+            let response = matches[0]
+            #expect(response.signature.count > 0)
         }
     }
 
@@ -540,17 +634,16 @@ struct WebAuthnClientFullStackTests {
             print("Starting credential creation, will cancel on waitingForUser...")
 
             do {
-                for try await status in await client.makeCredential(options) {
+                let stream = await client.makeCredential(options, authorization: .pin(defaultTestPin))
+                for try await status in stream {
                     switch status {
                     case .processing:
                         print("Processing...")
                     case .waitingForUser(let cancel):
                         print("Waiting for user - cancelling now!")
                         await cancel()
-                    case .requestingUV:
-                        print("Requesting UV...")
-                    case .requestingPIN(let submitPIN):
-                        submitPIN(defaultTestPin)
+                    case .waitingForUserVerification:
+                        Issue.record("UV should be skipped under .pin authorization")
                     case .finished:
                         Issue.record("makeCredential should have been cancelled")
                     }

--- a/YubiKit/UnitTests/FIDO/WebAuthn/MockWebAuthnBackend.swift
+++ b/YubiKit/UnitTests/FIDO/WebAuthn/MockWebAuthnBackend.swift
@@ -26,8 +26,17 @@ actor MockWebAuthnBackend: WebAuthn.Backend {
     nonisolated(unsafe) var onGetInfo: (() throws(CTAP2.SessionError) -> CTAP2.GetInfo.Response)!
     nonisolated(unsafe) var onGetUVRetries: (() throws(CTAP2.SessionError) -> Int)!
     nonisolated(unsafe) var onGetPinRetries: (() throws(CTAP2.SessionError) -> CTAP2.ClientPin.GetRetries.Response)!
+    /// Set one of these. Use the updates form to drive `.waitingForUser` keep-alives.
     nonisolated(unsafe) var onGetPinUVToken:
-        ((CTAP2.ClientPin.Method, CTAP2.ClientPin.Permission, String?) throws(CTAP2.SessionError) -> CTAP2.Token)!
+        (
+            (CTAP2.ClientPin.Method, CTAP2.ClientPin.Permission, String?)
+                throws(CTAP2.SessionError) -> CTAP2.Token
+        )?
+    nonisolated(unsafe) var onGetPinUVTokenUpdates:
+        (
+            (CTAP2.ClientPin.Method, CTAP2.ClientPin.Permission, String?)
+                throws(CTAP2.SessionError) -> CTAP2.StatusStream<CTAP2.Token>
+        )?
     nonisolated(unsafe) var onMakeCredential:
         ((CTAP2.MakeCredential.Parameters) -> CTAP2.StatusStream<CTAP2.MakeCredential.Response>)!
     nonisolated(unsafe) var onGetAssertion:
@@ -46,12 +55,23 @@ actor MockWebAuthnBackend: WebAuthn.Backend {
         try onGetPinRetries()
     }
 
-    func getPinUVToken(
+    func getPinUVTokenUpdates(
         using method: CTAP2.ClientPin.Method,
         permissions: CTAP2.ClientPin.Permission,
         rpId: String?
-    ) async throws(CTAP2.SessionError) -> CTAP2.Token {
-        try onGetPinUVToken(method, permissions, rpId)
+    ) async throws(CTAP2.SessionError) -> CTAP2.StatusStream<CTAP2.Token> {
+        if let onGetPinUVTokenUpdates {
+            return try onGetPinUVTokenUpdates(method, permissions, rpId)
+        }
+        guard let onGetPinUVToken else {
+            preconditionFailure("Set onGetPinUVToken or onGetPinUVTokenUpdates")
+        }
+        do throws(CTAP2.SessionError) {
+            let token = try onGetPinUVToken(method, permissions, rpId)
+            return .mocked(.finished(token))
+        } catch {
+            return .mocked(error: error)
+        }
     }
 
     func makeCredential(
@@ -118,17 +138,41 @@ extension CTAP2.StatusStream {
     static func mocked(error: CTAP2.SessionError) -> Self { .init { $0.yield(error: error) } }
 }
 
+// MARK: - Client Helpers
+
+extension WebAuthn.Client {
+    static func make(
+        backend: WebAuthn.Backend,
+        origin: String = "https://example.com"
+    ) throws -> WebAuthn.Client {
+        WebAuthn.Client(
+            backend: backend,
+            origin: try WebAuthn.Origin(origin),
+            allowedExtensions: .standard,
+            isPublicSuffix: { _ in false }
+        )
+    }
+}
+
 // MARK: - Test Stubs
 
 extension CTAP2.GetInfo.Response {
     static func stub(
         maxCredentialIdLength: UInt? = nil,
-        maxCredentialCountInList: UInt? = nil
+        maxCredentialCountInList: UInt? = nil,
+        clientPin: Bool = false,
+        userVerification: Bool = false,
+        pinUvAuthToken: Bool = false,
+        forcePinChange: Bool? = nil
     ) -> Self {
-        let options: CTAP2.GetInfo.Options = CBOR.Value.map([
+        var optionsMap: [CBOR.Value: CBOR.Value] = [
             .textString("up"): .boolean(true),
             .textString("rk"): .boolean(true),
-        ]).cborDecoded()!
+        ]
+        if clientPin { optionsMap[.textString("clientPin")] = .boolean(true) }
+        if userVerification { optionsMap[.textString("uv")] = .boolean(true) }
+        if pinUvAuthToken { optionsMap[.textString("pinUvAuthToken")] = .boolean(true) }
+        let options: CTAP2.GetInfo.Options = CBOR.Value.map(optionsMap).cborDecoded()!
 
         return Self(
             versions: [.fido2_1],
@@ -142,7 +186,7 @@ extension CTAP2.GetInfo.Response {
             transports: [.usb],
             algorithms: [.es256],
             maxSerializedLargeBlobArray: nil,
-            forcePinChange: nil,
+            forcePinChange: forcePinChange,
             minPinLength: nil,
             firmwareVersion: nil,
             maxCredBlobLength: nil,

--- a/YubiKit/UnitTests/FIDO/WebAuthn/PINRetryTests.swift
+++ b/YubiKit/UnitTests/FIDO/WebAuthn/PINRetryTests.swift
@@ -1,0 +1,210 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Testing
+
+@testable import YubiKit
+
+@Suite("WebAuthn PIN Failure Tests", .serialized)
+struct PINRetryTests {
+
+    private static let options = WebAuthn.Authentication.Options(
+        challenge: Data(repeating: 0x01, count: 32),
+        rpId: "example.com",
+        userVerification: .required
+    )
+
+    // MARK: - One-shot Semantics
+
+    @Test("pinInvalid throws pinRejected with the remaining retry count")
+    func testPinInvalidThrowsRejected() async throws {
+        let mock = MockWebAuthnBackend()
+        mock.onGetInfo = { .stub(clientPin: true, pinUvAuthToken: true) }
+        mock.onGetPinRetries = { .init(retries: 7, powerCycleState: false) }
+        mock.onGetUVRetries = { 0 }
+
+        var pinSubmissions: [String] = []
+        mock.onGetPinUVToken = {
+            (method: CTAP2.ClientPin.Method, _, _) throws(CTAP2.SessionError) -> CTAP2.Token in
+            guard case .pin(let pin) = method else {
+                throw CTAP2.SessionError.ctapError(.operationDenied, source: .here())
+            }
+            pinSubmissions.append(pin)
+            throw CTAP2.SessionError.ctapError(.pinInvalid, source: .here())
+        }
+        mock.onGetAssertion = { _ in .mocked(.finished(.stub(credentialId: Data([0xAA])))) }
+
+        let client = try WebAuthn.Client.make(backend: mock)
+
+        var caught: WebAuthn.ClientError?
+        do throws(WebAuthn.ClientError) {
+            _ = try await client.getAssertion(Self.options, authorization: .pin("wrong")).value()
+        } catch {
+            caught = error
+        }
+
+        #expect(pinSubmissions == ["wrong"])
+        guard case .pinRejected(let remaining, _) = caught else {
+            Issue.record("Expected pinRejected, got \(String(describing: caught))")
+            return
+        }
+        #expect(remaining == 7)
+    }
+
+    @Test("pinInvalid with retries == 0 throws pinBlocked")
+    func testPinExhaustedThrowsBlocked() async throws {
+        let mock = MockWebAuthnBackend()
+        mock.onGetInfo = { .stub(clientPin: true, pinUvAuthToken: true) }
+        mock.onGetPinRetries = { .init(retries: 0, powerCycleState: false) }
+        mock.onGetUVRetries = { 0 }
+        mock.onGetPinUVToken = {
+            (method: CTAP2.ClientPin.Method, _, _) throws(CTAP2.SessionError) -> CTAP2.Token in
+            guard case .pin = method else {
+                throw CTAP2.SessionError.ctapError(.operationDenied, source: .here())
+            }
+            throw CTAP2.SessionError.ctapError(.pinInvalid, source: .here())
+        }
+        mock.onGetAssertion = { _ in .mocked(.finished(.stub(credentialId: Data([0xAA])))) }
+
+        let client = try WebAuthn.Client.make(backend: mock)
+
+        var caught: WebAuthn.ClientError?
+        do throws(WebAuthn.ClientError) {
+            _ = try await client.getAssertion(Self.options, authorization: .pin("bad")).value()
+        } catch {
+            caught = error
+        }
+
+        guard case .pinBlocked = caught else {
+            Issue.record("Expected pinBlocked, got \(String(describing: caught))")
+            return
+        }
+    }
+
+    // MARK: - Error Propagation
+
+    @Test("pinInvalid followed by a getPinRetries transport failure surfaces the transport error")
+    func testPinInvalidGetRetriesFailureBubblesTransport() async throws {
+        let mock = MockWebAuthnBackend()
+        mock.onGetInfo = { .stub(clientPin: true, pinUvAuthToken: true) }
+        mock.onGetUVRetries = { 0 }
+        mock.onGetPinRetries = { () throws(CTAP2.SessionError) -> CTAP2.ClientPin.GetRetries.Response in
+            throw CTAP2.SessionError.connectionError(.connectionLost, source: .here())
+        }
+        mock.onGetPinUVToken = {
+            (method: CTAP2.ClientPin.Method, _, _) throws(CTAP2.SessionError) -> CTAP2.Token in
+            guard case .pin = method else {
+                throw CTAP2.SessionError.ctapError(.operationDenied, source: .here())
+            }
+            throw CTAP2.SessionError.ctapError(.pinInvalid, source: .here())
+        }
+        mock.onGetAssertion = { _ in .mocked(.finished(.stub(credentialId: Data([0xAA])))) }
+
+        let client = try WebAuthn.Client.make(backend: mock)
+
+        var caught: WebAuthn.ClientError?
+        do throws(WebAuthn.ClientError) {
+            _ = try await client.getAssertion(Self.options, authorization: .pin("wrong")).value()
+        } catch {
+            caught = error
+        }
+
+        // The post-pinInvalid getPinRetries call failed — we must NOT synthesize
+        // a pinBlocked (which would tell the user the PIN is locked when in fact
+        // the connection just dropped).
+        guard case .authenticatorNotAvailable = caught else {
+            Issue.record("Expected authenticatorNotAvailable, got \(String(describing: caught))")
+            return
+        }
+    }
+
+    @Test("forcePinChange surfaces before the PIN closure is invoked")
+    func testForcePinChangeThrowsBeforePrompt() async throws {
+        let mock = MockWebAuthnBackend()
+        mock.onGetInfo = {
+            .stub(clientPin: true, pinUvAuthToken: true, forcePinChange: true)
+        }
+        mock.onGetUVRetries = { 0 }
+
+        var pinUVTokenCalls = 0
+        let pinPromptCalls = Box(0)
+        mock.onGetPinUVToken = { _, _, _ throws(CTAP2.SessionError) in
+            pinUVTokenCalls += 1
+            throw CTAP2.SessionError.ctapError(.pinAuthInvalid, source: .here())
+        }
+        mock.onGetAssertion = { _ in .mocked(.finished(.stub(credentialId: Data([0xAA])))) }
+
+        let client = try WebAuthn.Client.make(backend: mock)
+
+        let auth = WebAuthn.Authorization(providePIN: {
+            pinPromptCalls.value += 1
+            return .pin("should-not-reach")
+        })
+
+        var caught: WebAuthn.ClientError?
+        do throws(WebAuthn.ClientError) {
+            _ = try await client.getAssertion(Self.options, authorization: auth).value()
+        } catch {
+            caught = error
+        }
+
+        #expect(pinPromptCalls.value == 0)
+        #expect(pinUVTokenCalls == 0)
+        guard case .forcePinChange = caught else {
+            Issue.record("Expected forcePinChange, got \(String(describing: caught))")
+            return
+        }
+    }
+
+    @Test("Falling to PIN path without clientPin configured throws pinNotSet")
+    func testPinPathWithoutClientPinThrowsPinNotSet() async throws {
+        let mock = MockWebAuthnBackend()
+        // BIO-only authenticator: UV configured but clientPin is not.
+        mock.onGetInfo = { .stub(clientPin: false, userVerification: true, pinUvAuthToken: true) }
+        // Entering the ceremony with UV already blocked forces PIN fall-through.
+        mock.onGetUVRetries = { 0 }
+
+        var pinUVTokenCalls = 0
+        let pinPromptCalls = Box(0)
+        mock.onGetPinUVToken = { _, _, _ throws(CTAP2.SessionError) in
+            pinUVTokenCalls += 1
+            throw CTAP2.SessionError.ctapError(.operationDenied, source: .here())
+        }
+        mock.onGetAssertion = { _ in .mocked(.finished(.stub(credentialId: Data([0xAA])))) }
+
+        let client = try WebAuthn.Client.make(backend: mock)
+
+        let auth = WebAuthn.Authorization(providePIN: {
+            pinPromptCalls.value += 1
+            return .pin("should-not-reach")
+        })
+
+        var caught: WebAuthn.ClientError?
+        do throws(WebAuthn.ClientError) {
+            _ = try await client.getAssertion(Self.options, authorization: auth).value()
+        } catch {
+            caught = error
+        }
+
+        // The SDK should recognise PIN is unavailable before invoking the
+        // PIN closure or hitting the authenticator with a doomed call.
+        #expect(pinPromptCalls.value == 0)
+        #expect(pinUVTokenCalls == 0)
+        guard case .pinNotSet = caught else {
+            Issue.record("Expected pinNotSet, got \(String(describing: caught))")
+            return
+        }
+    }
+}

--- a/YubiKit/UnitTests/FIDO/WebAuthn/StatusStreamTests.swift
+++ b/YubiKit/UnitTests/FIDO/WebAuthn/StatusStreamTests.swift
@@ -29,7 +29,7 @@ struct StatusStreamTests {
             continuation.yield(.finished("success"))
         }
 
-        let result = try await stream.value(pin: "")
+        let result = try await stream.value()
         #expect(result == "success")
     }
 
@@ -41,7 +41,7 @@ struct StatusStreamTests {
         }
 
         do {
-            _ = try await stream.value(pin: "")
+            _ = try await stream.value()
             Issue.record("Should have thrown")
         } catch let error {
             guard case .cancelled = error else {
@@ -67,7 +67,7 @@ struct StatusStreamTests {
         let timedStream = stream.withTimeout(.milliseconds(100))
 
         do {
-            _ = try await timedStream.value(pin: "")
+            _ = try await timedStream.value()
             Issue.record("Should have timed out")
         } catch let error {
             guard case .timeout = error else {
@@ -85,7 +85,7 @@ struct StatusStreamTests {
         }
 
         let timedStream = stream.withTimeout(.seconds(10))
-        let result = try await timedStream.value(pin: "")
+        let result = try await timedStream.value()
         #expect(result == "fast")
     }
 

--- a/YubiKit/UnitTests/FIDO/WebAuthn/TestHelpers.swift
+++ b/YubiKit/UnitTests/FIDO/WebAuthn/TestHelpers.swift
@@ -1,0 +1,23 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// Reference-typed state container so `@Sendable` closures captured by
+/// a WebAuthn ceremony (PIN/UV providers, status-stream observers) can
+/// mutate shared state across invocations.
+final class Box<T>: @unchecked Sendable {
+    var value: T
+    init(_ value: T) { self.value = value }
+}

--- a/YubiKit/UnitTests/FIDO/WebAuthn/UVFallbackToPINTests.swift
+++ b/YubiKit/UnitTests/FIDO/WebAuthn/UVFallbackToPINTests.swift
@@ -1,0 +1,221 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Testing
+
+@testable import YubiKit
+
+@Suite("WebAuthn UV → PIN Mid-Flight Downgrade", .serialized)
+struct UVFallbackToPINTests {
+
+    private static let options = WebAuthn.Authentication.Options(
+        challenge: Data(repeating: 0x01, count: 32),
+        rpId: "example.com",
+        userVerification: .required
+    )
+
+    // MARK: - fallbackToPIN exposed and routed into PIN path
+
+    @Test("fallbackToPIN closure is non-nil when clientPin set and uv: .preferred")
+    func testFallbackExposed() async throws {
+        let mock = MockWebAuthnBackend()
+        mock.onGetInfo = { .stub(clientPin: true, userVerification: true, pinUvAuthToken: true) }
+        mock.onGetUVRetries = { 3 }
+        mock.onGetPinRetries = { .init(retries: 8, powerCycleState: false) }
+
+        let gate = Promise<Void>()
+        let pinAttempts = Box(0)
+
+        mock.onGetPinUVTokenUpdates = { method, _, _ in
+            switch method {
+            case .uv:
+                return uvWaitingStream(gate: gate)
+            case .pin(let pin):
+                #expect(pin == "1234")
+                pinAttempts.value += 1
+                return .mocked(
+                    .finished(CTAP2.Token(token: Data(repeating: 0, count: 32), protocolVersion: .v2))
+                )
+            }
+        }
+        mock.onGetAssertion = { _ in .mocked(.finished(.stub(credentialId: Data([0xAA])))) }
+
+        let client = try WebAuthn.Client.make(backend: mock)
+        let auth = WebAuthn.Authorization(providePIN: { .pin("1234") }, uv: .preferred)
+        let stream = await client.getAssertion(Self.options, authorization: auth)
+
+        var sawUVWaiting = false
+        var sawFinished = false
+        for try await status in stream {
+            switch status {
+            case .waitingForUserVerification(_, let fallback):
+                sawUVWaiting = true
+                let fallback = try #require(fallback, "fallbackToPIN should be exposed")
+                await fallback()
+            case .finished:
+                sawFinished = true
+            default:
+                break
+            }
+        }
+
+        #expect(sawUVWaiting)
+        #expect(sawFinished)
+        #expect(pinAttempts.value == 1, "Ceremony should have continued via PIN path")
+    }
+
+    // MARK: - fallback suppressed under uv: .required
+
+    @Test("fallbackToPIN is nil under uv: .required")
+    func testFallbackSuppressedWhenUVRequired() async throws {
+        let mock = MockWebAuthnBackend()
+        mock.onGetInfo = { .stub(clientPin: true, userVerification: true, pinUvAuthToken: true) }
+        mock.onGetUVRetries = { 3 }
+        mock.onGetPinRetries = { .init(retries: 8, powerCycleState: false) }
+
+        let gate = Promise<Void>()
+        mock.onGetPinUVTokenUpdates = {
+            method,
+            _,
+            _ throws(CTAP2.SessionError) -> CTAP2.StatusStream<CTAP2.Token> in
+            guard case .uv = method else {
+                Issue.record("PIN path reached under uv: .required")
+                throw CTAP2.SessionError.ctapError(.operationDenied, source: .here())
+            }
+            return uvWaitingStream(gate: gate)
+        }
+        mock.onGetAssertion = { _ in .mocked(.finished(.stub(credentialId: Data([0xAA])))) }
+
+        let client = try WebAuthn.Client.make(backend: mock)
+        let auth = WebAuthn.Authorization(providePIN: { .pin("never-asked") }, uv: .required)
+        let stream = await client.getAssertion(Self.options, authorization: auth)
+
+        var fallbackVisibility: Bool?
+        var caught: WebAuthn.ClientError?
+        do throws(WebAuthn.ClientError) {
+            for try await status in stream {
+                if case .waitingForUserVerification(let cancel, let fallback) = status {
+                    fallbackVisibility = fallback != nil
+                    // Aborting via cancel surfaces .cancelled.
+                    await cancel()
+                }
+            }
+        } catch {
+            caught = error
+        }
+
+        #expect(fallbackVisibility == false, "fallbackToPIN must be nil under uv: .required")
+        guard case .cancelled = caught else {
+            Issue.record("Expected .cancelled, got \(String(describing: caught))")
+            return
+        }
+    }
+
+    // MARK: - fallback suppressed without clientPin
+
+    @Test("fallbackToPIN is nil when no clientPin is configured")
+    func testFallbackSuppressedWithoutPIN() async throws {
+        let mock = MockWebAuthnBackend()
+        mock.onGetInfo = { .stub(clientPin: false, userVerification: true, pinUvAuthToken: true) }
+        mock.onGetUVRetries = { 3 }
+
+        let gate = Promise<Void>()
+        mock.onGetPinUVTokenUpdates = { _, _, _ in uvWaitingStream(gate: gate) }
+        mock.onGetAssertion = { _ in .mocked(.finished(.stub(credentialId: Data([0xAA])))) }
+
+        let client = try WebAuthn.Client.make(backend: mock)
+        let auth = WebAuthn.Authorization(providePIN: { .pin("never-asked") }, uv: .preferred)
+        let stream = await client.getAssertion(Self.options, authorization: auth)
+
+        var fallbackVisibility: Bool?
+        var caught: WebAuthn.ClientError?
+        do throws(WebAuthn.ClientError) {
+            for try await status in stream {
+                if case .waitingForUserVerification(let cancel, let fallback) = status {
+                    fallbackVisibility = fallback != nil
+                    await cancel()
+                }
+            }
+        } catch {
+            caught = error
+        }
+
+        #expect(fallbackVisibility == false, "fallbackToPIN must be nil without clientPin")
+        guard case .cancelled = caught else {
+            Issue.record("Expected .cancelled, got \(String(describing: caught))")
+            return
+        }
+    }
+
+    // MARK: - cancel without fallback throws .cancelled
+
+    @Test("cancel without fallback aborts ceremony with .cancelled")
+    func testCancelAbortsCeremony() async throws {
+        let mock = MockWebAuthnBackend()
+        mock.onGetInfo = { .stub(clientPin: true, userVerification: true, pinUvAuthToken: true) }
+        mock.onGetUVRetries = { 3 }
+        mock.onGetPinRetries = { .init(retries: 8, powerCycleState: false) }
+
+        let gate = Promise<Void>()
+        let pinAttempts = Box(0)
+        mock.onGetPinUVTokenUpdates = { method, _, _ in
+            switch method {
+            case .uv:
+                return uvWaitingStream(gate: gate)
+            case .pin:
+                pinAttempts.value += 1
+                return .mocked(
+                    .finished(CTAP2.Token(token: Data(repeating: 0, count: 32), protocolVersion: .v2))
+                )
+            }
+        }
+        mock.onGetAssertion = { _ in .mocked(.finished(.stub(credentialId: Data([0xAA])))) }
+
+        let client = try WebAuthn.Client.make(backend: mock)
+        let auth = WebAuthn.Authorization(providePIN: { .pin("1234") }, uv: .preferred)
+        let stream = await client.getAssertion(Self.options, authorization: auth)
+
+        var caught: WebAuthn.ClientError?
+        do throws(WebAuthn.ClientError) {
+            for try await status in stream {
+                if case .waitingForUserVerification(let cancel, _) = status {
+                    await cancel()
+                }
+            }
+        } catch {
+            caught = error
+        }
+
+        guard case .cancelled = caught else {
+            Issue.record("Expected .cancelled, got \(String(describing: caught))")
+            return
+        }
+        #expect(pinAttempts.value == 0, "PIN path must not run after a plain cancel")
+    }
+}
+
+// MARK: - Test Helpers
+
+/// Builds a `getPinUVTokenUpdates` body that yields `.waitingForUser` and
+/// finalises with `keepaliveCancel` once the gate fulfils.
+private func uvWaitingStream(gate: Promise<Void>) -> CTAP2.StatusStream<CTAP2.Token> {
+    CTAP2.StatusStream<CTAP2.Token> { continuation in
+        Task {
+            continuation.yield(.waitingForUser(cancel: { await gate.fulfill(()) }))
+            try? await gate.value()
+            continuation.yield(error: .ctapError(.keepaliveCancel, source: .here()))
+        }
+    }
+}

--- a/YubiKit/UnitTests/FIDO/WebAuthn/UVRetryTests.swift
+++ b/YubiKit/UnitTests/FIDO/WebAuthn/UVRetryTests.swift
@@ -1,0 +1,347 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Testing
+
+@testable import YubiKit
+
+@Suite("WebAuthn UV Failure Tests", .serialized)
+struct UVRetryTests {
+
+    private static let options = WebAuthn.Authentication.Options(
+        challenge: Data(repeating: 0x01, count: 32),
+        rpId: "example.com",
+        userVerification: .required
+    )
+
+    // MARK: - uvInvalid Surfaces with Retries
+
+    @Test("uvInvalid throws uvRejected with retries remaining; PIN path not touched")
+    func testUVInvalidThrowsRejected() async throws {
+        let mock = MockWebAuthnBackend()
+        mock.onGetInfo = { .stub(clientPin: true, userVerification: true, pinUvAuthToken: true) }
+        mock.onGetPinRetries = { .init(retries: 8, powerCycleState: false) }
+        mock.onGetUVRetries = { 5 }
+
+        var uvAttempts = 0
+        let pinPromptCalls = Box(0)
+        mock.onGetPinUVToken = {
+            (method: CTAP2.ClientPin.Method, _, _) throws(CTAP2.SessionError) -> CTAP2.Token in
+            switch method {
+            case .uv:
+                uvAttempts += 1
+                throw CTAP2.SessionError.ctapError(.uvInvalid, source: .here())
+            case .pin:
+                Issue.record("PIN path reached on uvInvalid; should bubble as uvRejected")
+                throw CTAP2.SessionError.ctapError(.operationDenied, source: .here())
+            }
+        }
+        mock.onGetAssertion = { _ in .mocked(.finished(.stub(credentialId: Data([0xAA])))) }
+
+        let client = try WebAuthn.Client.make(backend: mock)
+
+        let auth = WebAuthn.Authorization(
+            providePIN: {
+                pinPromptCalls.value += 1
+                return .pin("never-asked")
+            },
+            uv: .preferred
+        )
+
+        var caught: WebAuthn.ClientError?
+        do throws(WebAuthn.ClientError) {
+            _ = try await client.getAssertion(Self.options, authorization: auth).value()
+        } catch {
+            caught = error
+        }
+
+        #expect(uvAttempts == 1)
+        #expect(pinPromptCalls.value == 0, "PIN closure must not be invoked on uvInvalid")
+        guard case .uvRejected(let remaining, _) = caught else {
+            Issue.record("Expected uvRejected, got \(String(describing: caught))")
+            return
+        }
+        #expect(remaining == 5)
+    }
+
+    @Test("uvInvalid on internal-UV path also surfaces as uvRejected")
+    func testUVInvalidInternalUVPathThrowsRejected() async throws {
+        let mock = MockWebAuthnBackend()
+        // Internal-UV authenticator: UV configured but no pinUvAuthToken.
+        // acquireAuthToken returns (token: nil, uv: true); the uvInvalid then
+        // comes from the makeCredential/getAssertion command itself, not from
+        // getPinUVToken — must still surface as uvRejected per the contract.
+        mock.onGetInfo = { .stub(clientPin: false, userVerification: true, pinUvAuthToken: false) }
+        mock.onGetUVRetries = { 4 }
+        mock.onGetPinUVToken = { _, _, _ throws(CTAP2.SessionError) in
+            Issue.record("getPinUVToken should not be called on internal-UV path")
+            throw CTAP2.SessionError.ctapError(.operationDenied, source: .here())
+        }
+        mock.onGetAssertion = { _ in .mocked(error: .ctapError(.uvInvalid, source: .here())) }
+
+        let client = try WebAuthn.Client.make(backend: mock)
+
+        var caught: WebAuthn.ClientError?
+        do throws(WebAuthn.ClientError) {
+            _ = try await client.getAssertion(Self.options, authorization: .uvOnly).value()
+        } catch {
+            caught = error
+        }
+
+        guard case .uvRejected(let remaining, _) = caught else {
+            Issue.record("Expected uvRejected, got \(String(describing: caught))")
+            return
+        }
+        #expect(remaining == 4)
+    }
+
+    @Test("uvInvalid followed by a getUVRetries transport failure surfaces the transport error")
+    func testUVInvalidGetRetriesFailureBubblesTransport() async throws {
+        let mock = MockWebAuthnBackend()
+        mock.onGetInfo = { .stub(clientPin: true, userVerification: true, pinUvAuthToken: true) }
+        mock.onGetPinRetries = { .init(retries: 8, powerCycleState: false) }
+
+        // First call (initial probe) succeeds; second call (post-uvInvalid)
+        // fails with a transport error. Must not be silently coerced to
+        // uvBlocked — that would hide the real connection failure.
+        let uvRetriesCalls = Box(0)
+        mock.onGetUVRetries = { () throws(CTAP2.SessionError) -> Int in
+            uvRetriesCalls.value += 1
+            if uvRetriesCalls.value == 1 { return 5 }
+            throw CTAP2.SessionError.connectionError(.connectionLost, source: .here())
+        }
+        mock.onGetPinUVToken = {
+            (method: CTAP2.ClientPin.Method, _, _) throws(CTAP2.SessionError) -> CTAP2.Token in
+            guard case .uv = method else {
+                Issue.record("PIN path reached on uvInvalid")
+                throw CTAP2.SessionError.ctapError(.operationDenied, source: .here())
+            }
+            throw CTAP2.SessionError.ctapError(.uvInvalid, source: .here())
+        }
+        mock.onGetAssertion = { _ in .mocked(.finished(.stub(credentialId: Data([0xAA])))) }
+
+        let client = try WebAuthn.Client.make(backend: mock)
+
+        var caught: WebAuthn.ClientError?
+        do throws(WebAuthn.ClientError) {
+            _ = try await client.getAssertion(
+                Self.options,
+                authorization: .init(providePIN: { .pin("ignored") }, uv: .preferred)
+            ).value()
+        } catch {
+            caught = error
+        }
+
+        guard case .authenticatorNotAvailable = caught else {
+            Issue.record("Expected authenticatorNotAvailable, got \(String(describing: caught))")
+            return
+        }
+    }
+
+    @Test("uvInvalid with no UV retries left throws uvBlocked")
+    func testUVInvalidExhaustedThrowsBlocked() async throws {
+        let mock = MockWebAuthnBackend()
+        mock.onGetInfo = { .stub(clientPin: true, userVerification: true, pinUvAuthToken: true) }
+        mock.onGetPinRetries = { .init(retries: 8, powerCycleState: false) }
+
+        // Initial probe sees retries left, but the post-uvInvalid re-fetch
+        // returns 0 — same effect as uvBlocked.
+        let uvRetriesCalls = Box(0)
+        mock.onGetUVRetries = {
+            uvRetriesCalls.value += 1
+            return uvRetriesCalls.value == 1 ? 1 : 0
+        }
+        mock.onGetPinUVToken = {
+            (method: CTAP2.ClientPin.Method, _, _) throws(CTAP2.SessionError) -> CTAP2.Token in
+            guard case .uv = method else {
+                Issue.record("PIN path reached on exhausted uvInvalid")
+                throw CTAP2.SessionError.ctapError(.operationDenied, source: .here())
+            }
+            throw CTAP2.SessionError.ctapError(.uvInvalid, source: .here())
+        }
+        mock.onGetAssertion = { _ in .mocked(.finished(.stub(credentialId: Data([0xAA])))) }
+
+        let client = try WebAuthn.Client.make(backend: mock)
+
+        var caught: WebAuthn.ClientError?
+        do throws(WebAuthn.ClientError) {
+            _ = try await client.getAssertion(
+                Self.options,
+                authorization: .init(providePIN: { .pin("nope") }, uv: .preferred)
+            ).value()
+        } catch {
+            caught = error
+        }
+
+        guard case .uvBlocked = caught else {
+            Issue.record("Expected uvBlocked, got \(String(describing: caught))")
+            return
+        }
+    }
+
+    // MARK: - One-shot UV with PIN Fallback
+
+    @Test("uvBlocked falls back to PIN in same ceremony when clientPin configured")
+    func testUVBlockedFallsBackToPIN() async throws {
+        let mock = MockWebAuthnBackend()
+        mock.onGetInfo = { .stub(clientPin: true, userVerification: true, pinUvAuthToken: true) }
+        mock.onGetPinRetries = { .init(retries: 8, powerCycleState: false) }
+        mock.onGetUVRetries = { 3 }
+
+        var uvAttempts = 0
+        var pinAttempts = 0
+        mock.onGetPinUVToken = {
+            (method: CTAP2.ClientPin.Method, _, _) throws(CTAP2.SessionError) -> CTAP2.Token in
+            switch method {
+            case .uv:
+                uvAttempts += 1
+                throw CTAP2.SessionError.ctapError(.uvBlocked, source: .here())
+            case .pin(let pin):
+                pinAttempts += 1
+                #expect(pin == "1234")
+                return CTAP2.Token(token: Data(repeating: 0, count: 32), protocolVersion: .v2)
+            }
+        }
+        mock.onGetAssertion = { _ in .mocked(.finished(.stub(credentialId: Data([0xAA])))) }
+
+        let client = try WebAuthn.Client.make(backend: mock)
+
+        let auth = WebAuthn.Authorization(providePIN: { .pin("1234") }, uv: .preferred)
+        let stream = await client.getAssertion(Self.options, authorization: auth)
+        var finished = false
+        for try await status in stream {
+            if case .finished = status { finished = true }
+        }
+
+        #expect(uvAttempts == 1)
+        #expect(pinAttempts == 1)
+        #expect(finished)
+    }
+
+    // MARK: - UV Without PIN Fallback
+
+    @Test("uvInvalid on BIO-only (no clientPin) throws uvRejected with retries remaining")
+    func testUVInvalidOnBioOnlyThrowsRejected() async throws {
+        let mock = MockWebAuthnBackend()
+        mock.onGetInfo = { .stub(clientPin: false, userVerification: true, pinUvAuthToken: true) }
+        mock.onGetUVRetries = { 1 }
+        mock.onGetPinUVToken = {
+            (method: CTAP2.ClientPin.Method, _, _) throws(CTAP2.SessionError) -> CTAP2.Token in
+            guard case .uv = method else {
+                Issue.record("PIN path reached without clientPin configured")
+                throw CTAP2.SessionError.ctapError(.operationDenied, source: .here())
+            }
+            throw CTAP2.SessionError.ctapError(.uvInvalid, source: .here())
+        }
+        mock.onGetAssertion = { _ in .mocked(.finished(.stub(credentialId: Data([0xAA])))) }
+
+        let client = try WebAuthn.Client.make(backend: mock)
+
+        var caught: WebAuthn.ClientError?
+        do throws(WebAuthn.ClientError) {
+            _ = try await client.getAssertion(Self.options, authorization: .uvOnly).value()
+        } catch {
+            caught = error
+        }
+
+        guard case .uvRejected(let remaining, _) = caught else {
+            Issue.record("Expected uvRejected, got \(String(describing: caught))")
+            return
+        }
+        #expect(remaining == 1)
+    }
+
+    @Test("uvBlocked on BIO-only (no clientPin) throws uvBlocked")
+    func testUVBlockedOnBioOnlyThrows() async throws {
+        let mock = MockWebAuthnBackend()
+        mock.onGetInfo = { .stub(clientPin: false, userVerification: true, pinUvAuthToken: true) }
+        mock.onGetUVRetries = { 3 }
+        mock.onGetPinUVToken = {
+            (method: CTAP2.ClientPin.Method, _, _) throws(CTAP2.SessionError) -> CTAP2.Token in
+            guard case .uv = method else {
+                Issue.record("PIN path reached without clientPin configured")
+                throw CTAP2.SessionError.ctapError(.operationDenied, source: .here())
+            }
+            throw CTAP2.SessionError.ctapError(.uvBlocked, source: .here())
+        }
+        mock.onGetAssertion = { _ in .mocked(.finished(.stub(credentialId: Data([0xAA])))) }
+
+        let client = try WebAuthn.Client.make(backend: mock)
+
+        var caught: WebAuthn.ClientError?
+        do throws(WebAuthn.ClientError) {
+            _ = try await client.getAssertion(Self.options, authorization: .uvOnly).value()
+        } catch {
+            caught = error
+        }
+
+        guard case .uvBlocked = caught else {
+            Issue.record("Expected uvBlocked, got \(String(describing: caught))")
+            return
+        }
+    }
+
+    // MARK: - uv: .required
+
+    @Test("uv: .required throws uvRejected on UV failure; PIN never touched")
+    func testUVRequiredDoesNotFallBackToPIN() async throws {
+        let mock = MockWebAuthnBackend()
+        // PIN-and-UV authenticator. With uv: .required we should NOT
+        // fall through to PIN even though clientPin is set.
+        mock.onGetInfo = { .stub(clientPin: true, userVerification: true, pinUvAuthToken: true) }
+        mock.onGetPinRetries = { .init(retries: 8, powerCycleState: false) }
+        mock.onGetUVRetries = { 5 }
+
+        var uvAttempts = 0
+        let pinPromptCalls = Box(0)
+        mock.onGetPinUVToken = {
+            (method: CTAP2.ClientPin.Method, _, _) throws(CTAP2.SessionError) -> CTAP2.Token in
+            switch method {
+            case .uv:
+                uvAttempts += 1
+                throw CTAP2.SessionError.ctapError(.uvInvalid, source: .here())
+            case .pin:
+                Issue.record("PIN path reached despite uv: .required")
+                throw CTAP2.SessionError.ctapError(.operationDenied, source: .here())
+            }
+        }
+        mock.onGetAssertion = { _ in .mocked(.finished(.stub(credentialId: Data([0xAA])))) }
+
+        let client = try WebAuthn.Client.make(backend: mock)
+
+        let auth = WebAuthn.Authorization(
+            providePIN: {
+                pinPromptCalls.value += 1
+                return .pin("never-asked")
+            },
+            uv: .required
+        )
+
+        var caught: WebAuthn.ClientError?
+        do throws(WebAuthn.ClientError) {
+            _ = try await client.getAssertion(Self.options, authorization: auth).value()
+        } catch {
+            caught = error
+        }
+
+        #expect(uvAttempts == 1)
+        #expect(pinPromptCalls.value == 0, "PIN closure must not be invoked under uv: .required")
+        guard case .uvRejected(let remaining, _) = caught else {
+            Issue.record("Expected uvRejected, got \(String(describing: caught))")
+            return
+        }
+        #expect(remaining == 5)
+    }
+}

--- a/YubiKit/YubiKit/FIDO/Session/CTAPSession+ClientPIN.swift
+++ b/YubiKit/YubiKit/FIDO/Session/CTAPSession+ClientPIN.swift
@@ -51,14 +51,30 @@ extension CTAP2.Session {
     ///   - rpId: Optional relying party ID (required for mc/ga permissions).
     ///   - pinProtocol: The PIN/UV auth protocol version to use. If nil, auto-selects.
     /// - Returns: A PIN/UV auth token that can be used to authenticate CTAP operations.
+    // NEXTMAJOR: Promote `getPinUVTokenUpdates` to public under this name; the
+    // scalar form drops keep-alive frames. Callers without UI use `.value`.
     public func getPinUVToken(
         using method: CTAP2.ClientPin.Method,
         permissions: CTAP2.ClientPin.Permission,
         rpId: String? = nil,
         protocol pinProtocol: CTAP2.ClientPin.ProtocolVersion? = nil
     ) async throws(CTAP2.SessionError) -> CTAP2.Token {
+        try await getPinUVTokenUpdates(
+            using: method,
+            permissions: permissions,
+            rpId: rpId,
+            protocol: pinProtocol
+        ).value
+    }
+
+    func getPinUVTokenUpdates(
+        using method: CTAP2.ClientPin.Method,
+        permissions: CTAP2.ClientPin.Permission,
+        rpId: String? = nil,
+        protocol pinProtocol: CTAP2.ClientPin.ProtocolVersion? = nil
+    ) async throws(CTAP2.SessionError) -> CTAP2.StatusStream<CTAP2.Token> {
         let handler = try await clientPinHandler(protocol: pinProtocol)
-        return try await handler.getToken(using: method, permissions: permissions, rpId: rpId)
+        return try await handler.getTokenUpdates(using: method, permissions: permissions, rpId: rpId)
     }
 
     /// Set a new PIN on the authenticator (must not already have a PIN).
@@ -143,11 +159,11 @@ private struct ClientPinHandler: Sendable {
         return try await stream.value.keyAgreement
     }
 
-    func getToken(
+    func getTokenUpdates(
         using method: CTAP2.ClientPin.Method,
         permissions: CTAP2.ClientPin.Permission,
         rpId: String? = nil
-    ) async throws(CTAP2.SessionError) -> CTAP2.Token {
+    ) async throws(CTAP2.SessionError) -> CTAP2.StatusStream<CTAP2.Token> {
         let authenticatorKey = try await getKeyAgreement()
 
         // Generate ephemeral key pair and derive shared secret
@@ -155,7 +171,7 @@ private struct ClientPinHandler: Sendable {
         let sharedSecret = secretResult.sharedSecret
         let platformKey = secretResult.platformKey
 
-        let response: CTAP2.ClientPin.GetToken.Response
+        let inner: CTAP2.StatusStream<CTAP2.ClientPin.GetToken.Response>
         switch method {
         case .pin(let pin):
             // Hash and encrypt PIN
@@ -172,11 +188,7 @@ private struct ClientPinHandler: Sendable {
                     permissions: permissions,
                     rpId: rpId
                 )
-                let stream: CTAP2.StatusStream<CTAP2.ClientPin.GetToken.Response> = await interface.send(
-                    command: .clientPin,
-                    payload: params
-                )
-                response = try await stream.value
+                inner = await interface.send(command: .clientPin, payload: params)
             } else {
                 // Fall back to 0x05 (legacy getPinToken)
                 let params = CTAP2.ClientPin.GetToken.Parameters(
@@ -184,11 +196,7 @@ private struct ClientPinHandler: Sendable {
                     keyAgreement: platformKey,
                     pinHashEnc: pinHashEnc
                 )
-                let stream: CTAP2.StatusStream<CTAP2.ClientPin.GetToken.Response> = await interface.send(
-                    command: .clientPin,
-                    payload: params
-                )
-                response = try await stream.value
+                inner = await interface.send(command: .clientPin, payload: params)
             }
 
         case .uv:
@@ -204,26 +212,47 @@ private struct ClientPinHandler: Sendable {
                 permissions: permissions,
                 rpId: rpId
             )
-            let stream: CTAP2.StatusStream<CTAP2.ClientPin.GetToken.Response> = await interface.send(
-                command: .clientPin,
-                payload: params
-            )
-            response = try await stream.value
+            inner = await interface.send(command: .clientPin, payload: params)
         }
 
-        let tokenData = try pinProtocol.decrypt(key: sharedSecret, ciphertext: response.pinUVAuthToken)
-
-        // Validate token size: V1 allows 16 or 32 bytes, V2 requires exactly 32 bytes
-        let validSize =
-            pinProtocol == .v1 ? (tokenData.count == 16 || tokenData.count == 32) : tokenData.count == 32
-        guard validSize else {
-            throw CTAP2.SessionError.responseParseError(
-                "Invalid token size: expected \(pinProtocol == .v1 ? "16 or 32" : "32") bytes, got \(tokenData.count)",
-                source: .here()
-            )
+        let pinProtocol = self.pinProtocol
+        return CTAP2.StatusStream { continuation in
+            Task {
+                do throws(CTAP2.SessionError) {
+                    for try await status in inner {
+                        switch status {
+                        case .processing:
+                            continuation.yield(.processing)
+                        case .waitingForUser(let cancel):
+                            continuation.yield(.waitingForUser(cancel: cancel))
+                        case .finished(let response):
+                            let tokenData = try pinProtocol.decrypt(
+                                key: sharedSecret,
+                                ciphertext: response.pinUVAuthToken
+                            )
+                            // Validate token size: V1 allows 16 or 32 bytes, V2 requires exactly 32.
+                            let validSize =
+                                pinProtocol == .v1
+                                ? (tokenData.count == 16 || tokenData.count == 32)
+                                : tokenData.count == 32
+                            guard validSize else {
+                                throw CTAP2.SessionError.responseParseError(
+                                    "Invalid token size: expected "
+                                        + "\(pinProtocol == .v1 ? "16 or 32" : "32") bytes, "
+                                        + "got \(tokenData.count)",
+                                    source: .here()
+                                )
+                            }
+                            continuation.yield(
+                                .finished(CTAP2.Token(token: tokenData, protocolVersion: pinProtocol))
+                            )
+                        }
+                    }
+                } catch {
+                    continuation.yield(error: error)
+                }
+            }
         }
-
-        return CTAP2.Token(token: tokenData, protocolVersion: pinProtocol)
     }
 
     func set(_ pin: String) async throws(CTAP2.SessionError) {

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Client/Authentication/AuthenticationResponse.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Client/Authentication/AuthenticationResponse.swift
@@ -14,29 +14,6 @@
 
 import Foundation
 
-// MARK: - Matched Credential
-
-extension WebAuthn.Authentication {
-
-    /// A credential that matched the authentication request.
-    ///
-    /// Call `select()` to complete the assertion with this credential.
-    /// Extension processing (PRF decryption, largeBlob read/write) is deferred
-    /// until selection.
-    public struct MatchedCredential: Sendable {
-        /// The credential ID.
-        public let id: Data
-        /// User information (for discoverable credentials).
-        public let user: WebAuthn.User?
-
-        /// Complete the assertion with this credential.
-        ///
-        /// Processes extensions (PRF decryption, largeBlob read/write) for this
-        /// credential only.
-        public let select: @Sendable () async throws(WebAuthn.ClientError) -> Response
-    }
-}
-
 // MARK: - Authentication Response
 
 extension WebAuthn.Authentication {

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Client/Authentication/Client+GetAssertion.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Client/Authentication/Client+GetAssertion.swift
@@ -20,17 +20,27 @@ extension WebAuthn.Client {
 
     // MARK: - Public API
 
-    /// Get all matching credentials for selection UI.
+    /// Get matching assertion responses.
     ///
-    /// Returns matched credentials that can be inspected for selection UI.
-    /// Call `select()` on the chosen credential to complete extension processing.
-    /// On success, the returned array is guaranteed to be non-empty. If no matching
-    /// credentials exist, throws ``WebAuthn/ClientError/noCredentials(source:)``.
+    /// Returns fully-resolved ``Response`` values — extension outputs are
+    /// processed eagerly, so selection is purely local. Discoverable-credential
+    /// requests return one ``Response`` per match; allow-list requests narrow
+    /// to one. Throws ``WebAuthn/ClientError/noCredentials(source:)`` if no
+    /// matches exist.
     ///
-    /// Uses the client's origin and validates the RP ID.
+    /// Uses the client's origin and validates the RP ID. PIN/UV is supplied
+    /// via the ``WebAuthn/Authorization`` parameter.
+    ///
+    /// - Parameters:
+    ///   - options: WebAuthn authentication options.
+    ///   - authorization: PIN/UV policy for this ceremony. Use
+    ///     ``WebAuthn/Authorization/pin(_:)`` for the trivial pre-supplied
+    ///     case, ``WebAuthn/Authorization/uvOnly`` for biometric-only, or
+    ///     build a custom instance to bridge into a UI.
     public func getAssertion(
-        _ options: WebAuthn.Authentication.Options
-    ) async -> WebAuthn.StatusStream<[WebAuthn.Authentication.MatchedCredential]> {
+        _ options: WebAuthn.Authentication.Options,
+        authorization: WebAuthn.Authorization
+    ) async -> WebAuthn.StatusStream<[WebAuthn.Authentication.Response]> {
         let rpId = options.rpId ?? origin.host
         let clientData = WebAuthn.ClientData.webauthn(
             type: "webauthn.get",
@@ -38,17 +48,24 @@ extension WebAuthn.Client {
             origin: origin,
             rpId: rpId
         )
-        return await getAssertion(options, clientData: clientData)
+        return await getAssertion(
+            options,
+            clientData: clientData,
+            authorization: authorization
+        )
     }
 
     /// Get all matching credentials using custom client data.
     ///
     /// On success, the returned array is guaranteed to be non-empty. If no matching
     /// credentials exist, throws ``WebAuthn/ClientError/noCredentials(source:)``.
+    ///
+    /// See ``getAssertion(_:authorization:)`` for `authorization` semantics.
     public func getAssertion(
         _ options: WebAuthn.Authentication.Options,
-        clientData: WebAuthn.ClientData
-    ) async -> WebAuthn.StatusStream<[WebAuthn.Authentication.MatchedCredential]> {
+        clientData: WebAuthn.ClientData,
+        authorization: WebAuthn.Authorization
+    ) async -> WebAuthn.StatusStream<[WebAuthn.Authentication.Response]> {
         if let error = validateRpId(clientData.rpId, origin: clientData.origin) {
             return .error(error)
         }
@@ -58,6 +75,7 @@ extension WebAuthn.Client {
                     let matches = try await self.performGetAssertions(
                         options: options,
                         clientData: clientData,
+                        authorization: authorization,
                         continuation: continuation
                     )
                     continuation.yield(.finished(matches))
@@ -73,24 +91,24 @@ extension WebAuthn.Client {
 
 extension WebAuthn.Client {
 
-    // Executes the CTAP2 getAssertion flow with PIN/UV handling and retry logic.
-    // For allow-list requests, silently probes to find a matching credential.
-    // Throws noCredentials if none exist (after user presence to prevent timing leaks).
-    // For discoverable requests, collects all matching assertions from the authenticator.
     fileprivate func performGetAssertions(
         options: WebAuthn.Authentication.Options,
         clientData: WebAuthn.ClientData,
-        continuation: WebAuthn.StatusStream<[WebAuthn.Authentication.MatchedCredential]>.Continuation
-    ) async throws(WebAuthn.ClientError) -> [WebAuthn.Authentication.MatchedCredential] {
+        authorization: WebAuthn.Authorization,
+        continuation: WebAuthn.StatusStream<[WebAuthn.Authentication.Response]>.Continuation
+    ) async throws(WebAuthn.ClientError) -> [WebAuthn.Authentication.Response] {
 
         let rpId = clientData.rpId
         let clientDataHash = clientData.clientDataHash
 
-        let requestPIN: @Sendable () async -> String? = {
-            await self.awaitPINEntry(from: continuation)
-        }
-        let requestUVApproval: @Sendable () async -> Bool = {
-            await self.awaitUVDecision(from: continuation)
+        // WebAuthn L3 §10.1.5: largeBlob.write requires exactly one entry in
+        // allowCredentials. Without this guard, multi-match assertions fan the
+        // write out across every matched credential.
+        if case .write = options.extensions?.largeBlob, options.allowCredentials.count != 1 {
+            throw .notSupported(
+                "largeBlob.write requires allowCredentials to contain exactly one entry",
+                source: .here()
+            )
         }
 
         var permissions: CTAP2.ClientPin.Permission = .getAssertion
@@ -117,8 +135,13 @@ extension WebAuthn.Client {
                 userVerification: retry.userVerification,
                 isMakeCredential: false,
                 allowUV: retry.allowUV,
-                requestPIN: requestPIN,
-                requestUVApproval: requestUVApproval
+                authorization: authorization,
+                yieldProcessing: { continuation.yield(.processing) },
+                yieldUVWaiting: { cancel, fallback in
+                    continuation.yield(
+                        .waitingForUserVerification(cancel: cancel, fallbackToPIN: fallback)
+                    )
+                }
             )
 
             // For allow-list requests, silently probe to find a matching credential.
@@ -139,7 +162,6 @@ extension WebAuthn.Client {
                     token: auth.token
                 )
                 if selectedCred == nil {
-                    // Send dummy credential to force UP before revealing no match
                     selectedCred = WebAuthn.CredentialDescriptor(
                         type: options.allowCredentials.first?.type ?? "public-key",
                         id: Data([0x00])
@@ -181,21 +203,52 @@ extension WebAuthn.Client {
                 if case .ctapError(.noCredentials, _) = error {
                     throw .noCredentials(source: .here())
                 }
-                guard retry.shouldRetry(for: error) else { throw WebAuthn.ClientError(error) }
+                guard retry.shouldRetry(for: error) else {
+                    if case .ctapError(.uvInvalid, _) = error {
+                        throw try await translateUVInvalid()
+                    }
+                    throw WebAuthn.ClientError(error)
+                }
                 continue
             }
 
-            var matches: [WebAuthn.Authentication.MatchedCredential] = []
+            var matches: [WebAuthn.Authentication.Response] = []
+            matches.reserveCapacity(collected.count)
             for ctapResponse in collected {
+                guard let credentialId = ctapResponse.credential?.id ?? selectedCred?.id else {
+                    throw WebAuthn.ClientError(
+                        CTAP2.SessionError.responseParseError(
+                            "Missing credential ID in assertion response",
+                            source: .here()
+                        )
+                    )
+                }
+                // Resolve extension outputs on the live connection so the
+                // returned `Response` is self-contained — selection by the
+                // caller is purely local.
+                let largeBlobOutput = try await backend.processLargeBlob(
+                    from: ctapResponse,
+                    action: largeBlobAction,
+                    token: auth.token
+                )
+                let extensionOutputs = try await backend.parseAuthenticationOutputs(
+                    from: ctapResponse,
+                    prf: prf,
+                    previewSign: previewSign,
+                    largeBlobOutput: largeBlobOutput,
+                    allowedExtensions: allowedExtensions
+                )
+                let authData = ctapResponse.authenticatorData
                 matches.append(
-                    try buildMatchedCredential(
-                        from: ctapResponse,
-                        fallbackCredentialId: selectedCred?.id,
-                        prf: prf,
-                        previewSign: previewSign,
-                        largeBlobAction: largeBlobAction,
-                        clientData: clientData,
-                        token: auth.token
+                    WebAuthn.Authentication.Response(
+                        credentialId: credentialId,
+                        rawAuthenticatorData: authData.rawData,
+                        signature: ctapResponse.signature,
+                        user: ctapResponse.user,
+                        clientExtensionResults: extensionOutputs,
+                        signCount: authData.signCount,
+                        authenticatorData: authData,
+                        clientDataJSON: clientData.clientDataJSON
                     )
                 )
             }
@@ -212,7 +265,7 @@ extension WebAuthn.Client {
     fileprivate func sendAssertion(
         parameters: CTAP2.GetAssertion.Parameters,
         token: CTAP2.Token?,
-        continuation: WebAuthn.StatusStream<[WebAuthn.Authentication.MatchedCredential]>.Continuation
+        continuation: WebAuthn.StatusStream<[WebAuthn.Authentication.Response]>.Continuation
     ) async throws(CTAP2.SessionError) -> CTAP2.GetAssertion.Response {
         let stream = await backend.getAssertion(parameters: parameters, token: token)
         var response: CTAP2.GetAssertion.Response?
@@ -233,60 +286,5 @@ extension WebAuthn.Client {
             )
         }
         return response
-    }
-
-    // Builds a MatchedCredential from a CTAP response with deferred extension processing.
-    fileprivate func buildMatchedCredential(
-        from ctapResponse: CTAP2.GetAssertion.Response,
-        fallbackCredentialId: Data?,
-        prf: WebAuthn.Extension.PRF?,
-        previewSign: CTAP2.Extension.PreviewSign?,
-        largeBlobAction: WebAuthn.Extension.LargeBlob.Authentication.Input?,
-        clientData: WebAuthn.ClientData,
-        token: CTAP2.Token?
-    ) throws(WebAuthn.ClientError) -> WebAuthn.Authentication.MatchedCredential {
-        guard let credentialId = ctapResponse.credential?.id ?? fallbackCredentialId else {
-            throw WebAuthn.ClientError(
-                CTAP2.SessionError.responseParseError(
-                    "Missing credential ID in assertion response",
-                    source: .here()
-                )
-            )
-        }
-
-        let backend = self.backend
-        let allowedExtensions = self.allowedExtensions
-
-        return WebAuthn.Authentication.MatchedCredential(
-            id: credentialId,
-            user: ctapResponse.user,
-            select: {
-                [ctapResponse, prf, previewSign, largeBlobAction, clientData, allowedExtensions]
-                () async throws(WebAuthn.ClientError) in
-                let largeBlobOutput = try await backend.processLargeBlob(
-                    from: ctapResponse,
-                    action: largeBlobAction,
-                    token: token
-                )
-                let extensionOutputs = try await backend.parseAuthenticationOutputs(
-                    from: ctapResponse,
-                    prf: prf,
-                    previewSign: previewSign,
-                    largeBlobOutput: largeBlobOutput,
-                    allowedExtensions: allowedExtensions
-                )
-                let authenticatorData = ctapResponse.authenticatorData
-                return WebAuthn.Authentication.Response(
-                    credentialId: credentialId,
-                    rawAuthenticatorData: authenticatorData.rawData,
-                    signature: ctapResponse.signature,
-                    user: ctapResponse.user,
-                    clientExtensionResults: extensionOutputs,
-                    signCount: authenticatorData.signCount,
-                    authenticatorData: authenticatorData,
-                    clientDataJSON: clientData.clientDataJSON
-                )
-            }
-        )
     }
 }

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Client/Authorization.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Client/Authorization.swift
@@ -1,0 +1,123 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+// MARK: - Authorization
+
+extension WebAuthn {
+
+    /// PIN/UV policy for a single WebAuthn ceremony.
+    ///
+    /// `Authorization` carries the PIN-providing closure and the UV
+    /// policy for one ceremony. It is supplied per call to
+    /// ``Client/makeCredential(_:authorization:)`` and
+    /// ``Client/getAssertion(_:authorization:)``.
+    ///
+    /// Use a built-in factory for trivial cases:
+    ///
+    /// ```swift
+    /// let r = try await client.makeCredential(opts, authorization: .pin("1234")).value()
+    /// ```
+    ///
+    /// Or build a custom instance to bridge into a UI:
+    ///
+    /// ```swift
+    /// let auth = WebAuthn.Authorization(providePIN: {
+    ///     guard let pin = await viewModel.askForPIN() else { return .cancel }
+    ///     return .pin(pin)
+    /// })
+    /// let r = try await client.makeCredential(opts, authorization: auth).value()
+    /// ```
+    ///
+    /// PIN attempts are one-shot: a wrong PIN throws
+    /// ``ClientError/pinRejected(retriesRemaining:source:)`` and the caller
+    /// decides whether to re-prompt and retry the ceremony with a fresh
+    /// `Authorization`.
+    public struct Authorization: Sendable {
+
+        /// Caller answer to a PIN prompt from the SDK.
+        public enum PINReply: Sendable {
+            /// Submit this PIN to the authenticator.
+            case pin(String)
+            /// Abort the ceremony — the SDK throws ``ClientError/cancelled(source:)``.
+            case cancel
+        }
+
+        /// How the SDK should handle built-in user verification (biometric
+        /// or on-device PIN) for this ceremony.
+        public enum UVPolicy: Sendable {
+            /// Attempt built-in UV first. If UV is locked out
+            /// (``ClientError/uvBlocked(source:)``) and `clientPin` is
+            /// configured, fall through to the PIN closure within the
+            /// same ceremony. A wrong-attempt failure surfaces as
+            /// ``ClientError/uvRejected(retriesRemaining:source:)`` so the
+            /// caller decides whether to re-prompt UV or switch to PIN.
+            /// The default for most ceremonies.
+            case preferred
+            /// Skip built-in UV entirely and go straight to the PIN closure.
+            case skipped
+            /// Attempt built-in UV; never fall through to PIN. A wrong
+            /// attempt throws ``ClientError/uvRejected(retriesRemaining:source:)``;
+            /// lockout throws ``ClientError/uvBlocked(source:)``. The PIN
+            /// closure is never invoked.
+            case required
+        }
+
+        /// Called when the SDK needs a PIN. Return ``PINReply/pin(_:)`` to
+        /// submit a PIN or ``PINReply/cancel`` to abort the ceremony.
+        public let providePIN: @Sendable () async -> PINReply
+
+        /// How to handle built-in UV for this ceremony. See ``UVPolicy``.
+        public let uv: UVPolicy
+
+        /// Build an authorization from a custom PIN-providing closure.
+        ///
+        /// - Parameters:
+        ///   - providePIN: Called when the SDK needs a PIN. Return
+        ///     ``PINReply/pin(_:)`` or ``PINReply/cancel``.
+        ///   - uv: UV policy for this ceremony. Defaults to ``UVPolicy/preferred``.
+        public init(
+            providePIN: @Sendable @escaping () async -> PINReply,
+            uv: UVPolicy = .preferred
+        ) {
+            self.providePIN = providePIN
+            self.uv = uv
+        }
+
+        /// Pre-supplied PIN authorization.
+        ///
+        /// The supplied PIN is used directly — built-in UV is skipped.
+        /// If the authenticator rejects the PIN the ceremony throws
+        /// ``ClientError/pinRejected(retriesRemaining:source:)``.
+        ///
+        /// To pre-supply a PIN but still attempt built-in UV first, use
+        /// the explicit initializer:
+        ///
+        /// ```swift
+        /// Authorization(providePIN: { .pin("1234") }, uv: .preferred)
+        /// ```
+        public static func pin(_ pin: String) -> Authorization {
+            Authorization(providePIN: { .pin(pin) }, uv: .skipped)
+        }
+
+        /// Built-in UV only. The PIN closure is never invoked; a wrong UV
+        /// attempt throws ``ClientError/uvRejected(retriesRemaining:source:)``
+        /// and lockout throws ``ClientError/uvBlocked(source:)``.
+        public static let uvOnly = Authorization(
+            providePIN: { .cancel },
+            uv: .required
+        )
+    }
+}

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Client/Backends/CTAP2Backend.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Client/Backends/CTAP2Backend.swift
@@ -36,11 +36,11 @@ extension WebAuthn {
 
         func getPinRetries() async throws(CTAP2.SessionError) -> CTAP2.ClientPin.GetRetries.Response
 
-        func getPinUVToken(
+        func getPinUVTokenUpdates(
             using method: CTAP2.ClientPin.Method,
             permissions: CTAP2.ClientPin.Permission,
             rpId: String?
-        ) async throws(CTAP2.SessionError) -> CTAP2.Token
+        ) async throws(CTAP2.SessionError) -> CTAP2.StatusStream<CTAP2.Token>
 
         // MARK: - Credentials
 
@@ -96,6 +96,19 @@ extension WebAuthn {
     }
 }
 
+// MARK: - Default Implementations
+
+extension WebAuthn.Backend {
+
+    func getPinUVToken(
+        using method: CTAP2.ClientPin.Method,
+        permissions: CTAP2.ClientPin.Permission,
+        rpId: String?
+    ) async throws(CTAP2.SessionError) -> CTAP2.Token {
+        try await getPinUVTokenUpdates(using: method, permissions: permissions, rpId: rpId).value
+    }
+}
+
 // MARK: - CTAP2.Session Conformance
 
 extension CTAP2.Session: WebAuthn.Backend {
@@ -108,12 +121,12 @@ extension CTAP2.Session: WebAuthn.Backend {
         try await getUVRetries(protocol: nil)
     }
 
-    func getPinUVToken(
+    func getPinUVTokenUpdates(
         using method: CTAP2.ClientPin.Method,
         permissions: CTAP2.ClientPin.Permission,
         rpId: String?
-    ) async throws(CTAP2.SessionError) -> CTAP2.Token {
-        try await getPinUVToken(using: method, permissions: permissions, rpId: rpId, protocol: nil)
+    ) async throws(CTAP2.SessionError) -> CTAP2.StatusStream<CTAP2.Token> {
+        try await getPinUVTokenUpdates(using: method, permissions: permissions, rpId: rpId, protocol: nil)
     }
 
     // MARK: - Extensions

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Client/Client.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Client/Client.swift
@@ -23,8 +23,11 @@ extension WebAuthn {
     /// Provides a unified interface for passkey registration and authentication
     /// backed by a YubiKey via CTAP2 protocol (USB/NFC).
     ///
-    /// All user interaction (PIN entry, UV approval) is communicated through the
-    /// status stream. Iterate the stream to handle these requests:
+    /// PIN entry and UV decisions are supplied per ceremony via the
+    /// ``Authorization`` parameter on ``makeCredential(_:authorization:)`` and
+    /// ``getAssertion(_:authorization:)``. The status stream reports ceremony
+    /// progress (`.processing`, `.waitingForUser`,
+    /// `.waitingForUserVerification`, `.finished`) only.
     ///
     /// ```swift
     /// let session = try await CTAP2.Session(connection: connection)
@@ -34,16 +37,30 @@ extension WebAuthn {
     ///     isPublicSuffix: { publicSuffixList.contains($0) }
     /// )
     ///
-    /// for try await status in client.makeCredential(options) {
+    /// // Trivial — pre-supplied PIN:
+    /// let response = try await client.makeCredential(options, authorization: .pin("1234")).value()
+    ///
+    /// // Custom — bridge into a UI:
+    /// let auth = WebAuthn.Authorization(providePIN: {
+    ///     guard let pin = await viewModel.askForPIN() else { return .cancel }
+    ///     return .pin(pin)
+    /// })
+    /// for try await status in await client.makeCredential(options, authorization: auth) {
     ///     switch status {
     ///     case .processing: showSpinner()
-    ///     case .waitingForUser(let cancel): showTouchPrompt()
-    ///     case .requestingUV(let useUV): useUV(true)
-    ///     case .requestingPIN(let submitPIN): submitPIN(await askForPIN())
+    ///     case .waitingForUser(let cancel): showTouchPrompt(onCancel: cancel)
+    ///     case .waitingForUserVerification(let cancel, let fallbackToPIN):
+    ///         showBiometricPrompt(onCancel: cancel, fallbackToPIN: fallbackToPIN)
     ///     case .finished(let response): return response
     ///     }
     /// }
     /// ```
+    ///
+    /// PIN attempts are one-shot: a wrong PIN throws
+    /// ``ClientError/pinRejected(retriesRemaining:source:)`` and the caller
+    /// decides whether to re-prompt and retry with a fresh ``Authorization``.
+    /// Returning ``Authorization/PINReply/cancel`` from `providePIN` aborts
+    /// the ceremony with ``ClientError/cancelled(source:)``.
     ///
     /// - SeeAlso: [Web Authentication](https://www.w3.org/TR/webauthn-3/)
     public actor Client {

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Client/ClientError.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Client/ClientError.swift
@@ -30,18 +30,27 @@ extension WebAuthn {
         case cancelled(source: SourceLocation)
         /// The operation timed out waiting for user interaction.
         case timeout(source: SourceLocation)
-        /// User verification failed (biometric mismatch or internal UV error).
-        case userVerificationFailed(retriesRemaining: Int?, source: SourceLocation)
-        /// The PIN was incorrect.
-        case invalidPIN(retriesRemaining: Int, source: SourceLocation)
+        /// A PIN attempt was rejected but retries are still available on the
+        /// authenticator. Re-invoke the operation with a fresh PIN.
+        case pinRejected(retriesRemaining: Int, source: SourceLocation)
+        /// A built-in UV attempt failed but retries are still available on
+        /// the authenticator. Re-invoke the operation to retry UV (or supply
+        /// a PIN via a fresh ``Authorization``).
+        case uvRejected(retriesRemaining: Int, source: SourceLocation)
+        /// Built-in UV is locked out for this authenticator. Per CTAP spec,
+        /// this is recoverable via a correct PIN entry on a subsequent
+        /// invocation that uses the PIN path.
+        case uvBlocked(source: SourceLocation)
         /// The PIN is blocked due to too many failed attempts. Factory reset required.
         case pinBlocked(source: SourceLocation)
         /// PIN authentication is temporarily blocked. Reinsert the authenticator.
         case pinAuthBlocked(source: SourceLocation)
         /// No PIN is configured on this authenticator.
         case pinNotSet(source: SourceLocation)
-        /// A PIN is required but no PIN provider was configured.
-        case pinRequired(source: SourceLocation)
+        /// The PIN does not meet the authenticator's complexity policy.
+        case pinComplexity(source: SourceLocation)
+        /// The authenticator requires a PIN change before further PIN-using operations.
+        case forcePinChange(source: SourceLocation)
         /// The PIN token expired. Retry the operation.
         case pinTokenExpired(source: SourceLocation)
         /// The requested feature is not supported by this authenticator.
@@ -71,12 +80,16 @@ extension WebAuthn.ClientError {
             case .noCredentials: self = .noCredentials(source: source)
             case .operationDenied, .keepaliveCancel: self = .cancelled(source: source)
             case .actionTimeout, .userActionTimeout: self = .timeout(source: source)
+            case .uvBlocked: self = .uvBlocked(source: source)
             case .pinBlocked: self = .pinBlocked(source: source)
             case .pinAuthBlocked: self = .pinAuthBlocked(source: source)
+            case .pinPolicyViolation: self = .pinComplexity(source: source)
             case .pinNotSet: self = .pinNotSet(source: source)
             case .pinTokenExpired: self = .pinTokenExpired(source: source)
             case .unsupportedAlgorithm: self = .unsupportedAlgorithm(source: source)
             case .keyStoreFull, .largeBlobStorageFull: self = .storageFull(source: source)
+            case .pinInvalid, .uvInvalid, .puatRequired:
+                preconditionFailure("CTAP \(code) must be resolved by Client+UserVerification, not here")
             default: self = .ctapError(ctapError, source: source)
             }
         case .connectionError:

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Client/Registration/Client+MakeCredential.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Client/Registration/Client+MakeCredential.swift
@@ -22,9 +22,21 @@ extension WebAuthn.Client {
 
     /// Create a new passkey credential.
     ///
-    /// Uses the client's origin and validates the RP ID.
+    /// Uses the client's origin and validates the RP ID. PIN/UV is supplied
+    /// via the ``WebAuthn/Authorization`` parameter; the SDK invokes its
+    /// `providePIN` closure when a PIN is needed. PIN attempts are one-shot:
+    /// a wrong PIN throws ``WebAuthn/ClientError/pinRejected(retriesRemaining:source:)``
+    /// and the caller re-invokes with a fresh ``WebAuthn/Authorization``.
+    ///
+    /// - Parameters:
+    ///   - options: WebAuthn registration options.
+    ///   - authorization: PIN/UV policy for this ceremony. Use
+    ///     ``WebAuthn/Authorization/pin(_:)`` for the trivial pre-supplied
+    ///     case, ``WebAuthn/Authorization/uvOnly`` for biometric-only, or
+    ///     build a custom instance to bridge into a UI.
     public func makeCredential(
-        _ options: WebAuthn.Registration.Options
+        _ options: WebAuthn.Registration.Options,
+        authorization: WebAuthn.Authorization
     ) async -> WebAuthn.StatusStream<WebAuthn.Registration.Response> {
         let rpId = options.rp.id
         let clientData = WebAuthn.ClientData.webauthn(
@@ -33,13 +45,20 @@ extension WebAuthn.Client {
             origin: origin,
             rpId: rpId
         )
-        return await makeCredential(options, clientData: clientData)
+        return await makeCredential(
+            options,
+            clientData: clientData,
+            authorization: authorization
+        )
     }
 
     /// Create a new passkey credential with custom client data.
+    ///
+    /// See ``makeCredential(_:authorization:)`` for `authorization` semantics.
     public func makeCredential(
         _ options: WebAuthn.Registration.Options,
-        clientData: WebAuthn.ClientData
+        clientData: WebAuthn.ClientData,
+        authorization: WebAuthn.Authorization
     ) async -> WebAuthn.StatusStream<WebAuthn.Registration.Response> {
         if let error = validateRpId(clientData.rpId, origin: clientData.origin) {
             return .error(error)
@@ -50,6 +69,7 @@ extension WebAuthn.Client {
                     let response = try await performMakeCredential(
                         options: options,
                         clientData: clientData,
+                        authorization: authorization,
                         continuation: continuation
                     )
                     continuation.yield(.finished(response))
@@ -65,14 +85,13 @@ extension WebAuthn.Client {
 
 extension WebAuthn.Client {
 
-    // Executes the CTAP2 makeCredential flow with PIN/UV handling and retry logic.
     fileprivate func performMakeCredential(
         options: WebAuthn.Registration.Options,
         clientData: WebAuthn.ClientData,
+        authorization: WebAuthn.Authorization,
         continuation: WebAuthn.StatusStream<WebAuthn.Registration.Response>.Continuation
     ) async throws(WebAuthn.ClientError) -> WebAuthn.Registration.Response {
 
-        // Fetch cached immutable authenticator capabilities.
         let cachedInfo: CTAP2.GetInfo.ImmutableView
         do throws(CTAP2.SessionError) {
             cachedInfo = try await backend.cachedInfo
@@ -94,7 +113,6 @@ extension WebAuthn.Client {
 
         var retry = RetryContext(userVerification: options.userVerification)
 
-        // Retry loop for recoverable UV/PIN errors.
         while true {
             // Re-fetch mutable state (PIN/UV counters) on each attempt.
             let info: CTAP2.GetInfo.Response
@@ -111,11 +129,15 @@ extension WebAuthn.Client {
                 userVerification: retry.userVerification,
                 isMakeCredential: true,
                 allowUV: retry.allowUV,
-                requestPIN: { await self.awaitPINEntry(from: continuation) },
-                requestUVApproval: { await self.awaitUVDecision(from: continuation) }
+                authorization: authorization,
+                yieldProcessing: { continuation.yield(.processing) },
+                yieldUVWaiting: { cancel, fallback in
+                    continuation.yield(
+                        .waitingForUserVerification(cancel: cancel, fallbackToPIN: fallback)
+                    )
+                }
             )
 
-            // Silently check if user already has a credential (exclude list).
             let excludedCred = try await findMatchingCredential(
                 from: options.excludeCredentials,
                 rpId: rpId,
@@ -167,7 +189,12 @@ extension WebAuthn.Client {
                 }
                 ctapResponse = response
             } catch {
-                guard retry.shouldRetry(for: error) else { throw WebAuthn.ClientError(error) }
+                guard retry.shouldRetry(for: error) else {
+                    if case .ctapError(.uvInvalid, _) = error {
+                        throw try await translateUVInvalid()
+                    }
+                    throw WebAuthn.ClientError(error)
+                }
                 continue
             }
 

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Client/Shared/Client+UserVerification.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Client/Shared/Client+UserVerification.swift
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import Foundation
-import os
 
 // MARK: - User Verification
 
@@ -42,51 +41,20 @@ extension WebAuthn.Client {
         }
     }
 
-    // MARK: - Stream Interaction
-
-    // Yields `.requestingUV` and waits for user to choose between UV and PIN.
-    func awaitUVDecision<R: Sendable>(
-        from continuation: WebAuthn.StatusStream<R>.Continuation
-    ) async -> Bool {
-        await withCheckedContinuation { checkedContinuation in
-            let once = OSAllocatedUnfairLock(initialState: false)
-            continuation.yield(
-                .requestingUV { useUV in
-                    let first = once.withLock {
-                        let old = $0
-                        $0 = true
-                        return !old
-                    }
-                    guard first else { return }
-                    checkedContinuation.resume(returning: useUV)
-                }
-            )
-        }
-    }
-
-    // Yields `.requestingPIN` and waits for user to provide a PIN.
-    func awaitPINEntry<R: Sendable>(
-        from continuation: WebAuthn.StatusStream<R>.Continuation
-    ) async -> String? {
-        await withCheckedContinuation { checkedContinuation in
-            let once = OSAllocatedUnfairLock(initialState: false)
-            continuation.yield(
-                .requestingPIN { pin in
-                    let first = once.withLock {
-                        let old = $0
-                        $0 = true
-                        return !old
-                    }
-                    guard first else { return }
-                    checkedContinuation.resume(returning: pin)
-                }
-            )
-        }
-    }
-
     // MARK: - Token Acquisition
 
-    // Acquires PIN/UV auth token if required.
+    // Acquires a PIN/UV auth token if required.
+    //
+    // PIN and UV are both one-shot. `uvInvalid` surfaces as `.uvRejected`
+    // with the remaining retry count so the caller can re-prompt the user;
+    // when retries are exhausted it surfaces as `.uvBlocked`. `uvBlocked`
+    // falls through to PIN when `clientPin` is configured (or throws
+    // `.uvBlocked` under `uv: .required` / no PIN). PIN failures
+    // (`pinInvalid`) throw `.pinRejected` with the remaining retry count.
+    //
+    // `yieldUVWaiting` exposes the CTAP cancel handle plus an optional
+    // `fallbackToPIN` closure (nil under `uv: .required` or no PIN).
+    //
     // Returns: (nil, nil) = no auth needed, (token, nil) = use token, (nil, true) = internal UV.
     func acquireAuthToken(
         info: CTAP2.GetInfo.Response,
@@ -95,8 +63,13 @@ extension WebAuthn.Client {
         userVerification: WebAuthn.UserVerificationPreference,
         isMakeCredential: Bool,
         allowUV: Bool = true,
-        requestPIN: @Sendable () async -> String?,
-        requestUVApproval: (@Sendable () async -> Bool)? = nil
+        authorization: WebAuthn.Authorization,
+        yieldProcessing: @Sendable () -> Void = {},
+        yieldUVWaiting:
+            @Sendable (
+                _ cancel: @Sendable @escaping () async -> Void,
+                _ fallbackToPIN: (@Sendable () async -> Void)?
+            ) -> Void = { _, _ in }
     ) async throws(WebAuthn.ClientError) -> (token: CTAP2.Token?, uv: Bool?) {
 
         let uvRequired = try isUserVerificationRequired(
@@ -109,50 +82,62 @@ extension WebAuthn.Client {
             return (token: nil, uv: nil)
         }
 
-        let hasPin = info.options.clientPin == true
         let hasUV = info.options.userVerification == true
+        let hasPin = info.options.clientPin == true
         // Internal UV only valid for basic operations (mc/ga), not management.
         let allowInternalUV = permissions.subtracting([.makeCredential, .getAssertion]).isEmpty
-
-        let uvRetries = hasUV && allowUV ? (try? await backend.getUVRetries()) ?? 0 : 0
-
-        // Try UV-based authentication if available.
-        if uvRetries > 0, info.options.pinUVAuthToken == true {
-            let proceedWithUV = await requestUVApproval?() ?? true
-
-            if proceedWithUV {
-                do throws(CTAP2.SessionError) {
-                    let token = try await backend.getPinUVToken(
-                        using: .uv,
-                        permissions: permissions,
-                        rpId: rpId
-                    )
-                    return (token: token, uv: nil)
-                } catch {
-                    switch error {
-                    case .ctapError(.uvBlocked, _),
-                        .ctapError(.operationDenied, _),
-                        .ctapError(.unauthorizedPermission, _):
-                        guard hasPin else {
-                            let retries = try? await backend.getUVRetries()
-                            throw .userVerificationFailed(
-                                retriesRemaining: retries,
-                                source: .here()
-                            )
-                        }
-                    // Fall through to PIN.
-                    default:
-                        throw WebAuthn.ClientError(error)
-                    }
-                }
+        let canTryUV = authorization.uv != .skipped && hasUV && allowUV
+        let initialUVRetries: Int
+        if canTryUV {
+            do throws(CTAP2.SessionError) {
+                initialUVRetries = try await backend.getUVRetries()
+            } catch {
+                throw WebAuthn.ClientError(error)
             }
-        } else if uvRetries > 0, allowInternalUV {
-            // Use internal UV (authenticator handles UV during command).
-            return (token: nil, uv: true)
+        } else {
+            initialUVRetries = 0
         }
 
-        // Fall back to PIN.
-        guard let pin = await requestPIN() else {
+        // External UV path: authenticator supports pinUVAuthToken.
+        if initialUVRetries > 0, info.options.pinUVAuthToken == true {
+            let canFallback = authorization.uv != .required && hasPin
+            let result = try await runExternalUV(
+                permissions: permissions,
+                rpId: rpId,
+                canFallback: canFallback,
+                yieldProcessing: yieldProcessing,
+                yieldUVWaiting: yieldUVWaiting
+            )
+            switch result {
+            case .token(let token):
+                return (token: token, uv: nil)
+            case .fallbackToPIN:
+                break
+            }
+        } else if initialUVRetries > 0, allowInternalUV {
+            // Internal UV (authenticator handles UV during MC/GA itself).
+            return (token: nil, uv: true)
+        } else if authorization.uv == .required {
+            // UV requested as strict-only but unavailable → uvBlocked.
+            throw .uvBlocked(source: .here())
+        }
+
+        // PIN path: requires clientPin to be configured.
+        guard hasPin else {
+            throw .pinNotSet(source: .here())
+        }
+
+        // CTAP 2.2 §6.5.5.7: getPinUVToken rejects even a correct PIN
+        // here, so surface upfront before the user enters one.
+        if info.forcePinChange == true {
+            throw .forcePinChange(source: .here())
+        }
+
+        let pin: String
+        switch await authorization.providePIN() {
+        case .pin(let value):
+            pin = value
+        case .cancel:
             throw .cancelled(source: .here())
         }
 
@@ -164,12 +149,122 @@ extension WebAuthn.Client {
             )
             return (token: token, uv: nil)
         } catch {
-            if case .ctapError(.pinInvalid, _) = error {
-                let retries = (try? await backend.getPinRetries())?.retries ?? 0
-                throw .invalidPIN(retriesRemaining: retries, source: .here())
+            guard case .ctapError(.pinInvalid, _) = error else {
+                throw WebAuthn.ClientError(error)
             }
+            let retries: Int
+            do {
+                retries = try await backend.getPinRetries().retries
+            } catch {
+                throw WebAuthn.ClientError(error)
+            }
+            guard retries > 0 else {
+                throw .pinBlocked(source: .here())
+            }
+            throw .pinRejected(retriesRemaining: retries, source: .here())
+        }
+    }
+}
+
+// MARK: - External UV Path
+
+extension WebAuthn.Client {
+
+    enum UVOutcome {
+        case token(CTAP2.Token)
+        case fallbackToPIN
+    }
+
+    fileprivate func runExternalUV(
+        permissions: CTAP2.ClientPin.Permission,
+        rpId: String,
+        canFallback: Bool,
+        yieldProcessing: @Sendable () -> Void,
+        yieldUVWaiting:
+            @Sendable (
+                _ cancel: @Sendable @escaping () async -> Void,
+                _ fallbackToPIN: (@Sendable () async -> Void)?
+            ) -> Void
+    ) async throws(WebAuthn.ClientError) -> UVOutcome {
+        let signal = FallbackSignal()
+
+        do throws(CTAP2.SessionError) {
+            let stream = try await backend.getPinUVTokenUpdates(
+                using: .uv,
+                permissions: permissions,
+                rpId: rpId
+            )
+            for try await status in stream {
+                switch status {
+                case .processing:
+                    yieldProcessing()
+                case .waitingForUser(let cancel):
+                    let fallback: (@Sendable () async -> Void)? =
+                        canFallback
+                        ? { @Sendable in
+                            await signal.request()
+                            await cancel()
+                        }
+                        : nil
+                    yieldUVWaiting(cancel, fallback)
+                case .finished(let token):
+                    return .token(token)
+                }
+            }
+            // Stream ended without `.finished` — should be unreachable.
+            throw CTAP2.SessionError.responseParseError(
+                "getPinUVTokenUpdates ended without a token",
+                source: .here()
+            )
+        } catch {
+            if case .ctapError(.keepaliveCancel, _) = error, await signal.isRequested {
+                return .fallbackToPIN
+            }
+            switch error {
+            case .ctapError(.uvInvalid, _):
+                // Surface retries left rather than silently falling through —
+                // the caller chooses re-prompt vs PIN.
+                throw try await translateUVInvalid()
+            case .ctapError(.uvBlocked, _):
+                if !canFallback {
+                    throw .uvBlocked(source: .here())
+                }
+                return .fallbackToPIN
+            default:
+                throw WebAuthn.ClientError(error)
+            }
+        }
+    }
+}
+
+private actor FallbackSignal {
+    private(set) var isRequested = false
+    func request() { isRequested = true }
+}
+
+// MARK: - UV Error Translation
+
+extension WebAuthn.Client {
+
+    // Translates a `uvInvalid` CTAP error into the public retry-aware contract.
+    // Used by both the external pinUVAuthToken path (in `acquireAuthToken`) and
+    // the internal-UV path (where `uvInvalid` surfaces from the makeCredential
+    // / getAssertion command itself, after `acquireAuthToken` returned `uv: true`).
+    //
+    // Returns `.uvRejected(retriesRemaining:)` while retries are left, `.uvBlocked`
+    // when exhausted. A failure to read the retry counter bubbles as the underlying
+    // transport error rather than being misreported as UV lockout — mirrors the
+    // PIN path's `getPinRetries` failure handling.
+    func translateUVInvalid() async throws(WebAuthn.ClientError) -> WebAuthn.ClientError {
+        let retries: Int
+        do {
+            retries = try await backend.getUVRetries()
+        } catch {
             throw WebAuthn.ClientError(error)
         }
+        return retries > 0
+            ? .uvRejected(retriesRemaining: retries, source: .here())
+            : .uvBlocked(source: .here())
     }
 }
 
@@ -205,6 +300,12 @@ extension WebAuthn.Client {
             || options.alwaysUV == true
         {
             guard uvConfigured else {
+                // PIN capability present but not configured: surface as
+                // `.pinNotSet` so callers can route into a PIN-setup flow
+                // instead of treating it as an unrecoverable failure.
+                if options.clientPin != nil {
+                    throw .pinNotSet(source: .here())
+                }
                 throw .notSupported("User verification not configured/supported", source: .here())
             }
             return true

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Extensions/WebAuthnCredBlob.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Extensions/WebAuthnCredBlob.swift
@@ -34,7 +34,7 @@ extension WebAuthn.Extension {
     ///     residentKey: .required,
     ///     extensions: .init(credBlob: myBlobData)
     /// )
-    /// let response = try await client.makeCredential(options).value(pin: pin)
+    /// let response = try await client.makeCredential(options, authorization: .pin(pin)).value()
     /// if response.clientExtensionResults.credBlob?.stored == true {
     ///     // Blob was stored successfully
     /// }
@@ -49,8 +49,8 @@ extension WebAuthn.Extension {
     ///     ...,
     ///     extensions: .init(getCredBlob: true)
     /// )
-    /// let matches = try await client.getAssertion(options).value(pin: pin)
-    /// let response = try await matches[0].select()
+    /// let matches = try await client.getAssertion(options, authorization: .pin(pin)).value()
+    /// let response = matches[0]
     /// if let blob = response.clientExtensionResults.credBlob?.blob {
     ///     // Use the retrieved blob data
     /// }

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Extensions/WebAuthnCredProps.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Extensions/WebAuthnCredProps.swift
@@ -35,7 +35,7 @@ extension WebAuthn.Extension {
     ///     residentKey: .preferred,
     ///     extensions: .init(credProps: true)
     /// )
-    /// let response = try await client.makeCredential(options).value(pin: pin)
+    /// let response = try await client.makeCredential(options, authorization: .pin(pin)).value()
     /// if response.clientExtensionResults.credProps?.rk == true {
     ///     // Credential is discoverable - user can sign in without typing username
     /// } else {

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Extensions/WebAuthnCredProtect.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Extensions/WebAuthnCredProtect.swift
@@ -34,7 +34,7 @@ extension WebAuthn.Extension {
     ///         credProtect: .enforced(.userVerificationRequired)
     ///     )
     /// )
-    /// let response = try await client.makeCredential(options).value(pin: pin)
+    /// let response = try await client.makeCredential(options, authorization: .pin(pin)).value()
     /// if let policy = response.clientExtensionResults.credProtect {
     ///     // Verify the applied protection level
     /// }

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Extensions/WebAuthnLargeBlob.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Extensions/WebAuthnLargeBlob.swift
@@ -33,7 +33,7 @@ extension WebAuthn.Extension {
     ///     ...,
     ///     extensions: .init(largeBlob: .required)
     /// )
-    /// let response = try await client.makeCredential(options).value(pin: pin)
+    /// let response = try await client.makeCredential(options, authorization: .pin(pin)).value()
     /// if response.clientExtensionResults.largeBlob?.supported == true {
     ///     // Credential supports large blob storage
     /// }
@@ -48,8 +48,8 @@ extension WebAuthn.Extension {
     ///     ...,
     ///     extensions: .init(largeBlob: .read)
     /// )
-    /// let matches = try await client.getAssertion(options).value(pin: pin)
-    /// let response = try await matches[0].select()
+    /// let matches = try await client.getAssertion(options, authorization: .pin(pin)).value()
+    /// let response = matches[0]
     /// if let blob = response.clientExtensionResults.largeBlob?.blob {
     ///     // Use the retrieved blob data
     /// }
@@ -65,8 +65,8 @@ extension WebAuthn.Extension {
     ///     allowCredentials: [.init(id: credentialId)],
     ///     extensions: .init(largeBlob: .write(myData))
     /// )
-    /// let matches = try await client.getAssertion(options).value(pin: pin)
-    /// let response = try await matches[0].select()
+    /// let matches = try await client.getAssertion(options, authorization: .pin(pin)).value()
+    /// let response = matches[0]
     /// if response.clientExtensionResults.largeBlob?.written == true {
     ///     // Blob stored successfully
     /// }

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Extensions/WebAuthnMinPinLength.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Extensions/WebAuthnMinPinLength.swift
@@ -33,7 +33,7 @@ extension WebAuthn.Extension {
     ///     ...,
     ///     extensions: .init(minPinLength: true)
     /// )
-    /// let response = try await client.makeCredential(options).value(pin: pin)
+    /// let response = try await client.makeCredential(options, authorization: .pin(pin)).value()
     /// if let length = response.clientExtensionResults.minPinLength?.length {
     ///     print("Minimum PIN length: \(length)")
     /// }

--- a/YubiKit/YubiKit/FIDO/WebAuthn/WebAuthn.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/WebAuthn.swift
@@ -29,32 +29,33 @@ public enum WebAuthn {
 
     /// Status updates during WebAuthn operations.
     ///
-    /// These status values are emitted during operations that may require user interaction
-    /// or extended processing time.
+    /// These status values report progress of an in-flight ceremony. PIN
+    /// entry and UV decisions are handled out-of-band via the
+    /// ``Authorization`` parameter on ``Client/makeCredential(_:authorization:)``
+    /// and ``Client/getAssertion(_:authorization:)`` — they do not appear
+    /// on this stream.
     public enum Status<Response: Sendable>: Sendable {
         /// The authenticator is processing the request.
         case processing
+
+        /// The authenticator is performing built-in user verification (e.g.
+        /// fingerprint capture on a YubiKey Bio).
+        ///
+        /// - Parameters:
+        ///   - cancel: Cancel the ceremony — surfaces as ``ClientError/cancelled(source:)``.
+        ///   - fallbackToPIN: Abandon UV and route into the PIN path within the
+        ///     same ceremony, calling ``Authorization/providePIN`` for the PIN.
+        ///     `nil` under ``Authorization/UVPolicy/required`` or when no
+        ///     `clientPin` is configured.
+        case waitingForUserVerification(
+            cancel: @Sendable () async -> Void,
+            fallbackToPIN: (@Sendable () async -> Void)?
+        )
 
         /// The authenticator is waiting for user interaction.
         ///
         /// - Parameter cancel: Closure to cancel the operation.
         case waitingForUser(cancel: @Sendable () async -> Void)
-
-        /// The client is about to request user verification (biometric).
-        ///
-        /// Call `useUV(true)` to proceed with biometric verification, or `useUV(false)`
-        /// to skip UV and use PIN instead. This is called before UV starts, giving the
-        /// user a chance to opt for PIN entry.
-        ///
-        /// - Parameter useUV: Closure to call with `true` for UV or `false` for PIN.
-        case requestingUV(useUV: @Sendable (Bool) -> Void)
-
-        /// The client needs a PIN to proceed.
-        ///
-        /// Call `submitPIN` with the PIN string, or `nil` to cancel the operation.
-        ///
-        /// - Parameter submitPIN: Closure to call with the PIN or `nil` to cancel.
-        case requestingPIN(submitPIN: @Sendable (String?) -> Void)
 
         /// The operation completed successfully with a response.
         case finished(Response)
@@ -64,16 +65,16 @@ public enum WebAuthn {
     ///
     /// ## Usage
     ///
-    /// For simple cases where you don't need status updates, use the ``value(pin:useUV:)`` method:
+    /// For simple cases without UI feedback, drain the stream with ``value()``:
     ///
     /// ```swift
-    /// let response = try await client.makeCredential(options: opts, origin: origin).value(pin: pin)
+    /// let response = try await client.makeCredential(opts, authorization: .pin(pin)).value()
     /// ```
     ///
     /// For UI feedback or cancellation support, iterate the stream:
     ///
     /// ```swift
-    /// let stream = client.makeCredential(options: opts, origin: origin)
+    /// let stream = await client.makeCredential(opts, authorization: .pin(pin))
     ///
     /// for try await status in stream {
     ///     switch status {
@@ -81,15 +82,15 @@ public enum WebAuthn {
     ///         showSpinner()
     ///     case .waitingForUser(let cancel):
     ///         showTouchPrompt(onCancel: { Task { await cancel() } })
-    ///     case .requestingUV(let useUV):
-    ///         askUserAboutUV { useUV($0) }
-    ///     case .requestingPIN(let submitPIN):
-    ///         submitPIN(await askForPIN())
     ///     case .finished(let response):
     ///         return response
     ///     }
     /// }
     /// ```
+    ///
+    /// PIN entry and UV decisions are handled out-of-band via the
+    /// ``Authorization`` parameter on ``Client/makeCredential(_:authorization:)``
+    /// and ``Client/getAssertion(_:authorization:)``.
     public struct StatusStream<R: Sendable>: AsyncSequence, @unchecked Sendable {
         public typealias Element = Status<R>
 
@@ -115,41 +116,14 @@ public enum WebAuthn {
             return Self(base.timeout(duration, error: .timeout(source: .here())))
         }
 
-        // MARK: - Value Accessors
+        // MARK: - Value Accessor
 
         /// Consumes the stream and returns the final response value.
         ///
-        /// Throws ``ClientError/pinRequired(source:)`` if the authenticator
-        /// requests a PIN. Use ``value(pin:useUV:)`` instead when a PIN may be needed.
+        /// Errors raised by the ceremony propagate as thrown errors.
         public func value() async throws(ClientError) -> R {
             for try await status in self {
-                switch status {
-                case .requestingPIN: throw .pinRequired(source: .here())
-                case .requestingUV(let approve): approve(true)
-                case .finished(let response): return response
-                default: break
-                }
-            }
-            preconditionFailure("StatusStream must yield .finished before ending")
-        }
-
-        /// Consumes the stream and returns the final response value, auto-responding
-        /// to PIN and UV requests.
-        ///
-        /// - Parameters:
-        ///   - pin: The PIN to submit when the authenticator requests it.
-        ///   - useUV: Whether to use biometric verification when available. Defaults to `true`.
-        public func value(
-            pin: String,
-            useUV: Bool = true
-        ) async throws(ClientError) -> R {
-            for try await status in self {
-                switch status {
-                case .requestingPIN(let submitPIN): submitPIN(pin)
-                case .requestingUV(let approve): approve(useUV)
-                case .finished(let response): return response
-                default: break
-                }
+                if case .finished(let response) = status { return response }
             }
             preconditionFailure("StatusStream must yield .finished before ending")
         }
@@ -299,7 +273,9 @@ extension WebAuthn.Status: StreamStatus {
 extension WebAuthn.Status {
     fileprivate static func areDuplicates(_ lhs: Self, _ rhs: Self) -> Bool {
         switch (lhs, rhs) {
-        case (.processing, .processing), (.waitingForUser, .waitingForUser):
+        case (.processing, .processing),
+            (.waitingForUser, .waitingForUser),
+            (.waitingForUserVerification, .waitingForUserVerification):
             true
         default:
             false


### PR DESCRIPTION
## Why

Building a UI on top of the old API meant juggling callbacks. The status stream mixed two different things:

- **What the authenticator is doing** (`processing`, `waitingForUser`)
- **What the SDK needs from you** (`requestingPIN(submitPIN)`, `requestingUV(useUV)`)

To answer a PIN prompt you had to capture the `submitPIN` closure mid-iteration, hop to your UI, await the PIN, then resume the closure. View models hated it.

## After

The stream is now strictly about the authenticator. PIN/UV is supplied up front via `WebAuthn.Authorization`:

```swift
let auth = WebAuthn.Authorization(providePIN: {
    guard let pin = await viewModel.askForPIN()
    return .pin(pin)
})

for try await status in await client.makeCredential(opts, authorization: auth) {
    switch status {
    case .processing:                  showSpinner()
    case .waitingForUser(let cancel):  showTouchPrompt(cancel)
    case .waitingForUserVerification(let cancel, let fallbackToPIN):
        showBiometricPrompt(cancel, useToPIN: fallbackToPIN)
    case .finished(let response):      return response
    }
}
```

That's the whole UI integration. No callbacks to capture, no continuations to resume — `providePIN` is a plain `async` closure that the SDK awaits when (and only when) it needs a PIN.

## Errors say what to render

- `pinRejected(retriesRemaining: 7)` → "Wrong PIN, 7 left"
- `uvBlocked` → "Use your PIN instead"
- `forcePinChange` → route to PIN-change flow
- `cancelled` → user backed out

Each error ends the ceremony. To retry, call again with a fresh `Authorization` — no hidden retry state.

## Bonus: built-in shortcuts for trivial cases

```swift
// Pre-supplied PIN, skip biometrics.
try await client.makeCredential(opts, authorization: .pin("1234")).value()

// Biometric only, never prompt for PIN.
try await client.makeCredential(opts, authorization: .uvOnly).value()
```