### PR TITLE
Reject PINs longer than 8 bytes instead of trapping in paddedPinData

### DIFF
--- a/YubiKit/YubiKit/PIV/PIVSession.swift
+++ b/YubiKit/YubiKit/PIV/PIVSession.swift
@@ -1102,7 +1102,9 @@ extension PIVSession {
 
 extension String {
     fileprivate func paddedPinData() -> Data? {
-        guard var data = self.data(using: .utf8) else { return nil }
+        // PIV PINs are at most 8 bytes; a longer value would make the padding
+        // range below negative and trap.
+        guard var data = self.data(using: .utf8), data.count <= 8 else { return nil }
         let paddingSize = 8 - data.count
         for _ in 0..<paddingSize {
             data.append(0xff)


### PR DESCRIPTION
8 - data.count goes negative for over-long PINs and 0..<negative is a fatal trap. Return nil so verifyPin/changeReference throw illegalArgument instead of crashing the process.  Discovered from crash reports in production application.