### PR TITLE
Reject PINs longer than 8 bytes instead of trapping in paddedPinData

### DIFF
--- a/YubiKit/UnitTests/PIVPinTests.swift
+++ b/YubiKit/UnitTests/PIVPinTests.swift
@@ -1,0 +1,70 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Testing
+
+@testable import YubiKit
+
+struct PIVPinTests {
+
+    @Test("padPin returns 8 bytes with the PIN followed by 0xff")
+    func testPadPin() throws {
+        let padded6 = try PIV.padPin("123456")
+        #expect(padded6 == Data([0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0xff, 0xff]))
+
+        let padded8 = try PIV.padPin("12345678")
+        #expect(padded8 == Data([0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38]))
+    }
+
+    @Test("padPin accepts an empty value, as used to exhaust retry counters")
+    func testPadEmptyPin() throws {
+        let paddedEmpty = try PIV.padPin("")
+        #expect(paddedEmpty == Data(repeating: 0xff, count: 8))
+    }
+
+    @Test("padPin counts UTF-8 bytes, not characters")
+    func testPadPinCountsBytes() throws {
+        // "åäö" is 3 characters but 6 UTF-8 bytes.
+        let padded = try PIV.padPin("åäö")
+        #expect(padded == Data([0xc3, 0xa5, 0xc3, 0xa4, 0xc3, 0xb6, 0xff, 0xff]))
+    }
+
+    @Test("padPin rejects a value longer than 8 UTF-8 bytes")
+    func testPinTooLong() {
+        do {
+            _ = try PIV.padPin("123456789")
+            Issue.record("Expected error to be thrown")
+        } catch {
+            guard case .illegalArgument = error else {
+                Issue.record("Expected illegalArgument, got \(error)")
+                return
+            }
+        }
+    }
+
+    @Test("padPin rejects a value of 8 characters that exceeds 8 UTF-8 bytes")
+    func testMultibytePinTooLong() {
+        // 8 characters, but 16 UTF-8 bytes.
+        do {
+            _ = try PIV.padPin("åäöåäöåä")
+            Issue.record("Expected error to be thrown")
+        } catch {
+            guard case .illegalArgument = error else {
+                Issue.record("Expected illegalArgument, got \(error)")
+                return
+            }
+        }
+    }
+}

--- a/YubiKit/YubiKit/PIV/PIVSession.swift
+++ b/YubiKit/YubiKit/PIV/PIVSession.swift
@@ -1102,7 +1102,9 @@ extension PIVSession {
 
 extension String {
     fileprivate func paddedPinData() -> Data? {
-        guard var data = self.data(using: .utf8) else { return nil }
+        // PIV PINs are at most 8 bytes; a longer value would make the padding
+        // range below negative and trap.
+        guard var data = self.data(using: .utf8), data.count <= 8 else { return nil }
         let paddingSize = 8 - data.count
         for _ in 0..<paddingSize {
             data.append(0xff)

--- a/YubiKit/YubiKit/PIV/PIVSession.swift
+++ b/YubiKit/YubiKit/PIV/PIVSession.swift
@@ -724,7 +724,7 @@ public final actor PIVSession: SmartCardSessionInternal {
     @discardableResult
     public func verifyPin(_ pin: String) async throws(PIVSessionError) -> PIV.VerifyPinResult {
         /* Fix trace: Logger.piv.debug("\(String(describing: self).lastComponent), \(#function)") */
-        guard let pinData = pin.paddedPinData() else { throw .illegalArgument("Invalid PIN format", source: .here()) }
+        let pinData = try PIV.padPin(pin)
         let apdu = APDU(cla: 0, ins: insVerify, p1: 0, p2: 0x80, command: pinData)
         do {
             try await process(apdu: apdu)
@@ -914,7 +914,7 @@ public final actor PIVSession: SmartCardSessionInternal {
     public func verify(temporaryPin pin: Data) async throws(PIVSessionError) {
         /* Fix trace: Logger.piv.debug("\(String(describing: self).lastComponent), \(#function)") */
         guard pin.count == temporaryPinLength else {
-            throw .illegalArgument("PIN must be \(temporaryPinLength) characters", source: .here())
+            throw .illegalArgument("Temporary PIN must be exactly \(temporaryPinLength) bytes", source: .here())
         }
         do {
             let data = TKBERTLVRecord(tag: 0x01, value: pin).data
@@ -1007,10 +1007,7 @@ extension PIVSession {
         valueOne: String,
         valueTwo: String
     ) async throws(PIVSessionError) {
-        guard let paddedValueOne = valueOne.paddedPinData(), let paddedValueTwo = valueTwo.paddedPinData() else {
-            throw .illegalArgument("Invalid PIN/PUK format", source: .here())
-        }
-        let data = paddedValueOne + paddedValueTwo
+        let data = try PIV.padPin(valueOne) + PIV.padPin(valueTwo)
         let apdu = APDU(cla: 0, ins: ins, p1: 0, p2: p2, command: data)
         do {
             try await process(apdu: apdu)
@@ -1100,15 +1097,22 @@ extension PIVSession {
 
 }
 
-extension String {
-    fileprivate func paddedPinData() -> Data? {
-        // PIV PINs are at most 8 bytes; a longer value would make the padding
-        // range below negative and trap.
-        guard var data = self.data(using: .utf8), data.count <= 8 else { return nil }
-        let paddingSize = 8 - data.count
-        for _ in 0..<paddingSize {
-            data.append(0xff)
+extension PIV {
+    /// Validate and pad a PIN or PUK to 8 bytes as required by PIV.
+    ///
+    /// Only the upper bound is enforced; the minimum is device policy enforced by the YubiKey.
+    /// Empty values are intentional: ``PIVSession/blockPin()`` and ``PIVSession/blockPuk()``
+    /// use them to exhaust the retry counters.
+    ///
+    /// - Parameter pin: The PIN or PUK to validate and pad.
+    /// - Returns: The value padded to 8 bytes with 0xff.
+    /// - Throws: `PIVSessionError.illegalArgument` if the value exceeds 8 UTF-8 bytes.
+    static func padPin(_ pin: String) throws(PIVSessionError) -> Data {
+        var data = Data(pin.utf8)
+        guard data.count <= 8 else {  // max 8 UTF-8 bytes
+            throw .illegalArgument("PIN/PUK must be at most 8 UTF-8 bytes", source: .here())
         }
+        data.append(Data(repeating: 0xff, count: 8 - data.count))
         return data
     }
 }


### PR DESCRIPTION
Supersedes #129, keeping the original fix from @kitknox as-is.

Second commit replaces `paddedPinData` with `PIV.padPin`, matching the `CTAP2.ClientPin.ProtocolVersion.padPin` convention, and adds unit tests. No minimum length is enforced: that is device policy, and `blockPin()`/`blockPuk()` rely on padding empty values. Also fixes the `verify(temporaryPin:)` error message, which said "characters" for a byte count.