### PR TITLE
Align integration scenarios with Python tests

### DIFF
--- a/IntegrationTesting/Tests/CTAP2Tests.swift
+++ b/IntegrationTesting/Tests/CTAP2Tests.swift
@@ -161,5 +161,67 @@ extension ScenarioSuites {
 
         @Test("factory reset clears credentials and the PIN")
         func factory() async throws { try await ScenarioTests.run(CTAP2Scenario.factory.scenario) }
+
+        @Test("largeBlob array round-trips two blobs and rejects writes without largeBlobWrite")
+        func largeBlobsArray() async throws { try await ScenarioTests.run(CTAP2Scenario.largeBlobsArray.scenario) }
+
+        @Test("hmac-secret round-trips deterministic secrets with one and two salts")
+        func hmacSecret() async throws { try await ScenarioTests.run(CTAP2Scenario.hmacSecret.scenario) }
+
+        @Test("credential management with a wrong-permission token is rejected")
+        func credManMissingPermissions() async throws {
+            try await ScenarioTests.run(CTAP2Scenario.credManMissingPermissions.scenario)
+        }
+
+        @Test("the raw encIdentifier re-randomizes between consecutive getInfo calls")
+        func encIdentifierChanges() async throws {
+            try await ScenarioTests.run(CTAP2Scenario.encIdentifierChanges.scenario)
+        }
+
+        @Test("platform-facilitated enterprise attestation yields a distinct certificate")
+        func enterpriseAttestationPlatform() async throws {
+            try await ScenarioTests.run(CTAP2Scenario.enterpriseAttestationPlatform.scenario)
+        }
+
+        @Test("previewSign rejects an unsupported algorithm")
+        func previewSignUnsupportedAlgorithm() async throws {
+            try await ScenarioTests.run(CTAP2Scenario.previewSignUnsupportedAlgorithm.scenario)
+        }
+
+        @Test("previewSign rejects invalid flag combinations")
+        func previewSignInvalidFlags() async throws {
+            try await ScenarioTests.run(CTAP2Scenario.previewSignInvalidFlags.scenario)
+        }
+
+        @Test("previewSign rejects a missing keyHandle or TBS")
+        func previewSignMissingParameter() async throws {
+            try await ScenarioTests.run(CTAP2Scenario.previewSignMissingParameter.scenario)
+        }
+
+        @Test("a UP-required previewSign key rejects assertion without user presence")
+        func previewSignUpRequired() async throws {
+            try await ScenarioTests.run(CTAP2Scenario.previewSignUpRequired.scenario)
+        }
+
+        @Test("a UV-required previewSign key rejects assertion without a UV token")
+        func previewSignUvRequired() async throws {
+            try await ScenarioTests.run(CTAP2Scenario.previewSignUvRequired.scenario)
+        }
+
+        @Test("previewSign generates a key and produces a non-empty signature")
+        func previewSignGenerateAndSign() async throws {
+            try await ScenarioTests.run(CTAP2Scenario.previewSignGenerateAndSign.scenario)
+        }
+
+        @Test("credProtect L1/L2/L3 govern discovery and usability with and without UV")
+        func credProtectEnforcement() async throws {
+            try await ScenarioTests.run(CTAP2Scenario.credProtectEnforcement.scenario)
+        }
+
+        @Test(
+            "per-algorithm make+assert, credential-management lifecycle, and largeBlob PIN/UV-protocol families",
+            arguments: ScenarioTests.parameterizedFamilies(in: .ctap2, besides: CTAP2Scenario.allCases.map(\.scenario))
+        )
+        func parameterizedFamilies(_ scenario: Scenario) async throws { try await ScenarioTests.run(scenario) }
     }
 }

--- a/IntegrationTesting/Tests/ConnectionTests.swift
+++ b/IntegrationTesting/Tests/ConnectionTests.swift
@@ -20,7 +20,7 @@ extension ScenarioSuites {
     @Suite("Connection")
     struct Connection {
 
-        @Test("opens a SmartCard connection")
+        @Test("acquires a usable SmartCard connection")
         func open() async throws { try await ScenarioTests.run(ConnectionScenario.open.scenario) }
 
         @Test("waitUntilClosed() is notified with the closing error")
@@ -31,14 +31,6 @@ extension ScenarioSuites {
 
         @Test("concurrent open attempts resolve to a single connection")
         func cancellation() async throws { try await ScenarioTests.run(ConnectionScenario.cancellation.scenario) }
-
-        @Test("opens a selected USB SmartCard connection")
-        func withDeviceSmartCard() async throws {
-            try await ScenarioTests.run(ConnectionScenario.withDeviceSmartCard.scenario)
-        }
-
-        @Test("opens a USB SmartCard connection to a slot from availableDevices()")
-        func withSlot() async throws { try await ScenarioTests.run(ConnectionScenario.withSlot.scenario) }
 
         @Test("manual SELECT + device-info exchange reads the firmware version")
         func sendManually() async throws { try await ScenarioTests.run(ConnectionScenario.sendManually.scenario) }

--- a/IntegrationTesting/Tests/OATHTests.swift
+++ b/IntegrationTesting/Tests/OATHTests.swift
@@ -20,9 +20,6 @@ extension ScenarioSuites {
     @Suite("OATH")
     struct OATH {
 
-        @Test("calculateCredentialCodes reassembles a response that spans multiple frames")
-        func chunkedData() async throws { try await ScenarioTests.run(OATHScenario.chunkedData.scenario) }
-
         @Test("listCredentials returns the populated credentials with the expected labels and types")
         func credentials() async throws { try await ScenarioTests.run(OATHScenario.credentials.scenario) }
 
@@ -43,6 +40,9 @@ extension ScenarioSuites {
 
         @Test("renaming a credential onto an existing identifier is rejected")
         func toExisting() async throws { try await ScenarioTests.run(OATHScenario.toExisting.scenario) }
+
+        @Test("renaming onto a distinct existing credential's identifier is rejected")
+        func toExistingDistinct() async throws { try await ScenarioTests.run(OATHScenario.toExistingDistinct.scenario) }
 
         @Test("deleteCredential removes a single credential")
         func credentialDelete() async throws { try await ScenarioTests.run(OATHScenario.credentialDelete.scenario) }
@@ -65,22 +65,47 @@ extension ScenarioSuites {
         @Test("deleteAccessKey removes the password so a fresh session needs no unlock")
         func deleteAccessKey() async throws { try await ScenarioTests.run(OATHScenario.deleteAccessKey.scenario) }
 
+        @Test("deleteAccessKey is rejected on a FIPS device")
+        func deleteAccessKeyRejectedOnFIPS() async throws {
+            try await ScenarioTests.run(OATHScenario.deleteAccessKeyRejectedOnFIPS.scenario)
+        }
+
         @Test("a locked OATH application rejects listing until it is unlocked")
         func lockedListRejected() async throws { try await ScenarioTests.run(OATHScenario.lockedListRejected.scenario) }
+
+        @Test("a locked OATH application rejects calculating a single code")
+        func lockedCalculateRejected() async throws {
+            try await ScenarioTests.run(OATHScenario.lockedCalculateRejected.scenario)
+        }
+
+        @Test("a locked OATH application rejects calculating all codes")
+        func lockedCalculateAllRejected() async throws {
+            try await ScenarioTests.run(OATHScenario.lockedCalculateAllRejected.scenario)
+        }
+
+        @Test("a locked OATH application rejects deleting a credential")
+        func lockedDeleteRejected() async throws {
+            try await ScenarioTests.run(OATHScenario.lockedDeleteRejected.scenario)
+        }
+
+        @Test("a locked OATH application rejects renaming a credential")
+        func lockedRenameRejected() async throws {
+            try await ScenarioTests.run(OATHScenario.lockedRenameRejected.scenario)
+        }
 
         @Test("calculateCredentialResponse matches the RFC 2202 HMAC-SHA1 test vector")
         func response() async throws { try await ScenarioTests.run(OATHScenario.response.scenario) }
 
-        @Test("calculateCredentialResponse matches the RFC 4231 HMAC-SHA256 vector")
-        func hmacSha256() async throws { try await ScenarioTests.run(OATHScenario.hmacSha256.scenario) }
+        @Test("the applet rejects adding beyond its credential limit")
+        func maxCredentials() async throws { try await ScenarioTests.run(OATHScenario.maxCredentials.scenario) }
 
-        @Test("calculateCredentialResponse matches the RFC 4231 HMAC-SHA512 vector")
-        func hmacSha512() async throws { try await ScenarioTests.run(OATHScenario.hmacSha512.scenario) }
+        @Test("a credential with a Unicode name round-trips correctly")
+        func unicodeName() async throws { try await ScenarioTests.run(OATHScenario.unicodeName.scenario) }
 
-        @Test("calculateCredentialCode matches the RFC 6238 TOTP-SHA1 vector at t=59")
-        func totpSha1_59() async throws { try await ScenarioTests.run(OATHScenario.totpSha1_59.scenario) }
-
-        @Test("successive calculateCredentialCode calls match the RFC 4226 HOTP-SHA1 vectors")
-        func hotpSha1() async throws { try await ScenarioTests.run(OATHScenario.hotpSha1.scenario) }
+        @Test(
+            "RFC 4231 HMAC / 6238 TOTP / 4226 HOTP test-vector families",
+            arguments: ScenarioTests.parameterizedFamilies(in: .oath, besides: OATHScenario.allCases.map(\.scenario))
+        )
+        func vectors(_ scenario: Scenario) async throws { try await ScenarioTests.run(scenario) }
     }
 }

--- a/IntegrationTesting/Tests/PIVTests.swift
+++ b/IntegrationTesting/Tests/PIVTests.swift
@@ -74,6 +74,16 @@ extension ScenarioSuites {
         @Test("imports an X25519 key and performs key agreement")
         func x25519KeyImport() async throws { try await ScenarioTests.run(PIVScenario.x25519KeyImport.scenario) }
 
+        @Test("imports an EC P-256 key with PIN policy ALWAYS and reads it back from metadata")
+        func importPinPolicyAlways() async throws {
+            try await ScenarioTests.run(PIVScenario.importPinPolicyAlways.scenario)
+        }
+
+        @Test("imports an EC P-256 key with touch policy ALWAYS and reads it back from metadata")
+        func importTouchPolicyAlways() async throws {
+            try await ScenarioTests.run(PIVScenario.importTouchPolicyAlways.scenario)
+        }
+
         @Test("generates an RSA-1024 key")
         func rsa1024KeyGeneration() async throws {
             try await ScenarioTests.run(PIVScenario.rsa1024KeyGeneration.scenario)
@@ -114,6 +124,21 @@ extension ScenarioSuites {
             try await ScenarioTests.run(PIVScenario.x25519KeyGeneration.scenario)
         }
 
+        @Test("generateKey without a prior management-key authenticate is rejected")
+        func generateKeyRequiresAuth() async throws {
+            try await ScenarioTests.run(PIVScenario.generateKeyRequiresAuth.scenario)
+        }
+
+        @Test("putCertificate without management-key authentication is rejected")
+        func putCertificateRequiresAuth() async throws {
+            try await ScenarioTests.run(PIVScenario.putCertificateRequiresAuth.scenario)
+        }
+
+        @Test("putKey without management-key authentication is rejected")
+        func putKeyRequiresAuth() async throws {
+            try await ScenarioTests.run(PIVScenario.putKeyRequiresAuth.scenario)
+        }
+
         @Test("attests a generated RSA key")
         func rsa() async throws { try await ScenarioTests.run(PIVScenario.rsa.scenario) }
 
@@ -122,6 +147,11 @@ extension ScenarioSuites {
 
         @Test("attests a generated X25519 key")
         func x25519Attestation() async throws { try await ScenarioTests.run(PIVScenario.x25519Attestation.scenario) }
+
+        @Test("reads the static attestation certificate from slot f9")
+        func exportAttestationCertificate() async throws {
+            try await ScenarioTests.run(PIVScenario.exportAttestationCertificate.scenario)
+        }
 
         @Test("writes and reads back an X.509 certificate")
         func putGet() async throws { try await ScenarioTests.run(PIVScenario.putGet.scenario) }
@@ -163,6 +193,11 @@ extension ScenarioSuites {
         @Test("sets the PIN and PUK retry attempts")
         func setAttempts() async throws { try await ScenarioTests.run(PIVScenario.setAttempts.scenario) }
 
+        @Test("setRetries takes effect, and wrong PIN/PUK then report the new remaining counts")
+        func setPinRetriesRoundTrip() async throws {
+            try await ScenarioTests.run(PIVScenario.setPinRetriesRoundTrip.scenario)
+        }
+
         @Test("reports remaining retries when changing the PIN with a wrong old PIN")
         func changePinFailure() async throws { try await ScenarioTests.run(PIVScenario.changePinFailure.scenario) }
 
@@ -181,17 +216,23 @@ extension ScenarioSuites {
         @Test("a key with PIN policy ALWAYS requires a fresh PIN verification before every signature")
         func pinPolicyAlways() async throws { try await ScenarioTests.run(PIVScenario.pinPolicyAlways.scenario) }
 
+        @Test("a key with PIN policy ONCE needs one verify per session, then re-verify after a fresh session")
+        func pinPolicyOnce() async throws { try await ScenarioTests.run(PIVScenario.pinPolicyOnce.scenario) }
+
+        @Test("a key with PIN policy NEVER signs without any PIN verification")
+        func pinPolicyNever() async throws { try await ScenarioTests.run(PIVScenario.pinPolicyNever.scenario) }
+
         @Test("reports a firmware version")
         func version() async throws { try await ScenarioTests.run(PIVScenario.version.scenario) }
-
-        @Test("reports a serial number")
-        func serialNumber() async throws { try await ScenarioTests.run(PIVScenario.serialNumber.scenario) }
 
         @Test("reads default management key metadata")
         func managementKey() async throws { try await ScenarioTests.run(PIVScenario.managementKey.scenario) }
 
         @Test("reads slot metadata for generated keys across PIN/touch policies")
         func slot() async throws { try await ScenarioTests.run(PIVScenario.slot.scenario) }
+
+        @Test("reads slot metadata for an imported (generated == false) key")
+        func slotMetadataPut() async throws { try await ScenarioTests.run(PIVScenario.slotMetadataPut.scenario) }
 
         @Test("reads metadata after setting an AES-192 management key")
         func aesManagementKey() async throws { try await ScenarioTests.run(PIVScenario.aesManagementKey.scenario) }
@@ -217,5 +258,11 @@ extension ScenarioSuites {
         func verifyUvWithoutFingerprints() async throws {
             try await ScenarioTests.run(PIVScenario.verifyUvWithoutFingerprints.scenario)
         }
+
+        @Test(
+            "import-decrypt, slot-metadata, key-agreement, FIPS, and PIN-complexity families",
+            arguments: ScenarioTests.parameterizedFamilies(in: .piv, besides: PIVScenario.allCases.map(\.scenario))
+        )
+        func parameterizedFamilies(_ scenario: Scenario) async throws { try await ScenarioTests.run(scenario) }
     }
 }

--- a/IntegrationTesting/Tests/SCPTests.swift
+++ b/IntegrationTesting/Tests/SCPTests.swift
@@ -23,11 +23,6 @@ extension ScenarioSuites {
         @Test("default SCP03 static keys authenticate a Management session")
         func defaultKeys() async throws { try await ScenarioTests.run(SCPScenario.defaultKeys.scenario) }
 
-        @Test("Management.getDeviceInfo over an SCP03 secure channel")
-        func managementDeviceInfo() async throws {
-            try await ScenarioTests.run(SCPScenario.managementDeviceInfo.scenario)
-        }
-
         @Test("importing a new SCP03 key set replaces the default keys")
         func importKeySCP03() async throws { try await ScenarioTests.run(SCPScenario.importKeySCP03.scenario) }
 

--- a/IntegrationTesting/Tests/Tests.swift
+++ b/IntegrationTesting/Tests/Tests.swift
@@ -93,6 +93,14 @@ enum ScenarioTests {
         }
     }
 
+    /// The parameterized families declared by a suite: every catalog scenario in `suite` that is not
+    /// one of the suite's enumerated cases. Driving `@Test(arguments:)` off this picks up a newly
+    /// added family automatically — no per-case wrapper to forget and no fragile id matching.
+    static func parameterizedFamilies(in suite: Scenario.Suite, besides enumeratedCases: [Scenario]) -> [Scenario] {
+        let enumeratedIDs = Set(enumeratedCases.map(\.id))
+        return Scenario.Catalog.scenarios(in: suite).filter { !enumeratedIDs.contains($0.id) }
+    }
+
 }
 
 /// Parent suite for per-scenario tests; serialized because they share one attached key.
@@ -134,6 +142,16 @@ enum ScenarioSuites {}
     let ids = Scenario.Catalog.allDeclared.map(\.id)
     let duplicates = Dictionary(grouping: ids, by: { $0 }).filter { $1.count > 1 }.keys.sorted()
     #expect(duplicates.isEmpty, "duplicate scenario ids: \(duplicates.joined(separator: ", "))")
+}
+
+// Each suite that declares parameterized families drives them from `parameterizedFamilies(in:besides:)`
+// in a `@Test(arguments:)`. An empty result there would run zero cases while still reporting green, so
+// guard that the families resolve — this fails loudly if a base id is renamed or a family stops being
+// declared.
+@Test func parameterizedFamiliesAreWired() {
+    #expect(!ScenarioTests.parameterizedFamilies(in: .oath, besides: OATHScenario.allCases.map(\.scenario)).isEmpty)
+    #expect(!ScenarioTests.parameterizedFamilies(in: .ctap2, besides: CTAP2Scenario.allCases.map(\.scenario)).isEmpty)
+    #expect(!ScenarioTests.parameterizedFamilies(in: .piv, besides: PIVScenario.allCases.map(\.scenario)).isEmpty)
 }
 
 @Test(.enabled(if: ScenarioTests.backendConfigured && ScenarioTests.configurationIsValid))

--- a/IntegrationTesting/Tests/WebAuthnTests.swift
+++ b/IntegrationTesting/Tests/WebAuthnTests.swift
@@ -49,37 +49,10 @@ extension ScenarioSuites {
             try await ScenarioTests.run(WebAuthnScenario.publicSuffixRejected.scenario)
         }
 
-        @Test("makeCredential with the wrong PIN throws pinRejected and decrements retries")
-        func wrongPin() async throws { try await ScenarioTests.run(WebAuthnScenario.wrongPin.scenario) }
-
-        @Test("clientDataJSON serializes with spec key ordering")
-        func clientDataJSON() async throws { try await ScenarioTests.run(WebAuthnScenario.clientDataJSON.scenario) }
-
-        @Test("getAssertion status stream delivers user-presence events and pulls the PIN via closure")
-        func statusStream() async throws { try await ScenarioTests.run(WebAuthnScenario.statusStream.scenario) }
-
         @Test("discoverable getAssertion for an RP with no credentials throws noCredentials")
         func discoverableNoCredentials() async throws {
             try await ScenarioTests.run(WebAuthnScenario.discoverableNoCredentials.scenario)
         }
-
-        @Test("makeCredential consumes a pre-supplied PIN silently while still emitting waitingForUser")
-        func prefetchedPinMakeCredential() async throws {
-            try await ScenarioTests.run(WebAuthnScenario.prefetchedPinMakeCredential.scenario)
-        }
-
-        @Test("getAssertion consumes a pre-supplied PIN silently")
-        func prefetchedPinGetAssertion() async throws {
-            try await ScenarioTests.run(WebAuthnScenario.prefetchedPinGetAssertion.scenario)
-        }
-
-        @Test("makeCredential can be cancelled from the status stream")
-        func cancelMakeCredential() async throws {
-            try await ScenarioTests.run(WebAuthnScenario.cancelMakeCredential.scenario)
-        }
-
-        @Test("credProtect echoes the applied protection level for each policy")
-        func allLevels() async throws { try await ScenarioTests.run(WebAuthnScenario.allLevels.scenario) }
 
         @Test("PRF enabled at registration derives deterministic secrets at authentication")
         func derive() async throws { try await ScenarioTests.run(WebAuthnScenario.derive.scenario) }
@@ -115,15 +88,6 @@ extension ScenarioSuites {
             try await ScenarioTests.run(WebAuthnScenario.oversizedRejected.scenario)
         }
 
-        @Test("credProps reports rk=true for a discoverable credential")
-        func discoverable() async throws { try await ScenarioTests.run(WebAuthnScenario.discoverable.scenario) }
-
-        @Test("credProps reports rk=false for a non-discoverable credential")
-        func nonDiscoverable() async throws { try await ScenarioTests.run(WebAuthnScenario.nonDiscoverable.scenario) }
-
-        @Test("credProps is nil when not requested")
-        func notRequested() async throws { try await ScenarioTests.run(WebAuthnScenario.notRequested.scenario) }
-
         @Test("minPinLength returns the enforced length once the RP is configured")
         func returnsValue() async throws { try await ScenarioTests.run(WebAuthnScenario.returnsValue.scenario) }
 
@@ -140,5 +104,30 @@ extension ScenarioSuites {
 
         @Test("thirdPartyPayment echoes true when the credential is registered for payment")
         func echoedTrue() async throws { try await ScenarioTests.run(WebAuthnScenario.echoedTrue.scenario) }
+
+        @Test("getAssertion with multiple allow-list entries returns the matching credential")
+        func allowCredentialsMultiple() async throws {
+            try await ScenarioTests.run(WebAuthnScenario.allowCredentialsMultiple.scenario)
+        }
+
+        @Test("getAssertion with only ineligible allow-list entries throws noCredentials")
+        func allowCredentialsIneligible() async throws {
+            try await ScenarioTests.run(WebAuthnScenario.allowCredentialsIneligible.scenario)
+        }
+
+        @Test("makeCredential rejects when multiple exclude-list entries match")
+        func excludeCredentialsMultiple() async throws {
+            try await ScenarioTests.run(WebAuthnScenario.excludeCredentialsMultiple.scenario)
+        }
+
+        @Test("makeCredential rejects when the exclude list is at the authenticator's max capacity")
+        func excludeCredentialsMax() async throws {
+            try await ScenarioTests.run(WebAuthnScenario.excludeCredentialsMax.scenario)
+        }
+
+        @Test("makeCredential succeeds when exclude-list entries belong to other RPs")
+        func excludeCredentialsOthers() async throws {
+            try await ScenarioTests.run(WebAuthnScenario.excludeCredentialsOthers.scenario)
+        }
     }
 }

--- a/YubiKit/IntegrationScenarios/Engine/Gate.swift
+++ b/YubiKit/IntegrationScenarios/Engine/Gate.swift
@@ -37,6 +37,9 @@ enum Gate {
             if let min = requirements.minVersion, deviceInfo.version < min {
                 return .skip(reason: "requires firmware ≥ \(min) (device is \(deviceInfo.version))")
             }
+            if let max = requirements.maxVersion, deviceInfo.version > max {
+                return .skip(reason: "requires firmware ≤ \(max) (device is \(deviceInfo.version))")
+            }
             for capability in requirements.capabilities
             where !deviceInfo.isApplicationSupported(capability, over: transport) {
                 return .skip(reason: "requires \(capability) over \(transport)")
@@ -46,6 +49,12 @@ enum Gate {
             }
             if requirements.excludesBio, isBio(deviceInfo) {
                 return .skip(reason: "requires a non-Bio device")
+            }
+            if requirements.requiresFIPS, !deviceInfo.isFIPS {
+                return .skip(reason: "requires a FIPS-certified device")
+            }
+            if requirements.excludesFIPS, deviceInfo.isFIPS {
+                return .skip(reason: "requires a non-FIPS device")
             }
         }
         if requirements.requiresFIDOTransport, !provider.hasFIDO {

--- a/YubiKit/IntegrationScenarios/Engine/RandomBytes.swift
+++ b/YubiKit/IntegrationScenarios/Engine/RandomBytes.swift
@@ -1,0 +1,26 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Security
+
+/// Cryptographically random bytes for scenario inputs — challenges, user handles, credential ids.
+/// Traps if the system RNG fails (`SecRandomCopyBytes` does not fail in practice), giving every
+/// scenario call site the same non-optional contract.
+func randomBytes(count: Int) -> Data {
+    var bytes = [UInt8](repeating: 0, count: count)
+    let status = SecRandomCopyBytes(kSecRandomDefault, count, &bytes)
+    precondition(status == errSecSuccess, "SecRandomCopyBytes failed: \(status)")
+    return Data(bytes)
+}

--- a/YubiKit/IntegrationScenarios/Engine/Requirements.swift
+++ b/YubiKit/IntegrationScenarios/Engine/Requirements.swift
@@ -19,10 +19,16 @@ import YubiKit
 public struct Requirements: Sendable {
     public var capabilities: Set<Capability>
     public var minVersion: Version?
+    /// Inclusive upper firmware bound; with `minVersion` this expresses a version range.
+    public var maxVersion: Version?
     public var transports: Set<DeviceTransport>?
     public var requiresBio: Bool
     /// Forbid a Bio device.
     public var excludesBio: Bool
+    /// Require a FIPS-certified device.
+    public var requiresFIPS: Bool
+    /// Forbid a FIPS-certified device (behavior that FIPS firmware blocks, e.g. PIN policy NEVER).
+    public var excludesFIPS: Bool
     public var requiresFIDOTransport: Bool
     public var requiresLightning: Bool
     public var requiresSCP: Bool
@@ -32,9 +38,12 @@ public struct Requirements: Sendable {
     init(
         capabilities: Set<Capability> = [],
         minVersion: Version? = nil,
+        maxVersion: Version? = nil,
         transports: Set<DeviceTransport>? = nil,
         requiresBio: Bool = false,
         excludesBio: Bool = false,
+        requiresFIPS: Bool = false,
+        excludesFIPS: Bool = false,
         requiresFIDOTransport: Bool = false,
         requiresLightning: Bool = false,
         requiresSCP: Bool = false,
@@ -42,9 +51,12 @@ public struct Requirements: Sendable {
     ) {
         self.capabilities = capabilities
         self.minVersion = minVersion
+        self.maxVersion = maxVersion
         self.transports = transports
         self.requiresBio = requiresBio
         self.excludesBio = excludesBio
+        self.requiresFIPS = requiresFIPS
+        self.excludesFIPS = excludesFIPS
         self.requiresFIDOTransport = requiresFIDOTransport
         self.requiresLightning = requiresLightning
         self.requiresSCP = requiresSCP
@@ -53,6 +65,7 @@ public struct Requirements: Sendable {
 
     /// Whether these requirements need `DeviceInfo`.
     var needsDeviceInfo: Bool {
-        !capabilities.isEmpty || minVersion != nil || requiresBio || excludesBio
+        !capabilities.isEmpty || minVersion != nil || maxVersion != nil
+            || requiresBio || excludesBio || requiresFIPS || excludesFIPS
     }
 }

--- a/YubiKit/IntegrationScenarios/Engine/Scenario+Parameterized.swift
+++ b/YubiKit/IntegrationScenarios/Engine/Scenario+Parameterized.swift
@@ -1,0 +1,55 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+/// One value in a parameterized scenario family. It carries the per-case metadata (id suffix,
+/// display name, gating) so `Scenario.parameterized` needs only a single body closure — the moral
+/// equivalent of a row in pytest's `@pytest.mark.parametrize`.
+protocol ScenarioParameter: Sendable {
+    /// Appended to the family id to keep each case's id unique (e.g. `"tc1.sha256"`).
+    var idSuffix: String { get }
+    /// Per-case display name.
+    var displayName: String { get }
+    /// Per-case gating (a SHA-512 vector can require newer firmware than its SHA-256 sibling).
+    var requirements: Requirements { get }
+    var platform: Platform { get }
+}
+
+extension ScenarioParameter {
+    var platform: Platform { .all }
+}
+
+extension Scenario {
+
+    /// Fans a single definition out into one scenario per value, mirroring pytest's
+    /// `@pytest.mark.parametrize`. Each value supplies its own id suffix, name, and requirements,
+    /// and the value is handed to the shared body.
+    static func parameterized<Value: ScenarioParameter>(
+        _ id: String,
+        over values: [Value],
+        run: @escaping @Sendable (Scenario.Context, Value) async throws -> Void
+    ) -> [Scenario] {
+        values.map { value in
+            Scenario(
+                "\(id).\(value.idSuffix)",
+                value.displayName,
+                requirements: value.requirements,
+                platform: value.platform
+            ) { context in
+                try await run(context, value)
+            }
+        }
+    }
+}

--- a/YubiKit/IntegrationScenarios/Engine/ScenarioContext+Sessions.swift
+++ b/YubiKit/IntegrationScenarios/Engine/ScenarioContext+Sessions.swift
@@ -39,10 +39,8 @@ extension Scenario.Context {
         if reset {
             try await session.reset()
             addTeardown {
-                guard let cleanup = try? await PIVSession.makeSession(connection: connection, scpKeyParams: scp) else {
-                    return
-                }
-                try? await cleanup.reset()
+                let cleanup = try await PIVSession.makeSession(connection: connection, scpKeyParams: scp)
+                try await cleanup.reset()
             }
         }
         if authenticated { try await session.authenticate(with: Self.defaultManagementKey) }
@@ -56,10 +54,8 @@ extension Scenario.Context {
         if reset {
             try await session.reset()
             addTeardown {
-                guard let cleanup = try? await OATHSession.makeSession(connection: connection, scpKeyParams: scp) else {
-                    return
-                }
-                try? await cleanup.reset()
+                let cleanup = try await OATHSession.makeSession(connection: connection, scpKeyParams: scp)
+                try await cleanup.reset()
             }
         }
         return session
@@ -80,6 +76,23 @@ extension Scenario.Context {
     func ctap2SessionAfterNFCReconnect() async throws -> CTAP2.Session {
         await reconnectWhenOverNFC()
         return try await ctap2Session()
+    }
+
+    /// Deletes resident credentials; a no-op when no PIN is set or credential management is unsupported.
+    func deleteResidentCredentials() async throws {
+        let session = try await ctap2Session()
+        guard try await session.getInfo().options.clientPin == true else { return }
+        guard try await CTAP2.CredentialManagement.isSupported(by: session) else { return }
+        let token = try await session.getPinUVToken(
+            using: .pin(Self.defaultTestPin),
+            permissions: [.credentialManagement]
+        )
+        let credentialManagement = try await session.credentialManagement(token: token)
+        for try await rp in credentialManagement.rps {
+            for try await credential in credentialManagement.credentials(for: rp.rpIdHash) {
+                try await credentialManagement.deleteCredential(credential.credentialId)
+            }
+        }
     }
 
     func webAuthnClient(

--- a/YubiKit/IntegrationScenarios/Engine/ScenarioContext.swift
+++ b/YubiKit/IntegrationScenarios/Engine/ScenarioContext.swift
@@ -147,6 +147,29 @@ extension Scenario {
             fail(message, file: file, line: line)
         }
 
+        /// Runs `body`, expecting it to throw. Records a failure — without aborting the rest of the
+        /// scenario — if the body returns instead, or if the thrown error does not satisfy
+        /// `isExpected`. Replaces the hand-rolled `do { …; record("should have thrown") } catch { … }`
+        /// idiom (and its `return`-in-`catch` footgun).
+        nonisolated func expectThrows(
+            _ action: String,
+            matching isExpected: (any Error) -> Bool = { _ in true },
+            file: String = #fileID,
+            line: Int = #line,
+            _ body: () async throws -> Void
+        ) async {
+            do {
+                try await body()
+                record("\(action) should have thrown but returned", file: file, line: line)
+            } catch {
+                if isExpected(error) {
+                    log("\(action) correctly rejected with \(error)")
+                } else {
+                    record("\(action): unexpected error \(error)", file: file, line: line)
+                }
+            }
+        }
+
         /// Abort the body and report the scenario as skipped.
         nonisolated func skip(_ reason: String) throws -> Never {
             log("⏭ \(reason) — skipping")

--- a/YubiKit/IntegrationScenarios/ScenarioCatalog.swift
+++ b/YubiKit/IntegrationScenarios/ScenarioCatalog.swift
@@ -14,20 +14,34 @@
 
 import Foundation
 
+/// A scenario suite: enumerated cases plus any parameterized families. Every suite enum conforms,
+/// so the catalog collects them uniformly through `allScenarios`.
+protocol ScenarioSuite: CaseIterable {
+    var scenario: Scenario { get }
+    /// Parameterized families fanned out from a base definition (default: none).
+    static var parameterizedScenarios: [Scenario] { get }
+}
+
+extension ScenarioSuite {
+    static var parameterizedScenarios: [Scenario] { [] }
+    /// One scenario per enumerated case, followed by any parameterized families.
+    static var allScenarios: [Scenario] { allCases.map(\.scenario) + parameterizedScenarios }
+}
+
 extension Scenario {
 
     public enum Catalog {
 
         public static let allDeclared: [Scenario] = {
             var scenarios: [Scenario] = []
-            scenarios += ManagementScenario.allCases.map(\.scenario)
-            scenarios += PIVScenario.allCases.map(\.scenario)
-            scenarios += OATHScenario.allCases.map(\.scenario)
-            scenarios += ConnectionScenario.allCases.map(\.scenario)
-            scenarios += CTAP2Scenario.allCases.map(\.scenario)
-            scenarios += CTAPHIDScenario.allCases.map(\.scenario)
-            scenarios += WebAuthnScenario.allCases.map(\.scenario)
-            scenarios += SCPScenario.allCases.map(\.scenario)
+            scenarios += ManagementScenario.allScenarios
+            scenarios += PIVScenario.allScenarios
+            scenarios += OATHScenario.allScenarios
+            scenarios += ConnectionScenario.allScenarios
+            scenarios += CTAP2Scenario.allScenarios
+            scenarios += CTAPHIDScenario.allScenarios
+            scenarios += WebAuthnScenario.allScenarios
+            scenarios += SCPScenario.allScenarios
             return scenarios
         }()
 

--- a/YubiKit/IntegrationScenarios/Scenarios/CTAP2.swift
+++ b/YubiKit/IntegrationScenarios/Scenarios/CTAP2.swift
@@ -17,8 +17,9 @@ import Foundation
 import YubiKit
 
 /// CTAP2 application scenarios.
-public enum CTAP2Scenario: CaseIterable {
+public enum CTAP2Scenario: CaseIterable, ScenarioSuite {
 
+    case cleanState
     case getInfo
     case makeGetAllowList
     case makeGetDiscoverable
@@ -61,9 +62,35 @@ public enum CTAP2Scenario: CaseIterable {
     case uvBlocking
     case userPresence
     case factory
+    case largeBlobsArray
+    case credProtectEnforcement
+    case hmacSecret
+    case credManMissingPermissions
+    case encIdentifierChanges
+    case enterpriseAttestationPlatform
+    case previewSignUnsupportedAlgorithm
+    case previewSignInvalidFlags
+    case previewSignMissingParameter
+    case previewSignUpRequired
+    case previewSignUvRequired
+    case previewSignGenerateAndSign
 
     public var scenario: Scenario {
         switch self {
+        // MARK: - Setup
+        case .cleanState:
+            return Scenario(
+                "CTAP2.Setup.cleanState",
+                "reset to a clean, PIN-less state before the suite",
+                requirements: Requirements(capabilities: [.fido2])
+            ) { context in
+                let session = try await context.ctap2Session()
+                for try await _ in await session.reset() {}
+                context.expect(
+                    try await session.getInfo().options.clientPin != true,
+                    "PIN should be cleared for a deterministic start"
+                )
+            }
         // MARK: - Info
         case .getInfo:
             return Scenario(
@@ -94,7 +121,7 @@ public enum CTAP2Scenario: CaseIterable {
                 requirements: Requirements(capabilities: [.fido2])
             ) { context in
                 var session = try await context.ctap2Session()
-                let clientDataHash = Data(repeating: 0xCD, count: 32)
+                let clientDataHash = defaultClientDataHash
 
                 context.touch("Touch the key to create a credential")
                 let makeParameters = CTAP2.MakeCredential.Parameters(
@@ -137,7 +164,8 @@ public enum CTAP2Scenario: CaseIterable {
                 requirements: Requirements(capabilities: [.fido2])
             ) { context in
                 var session = try await context.ctap2Session()
-                let clientDataHash = Data(repeating: 0xCD, count: 32)
+                await context.addTeardown { try await context.deleteResidentCredentials() }
+                let clientDataHash = defaultClientDataHash
 
                 context.touch("Touch the key to create a non-resident credential")
                 let nonRkParams = CTAP2.MakeCredential.Parameters(
@@ -151,7 +179,8 @@ public enum CTAP2Scenario: CaseIterable {
                     pubKeyCredParams: [.es256],
                     rk: false
                 )
-                let nonRkCredential = try await session.makeCredential(parameters: nonRkParams).value
+                let nonRkToken = try await makeCredentialToken(session, rpId: "example.com")
+                let nonRkCredential = try await session.makeCredential(parameters: nonRkParams, token: nonRkToken).value
                 context.expect(
                     ["packed", "none"].contains(nonRkCredential.attestationObject.format),
                     "expected packed or none attestation"
@@ -174,7 +203,8 @@ public enum CTAP2Scenario: CaseIterable {
                     pubKeyCredParams: [.es256],
                     rk: true
                 )
-                let rkCredential = try await session.makeCredential(parameters: rkParams).value
+                let rkToken = try await makeCredentialToken(session, rpId: "example.com")
+                let rkCredential = try await session.makeCredential(parameters: rkParams, token: rkToken).value
                 guard rkCredential.authenticatorData.attestedCredentialData != nil else {
                     context.record("Missing attested credential data for RK")
                     return
@@ -226,7 +256,7 @@ public enum CTAP2Scenario: CaseIterable {
             ) { context in
                 let session = try await context.ctap2Session()
                 let params = CTAP2.MakeCredential.Parameters(
-                    clientDataHash: Data(repeating: 0xCD, count: 32),
+                    clientDataHash: defaultClientDataHash,
                     rp: WebAuthn.RelyingParty(id: "example.com", name: "Example Corp"),
                     user: WebAuthn.User(
                         id: Data(repeating: 0x98, count: 32),
@@ -273,6 +303,7 @@ public enum CTAP2Scenario: CaseIterable {
                 requirements: Requirements(capabilities: [.fido2], minVersion: Version("5.6.0"))
             ) { context in
                 var session = try await context.ctap2Session()
+                await context.addTeardown { try await context.deleteResidentCredentials() }
                 let cases: [(label: String, algorithm: COSE.Algorithm, userByte: UInt8)] = [
                     ("EdDSA", .edDSA, 0x41),
                     ("ES384", .es384, 0x42),
@@ -285,7 +316,7 @@ public enum CTAP2Scenario: CaseIterable {
                         session = try await context.ctap2SessionAfterNFCReconnect()
                     }
                     let makeParameters = CTAP2.MakeCredential.Parameters(
-                        clientDataHash: Data(repeating: 0xCD, count: 32),
+                        clientDataHash: defaultClientDataHash,
                         rp: WebAuthn.RelyingParty(id: rpId, name: testCase.label),
                         user: WebAuthn.User(
                             id: Data(repeating: testCase.userByte, count: 32),
@@ -295,7 +326,9 @@ public enum CTAP2Scenario: CaseIterable {
                         pubKeyCredParams: [testCase.algorithm],
                         rk: true
                     )
-                    let credential = try await session.makeCredential(parameters: makeParameters).value
+                    let makeToken = try await makeCredentialToken(session, rpId: rpId)
+                    let credential = try await session.makeCredential(parameters: makeParameters, token: makeToken)
+                        .value
                     let attested = try context.require(
                         credential.authenticatorData.attestedCredentialData,
                         "\(testCase.label): makeCredential must return attested credential data"
@@ -331,9 +364,10 @@ public enum CTAP2Scenario: CaseIterable {
                 requirements: Requirements(capabilities: [.fido2], minVersion: Version("5.0.0"))
             ) { context in
                 var session = try await context.ctap2Session()
+                await context.addTeardown { try await context.deleteResidentCredentials() }
                 let rpId = "getnext.example"
                 let rp = WebAuthn.RelyingParty(id: rpId, name: "Get Next")
-                let clientDataHash = Data(repeating: 0xCD, count: 32)
+                let clientDataHash = defaultClientDataHash
                 for (index, userByte) in [UInt8(0x51), UInt8(0x52)].enumerated() {
                     context.touch("Touch the key to create resident credential \(index + 1)")
                     if index > 0 {
@@ -350,7 +384,8 @@ public enum CTAP2Scenario: CaseIterable {
                         pubKeyCredParams: [.es256],
                         rk: true
                     )
-                    _ = try await session.makeCredential(parameters: params).value
+                    let makeToken = try await makeCredentialToken(session, rpId: rpId)
+                    _ = try await session.makeCredential(parameters: params, token: makeToken).value
                 }
 
                 // No allow-list forces resident-key discovery; the sequence walks getAssertion +
@@ -379,7 +414,7 @@ public enum CTAP2Scenario: CaseIterable {
 
                 context.touch("Touch the key to create a credential")
                 let makeParameters = CTAP2.MakeCredential.Parameters(
-                    clientDataHash: Data(repeating: 0xCD, count: 32),
+                    clientDataHash: defaultClientDataHash,
                     rp: WebAuthn.RelyingParty(id: rpId, name: "UP Test"),
                     user: WebAuthn.User(
                         id: Data(repeating: 0x55, count: 32),
@@ -513,8 +548,10 @@ public enum CTAP2Scenario: CaseIterable {
                 context.expectEqual(metadata.existingCredentialsCount, 1)
 
                 let rps = try await credMgmt.rps.enumerate()
-                let credentials = try await credMgmt.credentials(for: rps[0].rpIdHash).enumerate()
-                try await credMgmt.deleteCredential(credentials[0].credentialId)
+                let rp = try context.require(rps.first, "expected one RP after creating a credential")
+                let credentials = try await credMgmt.credentials(for: rp.rpIdHash).enumerate()
+                let credential = try context.require(credentials.first, "expected one credential for the RP")
+                try await credMgmt.deleteCredential(credential.credentialId)
 
                 metadata = try await credMgmt.getMetadata()
                 context.expectEqual(metadata.existingCredentialsCount, 0)
@@ -539,8 +576,10 @@ public enum CTAP2Scenario: CaseIterable {
 
                 let credMgmt = try await getCredentialManagement(session)
                 let rps = try await credMgmt.rps.enumerate()
-                let credentials = try await credMgmt.credentials(for: rps[0].rpIdHash).enumerate()
-                let credentialId = credentials[0].credentialId
+                let rp = try context.require(rps.first, "expected one RP after creating a credential")
+                let credentials = try await credMgmt.credentials(for: rp.rpIdHash).enumerate()
+                let credential = try context.require(credentials.first, "expected one credential for the RP")
+                let credentialId = credential.credentialId
 
                 let updatedUser = WebAuthn.User(
                     id: cmTestUserId,
@@ -550,13 +589,19 @@ public enum CTAP2Scenario: CaseIterable {
                 try await credMgmt.updateUserInformation(credentialId: credentialId, user: updatedUser)
 
                 let rpsAfter = try await credMgmt.rps.enumerate()
-                let updated = try await credMgmt.credentials(for: rpsAfter[0].rpIdHash).enumerate()
-                context.expect(updated[0].user.id == cmTestUserId, "user id should be unchanged")
-                context.expect(updated[0].user.name == "UPDATED NAME", "user name should be updated")
-                context.expect(updated[0].user.displayName == "UPDATED DISPLAY NAME", "display name should be updated")
+                let rpAfter = try context.require(rpsAfter.first, "expected the RP after updating user information")
+                let updated = try await credMgmt.credentials(for: rpAfter.rpIdHash).enumerate()
+                let updatedCredential = try context.require(updated.first, "expected the updated credential")
+                context.expect(updatedCredential.user.id == cmTestUserId, "user id should be unchanged")
+                context.expect(updatedCredential.user.name == "UPDATED NAME", "user name should be updated")
+                context.expect(
+                    updatedCredential.user.displayName == "UPDATED DISPLAY NAME",
+                    "display name should be updated"
+                )
 
                 try await deleteAllCredentials(session)
             }
+        // PIN_AUTH_INVALID; identifier/credStoreState stable across reconnect, change on delete)
         case .readOnlyPpuat:
             return Scenario(
                 "CTAP2.CredentialManagement.readOnlyPpuat",
@@ -575,9 +620,11 @@ public enum CTAP2Scenario: CaseIterable {
 
                 let setupCredMgmt = try await getCredentialManagement(session)
                 let rps = try await setupCredMgmt.rps.enumerate()
-                let credentials = try await setupCredMgmt.credentials(for: rps[0].rpIdHash).enumerate()
-                let credentialId = credentials[0].credentialId
-                let rpIdHash = rps[0].rpIdHash
+                let rp = try context.require(rps.first, "expected one RP after creating a credential")
+                let credentials = try await setupCredMgmt.credentials(for: rp.rpIdHash).enumerate()
+                let credential = try context.require(credentials.first, "expected one credential for the RP")
+                let credentialId = credential.credentialId
+                let rpIdHash = rp.rpIdHash
 
                 let ppuat = try await session.getPinUVToken(
                     using: .pin(defaultTestPin),
@@ -600,11 +647,19 @@ public enum CTAP2Scenario: CaseIterable {
 
                 let info2 = try await session2.getInfo()
                 if let identifier {
-                    let identifier2 = try info2.encIdentifier!.decrypted(using: ppuat)
+                    let encryptedIdentifier = try context.require(
+                        info2.encIdentifier,
+                        "encIdentifier disappeared after re-establishment"
+                    )
+                    let identifier2 = try encryptedIdentifier.decrypted(using: ppuat)
                     context.expectEqual(identifier2, identifier, "encIdentifier consistent across re-establishment")
                 }
                 if let credStoreState {
-                    let credStoreState2 = try info2.encCredStoreState!.decrypted(using: ppuat)
+                    let encryptedState = try context.require(
+                        info2.encCredStoreState,
+                        "encCredStoreState disappeared after re-establishment"
+                    )
+                    let credStoreState2 = try encryptedState.decrypted(using: ppuat)
                     context.expectEqual(
                         credStoreState2,
                         credStoreState,
@@ -617,7 +672,11 @@ public enum CTAP2Scenario: CaseIterable {
                 try await cleanupCredMgmt.deleteCredential(credentialId)
                 if let credStoreState {
                     let info3 = try await session2.getInfo()
-                    let newState = try info3.encCredStoreState!.decrypted(using: ppuat)
+                    let encryptedState = try context.require(
+                        info3.encCredStoreState,
+                        "encCredStoreState disappeared after deleting a credential"
+                    )
+                    let newState = try encryptedState.decrypted(using: ppuat)
                     context.expect(newState != credStoreState, "credStoreState should change after a delete")
                 }
             }
@@ -665,8 +724,8 @@ public enum CTAP2Scenario: CaseIterable {
                 // Restore even if the body aborts below — a stuck alwaysUV forces UV on every later
                 // FIDO scenario. No-op when the body's own restore already ran.
                 await context.addTeardown {
-                    let current = (try? await session.getInfo())?.options.alwaysUV ?? initialAlwaysUV
-                    if current != initialAlwaysUV { try? await config.toggleAlwaysUV() }
+                    let current = try await session.getInfo().options.alwaysUV ?? initialAlwaysUV
+                    if current != initialAlwaysUV { try await config.toggleAlwaysUV() }
                 }
 
                 let newAlwaysUV = (try await session.getInfo()).options.alwaysUV ?? false
@@ -680,7 +739,7 @@ public enum CTAP2Scenario: CaseIterable {
             return Scenario(
                 "CTAP2.Config.enableEnterpriseAttestation",
                 "enable enterprise attestation",
-                requirements: Requirements(capabilities: [.fido2]),
+                requirements: Requirements(capabilities: [.fido2])
             ) { context in
                 let session = try await sessionWithPin(context)
                 let info = try await session.getInfo()
@@ -716,6 +775,13 @@ public enum CTAP2Scenario: CaseIterable {
                 }
                 guard info.forcePinChange != true else {
                     try context.skip("Force PIN change already set")
+                }
+                // The flag set below is sticky; clear it on teardown (only a PIN change does) so it
+                // doesn't block every later token-acquiring scenario.
+                await context.addTeardown {
+                    let cleanup = try await context.ctap2Session()
+                    try await cleanup.changePin(from: defaultTestPin, to: "76543211")
+                    try await cleanup.changePin(from: "76543211", to: defaultTestPin)
                 }
 
                 let token = try await session.getPinUVToken(
@@ -760,13 +826,15 @@ public enum CTAP2Scenario: CaseIterable {
                 context.expect(newInfo.minPinLength == newMinPinLength, "minPinLength should have increased")
 
                 // minPinLength must not be allowed to decrease.
-                do {
+                // python expects PIN_POLICY_VIOLATION; the SDK surfaces it as a CTAP2.SessionError.
+                await context.expectThrows(
+                    "decreasing minPinLength",
+                    matching: { $0 is CTAP2.SessionError }
+                ) {
                     try await config.setMinPINLength(newMinPINLength: currentMinPinLength)
-                    context.record("should not be able to decrease minPinLength")
-                } catch is CTAP2.SessionError {
-                    context.log("decreasing minPinLength correctly rejected")
                 }
             }
+        // python drives a wrong-PIN client and expects PIN_INVALID, here we omit UV and expect PUAT_REQUIRED)
         case .alwaysUvEnforced:
             return Scenario(
                 "CTAP2.Config.alwaysUvEnforced",
@@ -793,21 +861,20 @@ public enum CTAP2Scenario: CaseIterable {
                 try await session.config(token: token).toggleAlwaysUV()
                 // Restore even if the body aborts below — a stuck alwaysUV forces UV on every later FIDO scenario.
                 await context.addTeardown {
-                    let current = (try? await session.getInfo())?.options.alwaysUV ?? initialAlwaysUV
-                    guard current != initialAlwaysUV,
-                        let restoreToken = try? await session.getPinUVToken(
-                            using: .pin(defaultTestPin),
-                            permissions: [.authenticatorConfig]
-                        ),
-                        let restoreConfig = try? await session.config(token: restoreToken)
-                    else { return }
-                    try? await restoreConfig.toggleAlwaysUV()
+                    let current = try await session.getInfo().options.alwaysUV ?? initialAlwaysUV
+                    guard current != initialAlwaysUV else { return }
+                    let restoreToken = try await session.getPinUVToken(
+                        using: .pin(defaultTestPin),
+                        permissions: [.authenticatorConfig]
+                    )
+                    let restoreConfig = try await session.config(token: restoreToken)
+                    try await restoreConfig.toggleAlwaysUV()
                 }
                 context.expect((try await session.getInfo()).options.alwaysUV == true, "alwaysUV should be enabled")
 
                 let rpId = "auv.example"
                 let makeParameters = CTAP2.MakeCredential.Parameters(
-                    clientDataHash: Data(repeating: 0xCD, count: 32),
+                    clientDataHash: defaultClientDataHash,
                     rp: WebAuthn.RelyingParty(id: rpId, name: "Always UV"),
                     user: WebAuthn.User(
                         id: Data(repeating: 0x61, count: 32),
@@ -819,15 +886,8 @@ public enum CTAP2Scenario: CaseIterable {
                 )
 
                 // Without UV, makeCredential must be rejected with PUAT_REQUIRED under alwaysUV.
-                do {
+                await context.expectCTAPError(.puatRequired, during: "makeCredential without UV under alwaysUV") {
                     _ = try await session.makeCredential(parameters: makeParameters).value
-                    context.record("makeCredential without UV should have been rejected under alwaysUV")
-                } catch let error as CTAP2.SessionError {
-                    guard case .ctapError(.puatRequired, _) = error else {
-                        context.record("Expected PUAT_REQUIRED, got: \(error)")
-                        return
-                    }
-                    context.log("makeCredential without UV correctly rejected with PUAT_REQUIRED")
                 }
 
                 // The same makeCredential authorized with a PIN/UV token must still succeed and set the UV flag.
@@ -855,6 +915,7 @@ public enum CTAP2Scenario: CaseIterable {
                 )
             }
         // MARK: - Encrypted GetInfo fields
+        // The encrypted identifier blob re-randomizes on each read; decrypting it should yield a stable value.
         case .decryptIdentifier:
             return Scenario(
                 "CTAP2.EncryptedFields.decryptIdentifier",
@@ -873,7 +934,11 @@ public enum CTAP2Scenario: CaseIterable {
                 )
                 let identifier = try encIdentifier.decrypted(using: ppuat)
 
-                let identifier2 = try (try await session.getInfo()).encIdentifier!.decrypted(using: ppuat)
+                let encIdentifier2 = try context.require(
+                    (try await session.getInfo()).encIdentifier,
+                    "encIdentifier disappeared on the second GetInfo call"
+                )
+                let identifier2 = try encIdentifier2.decrypted(using: ppuat)
                 context.expectEqual(identifier, identifier2, "decrypted identifier consistent across GetInfo calls")
             }
         case .decryptCredStoreState:
@@ -894,9 +959,14 @@ public enum CTAP2Scenario: CaseIterable {
                 )
                 let state = try encCredStoreState.decrypted(using: ppuat)
 
-                let state2 = try (try await session.getInfo()).encCredStoreState!.decrypted(using: ppuat)
+                let encState2 = try context.require(
+                    (try await session.getInfo()).encCredStoreState,
+                    "encCredStoreState disappeared on the second GetInfo call"
+                )
+                let state2 = try encState2.decrypted(using: ppuat)
                 context.expectEqual(state, state2, "decrypted state consistent when no credentials changed")
             }
+        // identifier/credStoreState before and after reconnect)
         case .persistentToken:
             return Scenario(
                 "CTAP2.EncryptedFields.persistentToken",
@@ -918,11 +988,19 @@ public enum CTAP2Scenario: CaseIterable {
 
                 let session2 = try await context.ctap2SessionAfterNFCReconnect()
                 let info2 = try await session2.getInfo()
-                let identifier2 = try info2.encIdentifier!.decrypted(using: ppuat)
+                let encIdentifier2 = try context.require(
+                    info2.encIdentifier,
+                    "encIdentifier disappeared after re-establishment"
+                )
+                let identifier2 = try encIdentifier2.decrypted(using: ppuat)
                 context.expectEqual(identifier1, identifier2, "device identifier consistent across re-establishment")
 
                 if let credStoreState1 {
-                    let credStoreState2 = try info2.encCredStoreState!.decrypted(using: ppuat)
+                    let encCredStoreState2 = try context.require(
+                        info2.encCredStoreState,
+                        "encCredStoreState disappeared after re-establishment"
+                    )
+                    let credStoreState2 = try encCredStoreState2.decrypted(using: ppuat)
                     context.expectEqual(
                         credStoreState1,
                         credStoreState2,
@@ -964,7 +1042,11 @@ public enum CTAP2Scenario: CaseIterable {
                     }
                 }
 
-                let state1 = try (try await session.getInfo()).encCredStoreState!.decrypted(using: ppuat)
+                let encState1 = try context.require(
+                    (try await session.getInfo()).encCredStoreState,
+                    "encCredStoreState not supported"
+                )
+                let state1 = try encState1.decrypted(using: ppuat)
 
                 let makeCredToken = try await session.getPinUVToken(
                     using: .pin(defaultTestPin),
@@ -972,7 +1054,7 @@ public enum CTAP2Scenario: CaseIterable {
                     rpId: cmTestRpId
                 )
                 let params = CTAP2.MakeCredential.Parameters(
-                    clientDataHash: cmClientDataHash,
+                    clientDataHash: defaultClientDataHash,
                     rp: cmTestRp,
                     user: WebAuthn.User(id: Data([0x01, 0x02, 0x03]), name: "test", displayName: "Test"),
                     pubKeyCredParams: [.es256],
@@ -981,7 +1063,11 @@ public enum CTAP2Scenario: CaseIterable {
                 context.touch("Touch the key to create a credential")
                 _ = try await session.makeCredential(parameters: params, token: makeCredToken).value
 
-                let state2 = try (try await session.getInfo()).encCredStoreState!.decrypted(using: ppuat)
+                let encState2 = try context.require(
+                    (try await session.getInfo()).encCredStoreState,
+                    "encCredStoreState disappeared after creating a credential"
+                )
+                let state2 = try encState2.decrypted(using: ppuat)
                 context.expect(state2 != state1, "credStoreState should change after credential creation")
 
                 let deleteToken = try await session.getPinUVToken(
@@ -990,10 +1076,16 @@ public enum CTAP2Scenario: CaseIterable {
                 )
                 let credMgmt2 = try await session.credentialManagement(token: deleteToken)
                 let rps = try await credMgmt2.rps.enumerate()
-                let creds = try await credMgmt2.credentials(for: rps[0].rpIdHash).enumerate()
-                try await credMgmt2.deleteCredential(creds[0].credentialId)
+                let rp = try context.require(rps.first, "expected one RP after creating a credential")
+                let creds = try await credMgmt2.credentials(for: rp.rpIdHash).enumerate()
+                let credential = try context.require(creds.first, "expected one credential for the RP")
+                try await credMgmt2.deleteCredential(credential.credentialId)
 
-                let state3 = try (try await session.getInfo()).encCredStoreState!.decrypted(using: ppuat)
+                let encState3 = try context.require(
+                    (try await session.getInfo()).encCredStoreState,
+                    "encCredStoreState disappeared after deleting a credential"
+                )
+                let state3 = try encState3.decrypted(using: ppuat)
                 context.expect(state3 != state2, "credStoreState should change after credential deletion")
             }
         // MARK: - Bio (fingerprint)
@@ -1024,36 +1116,32 @@ public enum CTAP2Scenario: CaseIterable {
                 let templateId = try await enrollOneFingerprint(bio, context)
 
                 var enrollments = try await bio.enrollments.enumerate()
+                var enrollment = try context.require(enrollments.first, "expected one fingerprint enrollment")
                 context.expectEqual(enrollments.count, 1)
-                context.expect(enrollments[0].templateId == templateId, "enrolled template id should match")
+                context.expect(enrollment.templateId == templateId, "enrolled template id should match")
                 context.expect(
-                    enrollments[0].friendlyName == nil || enrollments[0].friendlyName == "",
+                    enrollment.friendlyName == nil || enrollment.friendlyName == "",
                     "a fresh enrollment should have no friendly name"
                 )
 
                 try await bio.setFriendlyName("Test 1", for: templateId)
                 enrollments = try await bio.enrollments.enumerate()
+                enrollment = try context.require(enrollments.first, "expected the renamed fingerprint enrollment")
                 context.expectEqual(enrollments.count, 1)
-                context.expect(enrollments[0].friendlyName == "Test 1", "friendly name should be set")
+                context.expect(enrollment.friendlyName == "Test 1", "friendly name should be set")
 
                 let sensorInfo = try await bio.getFingerprintSensorInfo()
                 if let maxLen = sensorInfo.maxTemplateFriendlyName {
                     let maxName = "Test" + String(repeating: "!", count: Int(maxLen) - 4)
                     try await bio.setFriendlyName(maxName, for: templateId)
                     enrollments = try await bio.enrollments.enumerate()
+                    enrollment = try context.require(enrollments.first, "expected the renamed fingerprint enrollment")
                     context.expectEqual(enrollments.count, 1)
-                    context.expect(enrollments[0].friendlyName == maxName, "max-length friendly name should be set")
+                    context.expect(enrollment.friendlyName == maxName, "max-length friendly name should be set")
 
                     let tooLongName = "Test" + String(repeating: "!", count: Int(maxLen) - 3)
-                    do {
+                    await context.expectCTAPError(.invalidLength, during: "setting an over-length fingerprint name") {
                         try await bio.setFriendlyName(tooLongName, for: templateId)
-                        context.record("a name exceeding the max length should be rejected")
-                    } catch let error as CTAP2.SessionError {
-                        guard case .ctapError(.invalidLength, _) = error else {
-                            context.record("Expected invalidLength, got: \(error)")
-                            return
-                        }
-                        context.log("over-length name correctly rejected with invalidLength")
                     }
                 }
 
@@ -1072,7 +1160,8 @@ public enum CTAP2Scenario: CaseIterable {
                 let (session, bio) = try await bioEnrollmentSession(context)
                 let templateId = try await enrollOneFingerprint(bio, context)
                 // Teardown, not a trailing call: a mid-body failure must not leave the enrollment behind.
-                await context.addTeardown { await cleanupEnrollment(session, templateId) }
+                await context.addTeardown { try await cleanupEnrollment(session, templateId) }
+                await context.addTeardown { try await context.deleteResidentCredentials() }
                 context.touch("Touch the enrolled fingerprint to get a UV token")
                 let uvToken = try await session.getPinUVToken(
                     using: .uv,
@@ -1080,7 +1169,7 @@ public enum CTAP2Scenario: CaseIterable {
                     rpId: "example.com"
                 )
                 let params = CTAP2.MakeCredential.Parameters(
-                    clientDataHash: Data(repeating: 0xCD, count: 32),
+                    clientDataHash: defaultClientDataHash,
                     rp: WebAuthn.RelyingParty(id: "example.com", name: "Example"),
                     user: WebAuthn.User(
                         id: Data(repeating: 0x10, count: 32),
@@ -1094,6 +1183,7 @@ public enum CTAP2Scenario: CaseIterable {
                 context.expect(credential.authenticatorData.flags.contains(.userPresent), "UP flag should be set")
                 context.expect(credential.authenticatorData.flags.contains(.userVerified), "UV flag should be set")
             }
+        // extended here to drive UV to UV_BLOCKED and confirm PIN still works afterward)
         case .uvBlocking:
             return Scenario(
                 "CTAP2.Bio.uvBlocking",
@@ -1104,7 +1194,8 @@ public enum CTAP2Scenario: CaseIterable {
                 let (session, bio) = try await bioEnrollmentSession(context)
                 let templateId = try await enrollOneFingerprint(bio, context)
                 // Teardown, not a trailing call: a mid-body failure must not leave the enrollment behind.
-                await context.addTeardown { await cleanupEnrollment(session, templateId) }
+                await context.addTeardown { try await cleanupEnrollment(session, templateId) }
+                await context.addTeardown { try await context.deleteResidentCredentials() }
 
                 let maxAttempts = 10
                 context.log("Use a DIFFERENT fingerprint (not the enrolled one) until UV is blocked")
@@ -1146,7 +1237,7 @@ public enum CTAP2Scenario: CaseIterable {
                     rpId: "example.com"
                 )
                 let params = CTAP2.MakeCredential.Parameters(
-                    clientDataHash: Data(repeating: 0xCD, count: 32),
+                    clientDataHash: defaultClientDataHash,
                     rp: WebAuthn.RelyingParty(id: "example.com", name: "Example"),
                     user: WebAuthn.User(
                         id: Data(repeating: 0x01, count: 32),
@@ -1194,7 +1285,7 @@ public enum CTAP2Scenario: CaseIterable {
                 "CTAP2.Reset.factory",
                 "factory reset clears credentials and the PIN",
                 // FIDO reset needs a wired link (USB or Lightning — both report `.usb`); NFC rejects it.
-                requirements: Requirements(capabilities: [.fido2], transports: [.usb]),
+                requirements: Requirements(capabilities: [.fido2], transports: [.usb])
             ) { context in
                 let session = try await context.ctap2Session()
                 context.touch("Touch the key to confirm the reset")
@@ -1209,6 +1300,730 @@ public enum CTAP2Scenario: CaseIterable {
 
                 let info = try await session.getInfo()
                 context.expect(info.options.clientPin != true, "PIN should be cleared after a reset")
+            }
+        // MARK: - LargeBlobs (array)
+        // a write with a non-largeBlobWrite token is rejected PIN_AUTH_INVALID)
+        case .largeBlobsArray:
+            return Scenario(
+                "CTAP2.LargeBlobs.readWrite",
+                "largeBlob array round-trips two credential-keyed blobs and rejects writes without largeBlobWrite",
+                requirements: Requirements(capabilities: [.fido2])
+            ) { context in
+                let session = try await sessionWithPin(context)
+                guard try await session.supportsLargeBlobs() else {
+                    try context.skip("LargeBlobs not supported by this authenticator")
+                }
+                await context.addTeardown { try await context.deleteResidentCredentials() }
+
+                // Two independent credential keys, obtained via the largeBlobKey extension on two RKs.
+                let key1 = try await makeLargeBlobKeyCredential(session, context, userByte: 0x71, rpId: "lb1.example")
+                let key2 = try await makeLargeBlobKeyCredential(session, context, userByte: 0x72, rpId: "lb2.example")
+                let data1 = Data("test data".utf8)
+                let data2 = Data("some other data".utf8)
+
+                // A largeBlobWrite token is reusable across writes, so mint it once for the round-trip.
+                let writeToken = try await session.getPinUVToken(
+                    using: .pin(defaultTestPin),
+                    permissions: [.largeBlobWrite]
+                )
+
+                // Clean slate, then ensure these keys hold nothing yet.
+                try await session.deleteBlob(key: key1, token: writeToken)
+                try await session.deleteBlob(key: key2, token: writeToken)
+                context.expect(try await session.getBlob(key: key1) == nil, "key1 should start empty")
+                context.expect(try await session.getBlob(key: key2) == nil, "key2 should start empty")
+
+                // Put key1/data1, read it back.
+                try await session.putBlob(key: key1, data: data1, token: writeToken)
+                context.expectEqual(try await session.getBlob(key: key1), data1, "key1 should read back data1")
+
+                // Put key2/data2, both blobs coexist.
+                try await session.putBlob(key: key2, data: data2, token: writeToken)
+                context.expectEqual(try await session.getBlob(key: key1), data1, "key1 unchanged after writing key2")
+                context.expectEqual(try await session.getBlob(key: key2), data2, "key2 should read back data2")
+
+                // Delete key1, key2 survives.
+                try await session.deleteBlob(key: key1, token: writeToken)
+                context.expect(try await session.getBlob(key: key1) == nil, "key1 should be gone after delete")
+                context.expectEqual(try await session.getBlob(key: key2), data2, "key2 should survive key1 delete")
+
+                // Delete key2, both gone.
+                try await session.deleteBlob(key: key2, token: writeToken)
+                context.expect(try await session.getBlob(key: key2) == nil, "key2 should be gone after delete")
+
+                // A write authorized with a token lacking largeBlobWrite must be rejected with pinAuthInvalid.
+                let wrongToken = try await session.getPinUVToken(
+                    using: .pin(defaultTestPin),
+                    permissions: [.credentialManagement]
+                )
+                await context.expectCTAPError(.pinAuthInvalid, during: "putBlob with a non-largeBlobWrite token") {
+                    try await session.putBlob(key: key1, data: data1, token: wrongToken)
+                }
+            }
+        // MARK: - credProtect (enforcement)
+        case .credProtectEnforcement:
+            return Scenario(
+                "CTAP2.CredProtect.enforcement",
+                "credProtect L1/L2/L3 govern discovery and usability with and without UV",
+                requirements: Requirements(capabilities: [.fido2])
+            ) { context in
+                let session = try await sessionWithPin(context)
+                guard try await CTAP2.Extension.CredProtect.isSupported(by: session) else {
+                    try context.skip("credProtect not supported by this authenticator")
+                }
+                await context.addTeardown { try await context.deleteResidentCredentials() }
+                let clientDataHash = defaultClientDataHash
+
+                // --- L1 (userVerificationOptional): discoverable + usable without UV. ---
+                _ = try await makeCredProtectCredential(
+                    session,
+                    context,
+                    level: .userVerificationOptional,
+                    userByte: 0xC1,
+                    rpId: "cp1.example"
+                )
+                context.touch("Touch the key to authenticate the L1 credential")
+                let l1Assertion = try await session.getAssertion(
+                    parameters: CTAP2.GetAssertion.Parameters(rpId: "cp1.example", clientDataHash: clientDataHash)
+                ).value
+                context.expect(
+                    l1Assertion.authenticatorData.flags.contains(.userPresent),
+                    "L1 credential should be discoverable and usable without UV"
+                )
+
+                // --- L2 (userVerificationOptionalWithCredentialIDList): hidden from RK discovery w/o UV,
+                //     usable by id w/o UV. ---
+                let cid2 = try await makeCredProtectCredential(
+                    session,
+                    context,
+                    level: .userVerificationOptionalWithCredentialIDList,
+                    userByte: 0xC2,
+                    rpId: "cp2.example"
+                )
+                await context.expectCTAPError(.noCredentials, during: "L2 RK discovery without UV") {
+                    _ = try await session.getAssertion(
+                        parameters: CTAP2.GetAssertion.Parameters(rpId: "cp2.example", clientDataHash: clientDataHash)
+                    ).value
+                }
+                context.touch("Touch the key to authenticate the L2 credential by id")
+                let l2ById = try await session.getAssertion(
+                    parameters: CTAP2.GetAssertion.Parameters(
+                        rpId: "cp2.example",
+                        clientDataHash: clientDataHash,
+                        allowList: [WebAuthn.CredentialDescriptor(id: cid2)]
+                    )
+                ).value
+                context.expect(
+                    l2ById.authenticatorData.flags.contains(.userPresent),
+                    "L2 credential should be usable by id without UV"
+                )
+
+                // --- L3 (userVerificationRequired): hidden even by id w/o UV, usable only with UV. ---
+                let cid3 = try await makeCredProtectCredential(
+                    session,
+                    context,
+                    level: .userVerificationRequired,
+                    userByte: 0xC3,
+                    rpId: "cp3.example"
+                )
+                await context.expectCTAPError(.noCredentials, during: "L3 use by id without UV") {
+                    _ = try await session.getAssertion(
+                        parameters: CTAP2.GetAssertion.Parameters(
+                            rpId: "cp3.example",
+                            clientDataHash: clientDataHash,
+                            allowList: [WebAuthn.CredentialDescriptor(id: cid3)]
+                        )
+                    ).value
+                }
+                let uvToken = try await session.getPinUVToken(
+                    using: .pin(defaultTestPin),
+                    permissions: [.getAssertion],
+                    rpId: "cp3.example"
+                )
+                context.touch("Touch the key to authenticate the L3 credential with UV")
+                let l3WithUv = try await session.getAssertion(
+                    parameters: CTAP2.GetAssertion.Parameters(
+                        rpId: "cp3.example",
+                        clientDataHash: clientDataHash,
+                        allowList: [WebAuthn.CredentialDescriptor(id: cid3)]
+                    ),
+                    token: uvToken
+                ).value
+                context.expect(
+                    l3WithUv.authenticatorData.flags.contains(.userVerified),
+                    "L3 credential should be usable with UV and set the UV flag"
+                )
+            }
+        // MARK: - hmac-secret (raw CTAP2 extension)
+        case .hmacSecret:
+            return Scenario(
+                "CTAP2.Extension.hmacSecret",
+                "hmac-secret round-trips deterministic secrets with one and two salts",
+                requirements: Requirements(capabilities: [.fido2])
+            ) { context in
+                let session = try await sessionWithPin(context)
+                guard try await CTAP2.Extension.HmacSecret.isSupported(by: session) else {
+                    try context.skip("hmac-secret not supported")
+                }
+                await context.addTeardown { try await context.deleteResidentCredentials() }
+
+                let hmac = try await CTAP2.Extension.HmacSecret(session: session)
+                let token = try await session.getPinUVToken(
+                    using: .pin(defaultTestPin),
+                    permissions: [.makeCredential],
+                    rpId: "hmac.example"
+                )
+                let params = CTAP2.MakeCredential.Parameters(
+                    clientDataHash: defaultClientDataHash,
+                    rp: WebAuthn.RelyingParty(id: "hmac.example", name: "HMAC Test"),
+                    user: WebAuthn.User(
+                        id: Data(repeating: 0xA1, count: 32),
+                        name: "hmac@example.com",
+                        displayName: "HMAC User"
+                    ),
+                    pubKeyCredParams: [.es256],
+                    extensions: [hmac.makeCredential.input()],
+                    rk: true
+                )
+                context.touch("Touch the key to create the hmac-secret credential")
+                let mcResponse = try await session.makeCredential(parameters: params, token: token).value
+                let mcResult = try hmac.makeCredential.output(from: mcResponse)
+                context.expect(mcResult == .enabled, "hmac-secret should be enabled on the credential")
+
+                let credentialId = try context.require(
+                    mcResponse.authenticatorData.attestedCredentialData?.credentialId,
+                    "makeCredential must return a credential id"
+                )
+
+                // First assertion: one salt.
+                let salt1 = randomBytes(count: 32)
+                let gaToken = try await session.getPinUVToken(
+                    using: .pin(defaultTestPin),
+                    permissions: [.getAssertion],
+                    rpId: "hmac.example"
+                )
+                let gaParams = CTAP2.GetAssertion.Parameters(
+                    rpId: "hmac.example",
+                    clientDataHash: defaultClientDataHash,
+                    allowList: [.init(id: credentialId)],
+                    extensions: [try hmac.getAssertion.input(salt1: salt1)]
+                )
+                context.touch("Touch the key for first assertion")
+                let ga1 = try await session.getAssertion(parameters: gaParams, token: gaToken).value
+                let secrets1 = try context.require(
+                    try hmac.getAssertion.output(from: ga1),
+                    "first assertion should return hmac-secret output"
+                )
+
+                // Second assertion: two salts.
+                let salt2 = randomBytes(count: 32)
+                let gaToken2 = try await session.getPinUVToken(
+                    using: .pin(defaultTestPin),
+                    permissions: [.getAssertion],
+                    rpId: "hmac.example"
+                )
+                let gaParams2 = CTAP2.GetAssertion.Parameters(
+                    rpId: "hmac.example",
+                    clientDataHash: defaultClientDataHash,
+                    allowList: [.init(id: credentialId)],
+                    extensions: [try hmac.getAssertion.input(salt1: salt1, salt2: salt2)]
+                )
+                context.touch("Touch the key for second assertion")
+                let ga2 = try await session.getAssertion(parameters: gaParams2, token: gaToken2).value
+                let secrets2 = try context.require(
+                    try hmac.getAssertion.output(from: ga2),
+                    "second assertion should return hmac-secret output"
+                )
+
+                context.expectEqual(secrets2.first, secrets1.first, "same salt1 should produce the same first secret")
+                let second = try context.require(secrets2.second, "two-salt assertion should return a second secret")
+                context.expect(second != secrets1.first, "different salt should produce a different secret")
+            }
+        // MARK: - CredentialManagement (missing permissions)
+        case .credManMissingPermissions:
+            return Scenario(
+                "CTAP2.CredentialManagement.missingPermissions",
+                "credential management with a wrong-permission token is rejected with pinAuthInvalid",
+                requirements: Requirements(capabilities: [.fido2])
+            ) { context in
+                let session = try await sessionWithPin(context)
+                let info = try await session.getInfo()
+                guard info.options.credentialManagement == true else {
+                    try context.skip("credentialManagement not supported")
+                }
+
+                let wrongToken = try await session.getPinUVToken(
+                    using: .pin(defaultTestPin),
+                    permissions: [.largeBlobWrite]
+                )
+                let credMgmt = try await session.credentialManagement(token: wrongToken)
+                await context.expectCTAPError(.pinAuthInvalid, during: "getMetadata with a largeBlobWrite token") {
+                    _ = try await credMgmt.getMetadata()
+                }
+            }
+        // MARK: - EncryptedFields (identifier re-randomizes)
+        case .encIdentifierChanges:
+            return Scenario(
+                "CTAP2.EncryptedFields.encIdentifierChanges",
+                "the raw encIdentifier re-randomizes between consecutive getInfo calls",
+                requirements: Requirements(capabilities: [.fido2])
+            ) { context in
+                let session = try await sessionWithPin(context)
+                let info1 = try await session.getInfo()
+                guard let enc1 = info1.encIdentifier else {
+                    try context.skip("encIdentifier not supported")
+                }
+                let enc2 = try context.require(
+                    (try await session.getInfo()).encIdentifier,
+                    "second getInfo should also return encIdentifier"
+                )
+                context.expect(
+                    enc1.encryptedData != enc2.encryptedData,
+                    "raw encIdentifier should differ between two getInfo calls"
+                )
+            }
+        // MARK: - Config (enterprise attestation via WebAuthn client)
+        case .enterpriseAttestationPlatform:
+            return Scenario(
+                "CTAP2.Config.enterpriseAttestationPlatform",
+                "platform-facilitated enterprise attestation yields a distinct attestation certificate",
+                requirements: Requirements(capabilities: [.fido2])
+            ) { context in
+                let session = try await sessionWithPin(context)
+                let info = try await session.getInfo()
+                guard info.options.authenticatorConfig == true else {
+                    try context.skip("authenticatorConfig not supported")
+                }
+                guard info.options.supportsEnterpriseAttestation else {
+                    try context.skip("Enterprise attestation not supported")
+                }
+
+                // Baseline: direct attestation certificate before enabling EP.
+                let baselineClient = WebAuthn.Client(
+                    session: session,
+                    origin: try WebAuthn.Origin("https://example.com"),
+                    isPublicSuffix: { _ in false }
+                )
+                let baselineOptions = WebAuthn.Registration.Options(
+                    challenge: randomBytes(count: 32),
+                    rp: .init(id: "example.com", name: "EP Test"),
+                    user: .init(
+                        id: randomBytes(count: 32),
+                        name: "ep-baseline@example.com",
+                        displayName: "EP Baseline"
+                    ),
+                    attestation: .direct
+                )
+                context.touch("Touch the key for baseline credential")
+                let baselineResponse = try await baselineClient.makeCredential(
+                    baselineOptions,
+                    authorization: .pin(defaultTestPin)
+                ).value
+                let baselineCert = baselineResponse.rawAttestationObject
+
+                // Enable enterprise attestation.
+                let configToken = try await session.getPinUVToken(
+                    using: .pin(defaultTestPin),
+                    permissions: [.authenticatorConfig]
+                )
+                try await session.config(token: configToken).enableEnterpriseAttestation()
+
+                // Enterprise attestation with the RP in the platform list.
+                let epClient = WebAuthn.Client(
+                    session: session,
+                    origin: try WebAuthn.Origin("https://example.com"),
+                    enterpriseRpIds: ["example.com"],
+                    isPublicSuffix: { _ in false }
+                )
+                let epOptions = WebAuthn.Registration.Options(
+                    challenge: randomBytes(count: 32),
+                    rp: .init(id: "example.com", name: "EP Test"),
+                    user: .init(
+                        id: randomBytes(count: 32),
+                        name: "ep-enterprise@example.com",
+                        displayName: "EP Enterprise"
+                    ),
+                    attestation: .enterprise
+                )
+                context.touch("Touch the key for enterprise credential")
+                let epResponse = try await epClient.makeCredential(
+                    epOptions,
+                    authorization: .pin(defaultTestPin)
+                ).value
+                let epCert = epResponse.rawAttestationObject
+
+                context.expect(
+                    baselineCert != epCert,
+                    "enterprise attestation should produce a different attestation object than direct"
+                )
+            }
+        // MARK: - previewSign (raw CTAP2 extension — error cases)
+        case .previewSignUnsupportedAlgorithm:
+            return Scenario(
+                "CTAP2.PreviewSign.unsupportedAlgorithm",
+                "previewSign rejects an unsupported algorithm with UNSUPPORTED_ALGORITHM",
+                requirements: Requirements(capabilities: [.fido2])
+            ) { context in
+                let session = try await sessionWithPin(context)
+                guard try await CTAP2.Extension.PreviewSign.isSupported(by: session) else {
+                    try context.skip("previewSign not supported")
+                }
+                let previewSign = try await CTAP2.Extension.PreviewSign(session: session)
+                let token = try await session.getPinUVToken(
+                    using: .pin(defaultTestPin),
+                    permissions: [.makeCredential]
+                )
+                let params = CTAP2.MakeCredential.Parameters(
+                    clientDataHash: defaultClientDataHash,
+                    rp: WebAuthn.RelyingParty(id: "example.com", name: "PS Test"),
+                    user: WebAuthn.User(
+                        id: randomBytes(count: 32),
+                        name: "ps@example.com",
+                        displayName: "PS"
+                    ),
+                    pubKeyCredParams: [.es256],
+                    extensions: [previewSign.makeCredential.input(algorithms: [.init(rawValue: -18)], flags: 0)],
+                    rk: false
+                )
+                context.touch("Touch the key")
+                await context.expectCTAPError(
+                    .unsupportedAlgorithm,
+                    during: "makeCredential with unsupported previewSign algorithm"
+                ) {
+                    _ = try await session.makeCredential(parameters: params, token: token).value
+                }
+            }
+        case .previewSignInvalidFlags:
+            return Scenario(
+                "CTAP2.PreviewSign.invalidFlags",
+                "previewSign rejects invalid flag combinations with INVALID_OPTION",
+                requirements: Requirements(capabilities: [.fido2])
+            ) { context in
+                let session = try await sessionWithPin(context)
+                guard try await CTAP2.Extension.PreviewSign.isSupported(by: session) else {
+                    try context.skip("previewSign not supported")
+                }
+                let previewSign = try await CTAP2.Extension.PreviewSign(session: session)
+
+                let validFlags: Set<UInt8> = [0b000, 0b001, 0b101]
+                let invalidSamples: [UInt8] = [0b010, 0b011, 0b100, 0b110, 0b111, 0x10, 0x80, 0xFF]
+
+                for flags in invalidSamples {
+                    guard !validFlags.contains(flags) else { continue }
+                    let token = try await session.getPinUVToken(
+                        using: .pin(defaultTestPin),
+                        permissions: [.makeCredential]
+                    )
+                    let params = CTAP2.MakeCredential.Parameters(
+                        clientDataHash: defaultClientDataHash,
+                        rp: WebAuthn.RelyingParty(id: "example.com", name: "PS Flags"),
+                        user: WebAuthn.User(
+                            id: randomBytes(count: 32),
+                            name: "psflags@example.com",
+                            displayName: "PS Flags"
+                        ),
+                        pubKeyCredParams: [.es256],
+                        extensions: [
+                            previewSign.makeCredential.input(
+                                algorithms: [.esp256, .es256],
+                                flags: flags
+                            )
+                        ],
+                        rk: false
+                    )
+                    context.touch("Touch the key (flags=\(flags))")
+                    await context.expectCTAPError(
+                        .invalidOption,
+                        during: "makeCredential with previewSign flags=\(flags)"
+                    ) {
+                        _ = try await session.makeCredential(parameters: params, token: token).value
+                    }
+                }
+            }
+        case .previewSignMissingParameter:
+            return Scenario(
+                "CTAP2.PreviewSign.missingParameter",
+                "previewSign getAssertion rejects a missing keyHandle or TBS with INVALID_OPTION",
+                requirements: Requirements(capabilities: [.fido2])
+            ) { context in
+                let session = try await sessionWithPin(context)
+                guard try await CTAP2.Extension.PreviewSign.isSupported(by: session) else {
+                    try context.skip("previewSign not supported")
+                }
+                let previewSign = try await CTAP2.Extension.PreviewSign(session: session)
+
+                let mcToken = try await session.getPinUVToken(
+                    using: .pin(defaultTestPin),
+                    permissions: [.makeCredential]
+                )
+                let mcParams = CTAP2.MakeCredential.Parameters(
+                    clientDataHash: defaultClientDataHash,
+                    rp: WebAuthn.RelyingParty(id: "example.com", name: "PS Missing"),
+                    user: WebAuthn.User(
+                        id: randomBytes(count: 32),
+                        name: "psmissing@example.com",
+                        displayName: "PS Missing"
+                    ),
+                    pubKeyCredParams: [.es256],
+                    extensions: [previewSign.makeCredential.input(algorithms: [.esp256, .es256], flags: 0)],
+                    rk: false
+                )
+                context.touch("Touch the key to generate a previewSign key")
+                let mcResponse = try await session.makeCredential(parameters: mcParams, token: mcToken).value
+                let generatedKey = try context.require(
+                    previewSign.makeCredential.output(from: mcResponse),
+                    "previewSign should return a generated key"
+                )
+                let credentialId = try context.require(
+                    mcResponse.authenticatorData.attestedCredentialData?.credentialId,
+                    "makeCredential must return a credential id"
+                )
+
+                let tbs = randomBytes(count: 32)
+
+                // Missing keyHandle: pass empty data as keyHandle.
+                let gaTokenKH = try await session.getPinUVToken(
+                    using: .pin(defaultTestPin),
+                    permissions: [.getAssertion],
+                    rpId: "example.com"
+                )
+                let missingKH = CTAP2.GetAssertion.Parameters(
+                    rpId: "example.com",
+                    clientDataHash: defaultClientDataHash,
+                    allowList: [.init(id: credentialId)],
+                    extensions: [
+                        previewSign.getAssertion.input(keyHandle: Data(), tbs: tbs)
+                    ],
+                    up: false
+                )
+                await context.expectCTAPError(
+                    .invalidOption,
+                    .invalidCredential,
+                    during: "getAssertion with empty previewSign keyHandle"
+                ) {
+                    _ = try await session.getAssertion(parameters: missingKH, token: gaTokenKH).value
+                }
+
+                // Missing TBS: pass empty data as TBS.
+                let gaTokenTBS = try await session.getPinUVToken(
+                    using: .pin(defaultTestPin),
+                    permissions: [.getAssertion],
+                    rpId: "example.com"
+                )
+                let missingTBS = CTAP2.GetAssertion.Parameters(
+                    rpId: "example.com",
+                    clientDataHash: defaultClientDataHash,
+                    allowList: [.init(id: credentialId)],
+                    extensions: [
+                        previewSign.getAssertion.input(
+                            keyHandle: generatedKey.keyHandle,
+                            tbs: Data()
+                        )
+                    ],
+                    up: false
+                )
+                await context.expectCTAPError(
+                    .invalidOption,
+                    .invalidCredential,
+                    during: "getAssertion with empty previewSign TBS"
+                ) {
+                    _ = try await session.getAssertion(parameters: missingTBS, token: gaTokenTBS).value
+                }
+            }
+        case .previewSignUpRequired:
+            return Scenario(
+                "CTAP2.PreviewSign.upRequired",
+                "a previewSign key created with the UP flag rejects assertion without user presence",
+                requirements: Requirements(capabilities: [.fido2])
+            ) { context in
+                let session = try await sessionWithPin(context)
+                guard try await CTAP2.Extension.PreviewSign.isSupported(by: session) else {
+                    try context.skip("previewSign not supported")
+                }
+                let previewSign = try await CTAP2.Extension.PreviewSign(session: session)
+
+                let mcToken = try await session.getPinUVToken(
+                    using: .pin(defaultTestPin),
+                    permissions: [.makeCredential]
+                )
+                let mcParams = CTAP2.MakeCredential.Parameters(
+                    clientDataHash: defaultClientDataHash,
+                    rp: WebAuthn.RelyingParty(id: "example.com", name: "PS UP"),
+                    user: WebAuthn.User(
+                        id: randomBytes(count: 32),
+                        name: "psup@example.com",
+                        displayName: "PS UP"
+                    ),
+                    pubKeyCredParams: [.es256],
+                    extensions: [previewSign.makeCredential.input(algorithms: [.esp256, .es256], flags: 0b001)],
+                    rk: false
+                )
+                context.touch("Touch the key to create a UP-required previewSign key")
+                let mcResponse = try await session.makeCredential(parameters: mcParams, token: mcToken).value
+                let generatedKey = try context.require(
+                    previewSign.makeCredential.output(from: mcResponse),
+                    "previewSign should return a generated key"
+                )
+                let credentialId = try context.require(
+                    mcResponse.authenticatorData.attestedCredentialData?.credentialId,
+                    "makeCredential must return a credential id"
+                )
+
+                let gaToken = try await session.getPinUVToken(
+                    using: .pin(defaultTestPin),
+                    permissions: [.getAssertion],
+                    rpId: "example.com"
+                )
+                let gaParams = CTAP2.GetAssertion.Parameters(
+                    rpId: "example.com",
+                    clientDataHash: defaultClientDataHash,
+                    allowList: [.init(id: credentialId)],
+                    extensions: [
+                        previewSign.getAssertion.input(
+                            keyHandle: generatedKey.keyHandle,
+                            tbs: randomBytes(count: 32)
+                        )
+                    ],
+                    up: false
+                )
+                await context.expectCTAPError(
+                    .upRequired,
+                    during: "getAssertion without UP on a UP-required previewSign key"
+                ) {
+                    _ = try await session.getAssertion(parameters: gaParams, token: gaToken).value
+                }
+            }
+        case .previewSignUvRequired:
+            return Scenario(
+                "CTAP2.PreviewSign.uvRequired",
+                "a previewSign key created with UP+UV flags rejects assertion without a UV token",
+                requirements: Requirements(capabilities: [.fido2])
+            ) { context in
+                let session = try await sessionWithPin(context)
+                guard try await CTAP2.Extension.PreviewSign.isSupported(by: session) else {
+                    try context.skip("previewSign not supported")
+                }
+                let previewSign = try await CTAP2.Extension.PreviewSign(session: session)
+
+                let mcToken = try await session.getPinUVToken(
+                    using: .pin(defaultTestPin),
+                    permissions: [.makeCredential]
+                )
+                let mcParams = CTAP2.MakeCredential.Parameters(
+                    clientDataHash: defaultClientDataHash,
+                    rp: WebAuthn.RelyingParty(id: "example.com", name: "PS UV"),
+                    user: WebAuthn.User(
+                        id: randomBytes(count: 32),
+                        name: "psuv@example.com",
+                        displayName: "PS UV"
+                    ),
+                    pubKeyCredParams: [.es256],
+                    extensions: [previewSign.makeCredential.input(algorithms: [.esp256, .es256], flags: 0b101)],
+                    rk: false
+                )
+                context.touch("Touch the key to create a UV-required previewSign key")
+                let mcResponse = try await session.makeCredential(parameters: mcParams, token: mcToken).value
+                let generatedKey = try context.require(
+                    previewSign.makeCredential.output(from: mcResponse),
+                    "previewSign should return a generated key"
+                )
+                let credentialId = try context.require(
+                    mcResponse.authenticatorData.attestedCredentialData?.credentialId,
+                    "makeCredential must return a credential id"
+                )
+
+                let gaToken = try await session.getPinUVToken(
+                    using: .pin(defaultTestPin),
+                    permissions: [.getAssertion],
+                    rpId: "example.com"
+                )
+                let gaParams = CTAP2.GetAssertion.Parameters(
+                    rpId: "example.com",
+                    clientDataHash: defaultClientDataHash,
+                    allowList: [.init(id: credentialId)],
+                    extensions: [
+                        previewSign.getAssertion.input(
+                            keyHandle: generatedKey.keyHandle,
+                            tbs: randomBytes(count: 32)
+                        )
+                    ],
+                    up: true
+                )
+                await context.expectCTAPError(
+                    .puatRequired,
+                    during: "getAssertion without UV on a UV-required previewSign key"
+                ) {
+                    _ = try await session.getAssertion(parameters: gaParams, token: gaToken).value
+                }
+            }
+        // MARK: - previewSign (generate and sign round-trip)
+        case .previewSignGenerateAndSign:
+            return Scenario(
+                "CTAP2.PreviewSign.generateAndSign",
+                "previewSign generates a key and produces a non-empty signature",
+                requirements: Requirements(capabilities: [.fido2])
+            ) { context in
+                let session = try await sessionWithPin(context)
+                guard try await CTAP2.Extension.PreviewSign.isSupported(by: session) else {
+                    try context.skip("previewSign not supported")
+                }
+                let previewSign = try await CTAP2.Extension.PreviewSign(session: session)
+
+                let mcToken = try await session.getPinUVToken(
+                    using: .pin(defaultTestPin),
+                    permissions: [.makeCredential]
+                )
+                let mcParams = CTAP2.MakeCredential.Parameters(
+                    clientDataHash: defaultClientDataHash,
+                    rp: WebAuthn.RelyingParty(id: "example.com", name: "PS Sign"),
+                    user: WebAuthn.User(
+                        id: randomBytes(count: 32),
+                        name: "pssign@example.com",
+                        displayName: "PS Sign"
+                    ),
+                    pubKeyCredParams: [.es256],
+                    extensions: [previewSign.makeCredential.input(algorithms: [.esp256, .es256], flags: 0)],
+                    rk: false
+                )
+                context.touch("Touch the key to generate a previewSign key")
+                let mcResponse = try await session.makeCredential(parameters: mcParams, token: mcToken).value
+                let generatedKey = try context.require(
+                    previewSign.makeCredential.output(from: mcResponse),
+                    "previewSign should return a generated key"
+                )
+                context.expect(!generatedKey.keyHandle.isEmpty, "keyHandle should not be empty")
+                context.expect(!generatedKey.publicKey.isEmpty, "publicKey should not be empty")
+                context.expect(!generatedKey.attestationObject.isEmpty, "attestationObject should not be empty")
+
+                let credentialId = try context.require(
+                    mcResponse.authenticatorData.attestedCredentialData?.credentialId,
+                    "makeCredential must return a credential id"
+                )
+
+                let tbs = randomBytes(count: 32)
+                let gaToken = try await session.getPinUVToken(
+                    using: .pin(defaultTestPin),
+                    permissions: [.getAssertion],
+                    rpId: "example.com"
+                )
+                let gaParams = CTAP2.GetAssertion.Parameters(
+                    rpId: "example.com",
+                    clientDataHash: defaultClientDataHash,
+                    allowList: [.init(id: credentialId)],
+                    extensions: [
+                        previewSign.getAssertion.input(
+                            keyHandle: generatedKey.keyHandle,
+                            tbs: tbs
+                        )
+                    ],
+                    up: false
+                )
+                let gaResponse = try await session.getAssertion(parameters: gaParams, token: gaToken).value
+                let signature = try context.require(
+                    previewSign.getAssertion.output(from: gaResponse),
+                    "getAssertion should return a previewSign signature"
+                )
+                context.expect(!signature.isEmpty, "signature should not be empty")
             }
         }
     }
@@ -1269,20 +2084,13 @@ public enum CTAP2Scenario: CaseIterable {
             try await session.changePin(from: defaultTestPin, to: otherPin, protocol: pinProtocol)
 
             // The old PIN must now be rejected and decrement the counter.
-            do {
+            await context.expectCTAPError(.pinInvalid, during: "using the old PIN after a change") {
                 _ = try await session.getPinUVToken(
                     using: .pin(defaultTestPin),
                     permissions: [.makeCredential, .getAssertion],
                     rpId: "localhost",
                     protocol: pinProtocol
                 )
-                context.record("old PIN should have been rejected")
-            } catch let error as CTAP2.SessionError {
-                guard case .ctapError(.pinInvalid, _) = error else {
-                    context.record("Expected PIN_INVALID, got: \(error)")
-                    return
-                }
-                context.log("old PIN rejected")
             }
             let afterWrong = try await session.getPinRetries(protocol: pinProtocol)
             context.expectEqual(afterWrong.retries, 7, "retries should decrement after a wrong PIN")
@@ -1314,20 +2122,16 @@ public enum CTAP2Scenario: CaseIterable {
 
             // On a device without pinUvAuthToken, requesting a UV token must throw featureNotSupported.
             guard info.options.pinUVAuthToken == true else {
-                do {
+                await context.expectThrows(
+                    "requesting a UV token on a non-UV device",
+                    matching: { if case CTAP2.SessionError.featureNotSupported = $0 { true } else { false } }
+                ) {
                     _ = try await session.getPinUVToken(
                         using: .uv,
                         permissions: [.makeCredential, .getAssertion],
                         rpId: "example.com",
                         protocol: pinProtocol
                     )
-                    context.record("should have thrown featureNotSupported")
-                } catch let error as CTAP2.SessionError {
-                    guard case .featureNotSupported = error else {
-                        context.record("Expected featureNotSupported, got: \(error)")
-                        return
-                    }
-                    context.log("correctly threw featureNotSupported on a non-UV device")
                 }
                 return
             }
@@ -1361,15 +2165,8 @@ public enum CTAP2Scenario: CaseIterable {
                 try context.skip("Device doesn't enforce PIN complexity")
             }
 
-            do {
+            await context.expectCTAPError(.pinPolicyViolation, during: "changing to a weak PIN") {
                 try await session.changePin(from: defaultTestPin, to: "33333333", protocol: pinProtocol)
-                context.record("weak PIN should have been rejected")
-            } catch let error as CTAP2.SessionError {
-                guard case .ctapError(.pinPolicyViolation, _) = error else {
-                    context.record("Expected PIN_POLICY_VIOLATION, got: \(error)")
-                    return
-                }
-                context.log("weak PIN correctly rejected with PIN_POLICY_VIOLATION")
             }
 
             // A policy violation must not decrement the retry counter.
@@ -1384,7 +2181,7 @@ public enum CTAP2Scenario: CaseIterable {
         return Scenario(
             isV1 ? "CTAP2.ClientPIN.retryExhaustionV1" : "CTAP2.ClientPIN.retryExhaustionV2",
             "clientPIN retry exhaustion soft-locks the authenticator (\(suffix))",
-            requirements: Requirements(capabilities: [.fido2]),
+            requirements: Requirements(capabilities: [.fido2])
         ) { context in
             let session = try await sessionWithPin(context)
             let wrongPin = "99999999"
@@ -1400,22 +2197,13 @@ public enum CTAP2Scenario: CaseIterable {
 
             // 8 -> 7 -> 6 -> 5 (the third wrong attempt may soft-lock).
             for expected in [7, 6, 5] {
-                do {
+                await context.expectCTAPError(.pinInvalid, .pinAuthBlocked, during: "wrong PIN attempt") {
                     _ = try await session.getPinUVToken(
                         using: .pin(wrongPin),
                         permissions: [.makeCredential, .getAssertion],
                         rpId: "localhost",
                         protocol: pinProtocol
                     )
-                    context.record("wrong PIN should have been rejected")
-                } catch let error as CTAP2.SessionError {
-                    if case .ctapError(.pinInvalid, _) = error {
-                        // expected
-                    } else if case .ctapError(.pinAuthBlocked, _) = error {
-                        // expected (soft-lock)
-                    } else {
-                        context.record("Expected PIN_INVALID or PIN_AUTH_BLOCKED, got: \(error)")
-                    }
                 }
                 retries = try await session.getPinRetries(protocol: pinProtocol)
                 context.expectEqual(retries.retries, expected)
@@ -1423,36 +2211,24 @@ public enum CTAP2Scenario: CaseIterable {
 
             // Soft-locked: the counter freezes and even the correct PIN is blocked.
             let frozen = retries.retries
-            do {
+            await context.expectCTAPError(.pinAuthBlocked, during: "wrong PIN while soft-locked") {
                 _ = try await session.getPinUVToken(
                     using: .pin(wrongPin),
                     permissions: [.makeCredential, .getAssertion],
                     rpId: "localhost",
                     protocol: pinProtocol
                 )
-                context.record("wrong PIN should be blocked")
-            } catch let error as CTAP2.SessionError {
-                guard case .ctapError(.pinAuthBlocked, _) = error else {
-                    context.record("Expected PIN_AUTH_BLOCKED, got: \(error)")
-                    return
-                }
             }
             retries = try await session.getPinRetries(protocol: pinProtocol)
             context.expectEqual(retries.retries, frozen)
 
-            do {
+            await context.expectCTAPError(.pinAuthBlocked, during: "correct PIN while soft-locked") {
                 _ = try await session.getPinUVToken(
                     using: .pin(defaultTestPin),
                     permissions: [.makeCredential, .getAssertion],
                     rpId: "localhost",
                     protocol: pinProtocol
                 )
-                context.record("correct PIN should be blocked while soft-locked")
-            } catch let error as CTAP2.SessionError {
-                guard case .ctapError(.pinAuthBlocked, _) = error else {
-                    context.record("Expected PIN_AUTH_BLOCKED, got: \(error)")
-                    return
-                }
             }
             retries = try await session.getPinRetries(protocol: pinProtocol)
             context.expectEqual(retries.retries, frozen)
@@ -1461,9 +2237,265 @@ public enum CTAP2Scenario: CaseIterable {
     }
 }
 
+// MARK: - Parameterized per-algorithm make + assert family
+
+extension CTAP2Scenario {
+
+    /// Fans make-then-assert out over each COSE algorithm the WebAuthn client can register. For each
+    /// algorithm: register a single-algorithm credential via the WebAuthn client, assert the credential
+    /// public key reports that algorithm, then get an assertion by allow-list to the created id and
+    /// confirm it round-trips.
+    static var parameterizedScenarios: [Scenario] {
+        makeAssertScenarios + credManagementProtocolScenarios + largeBlobsProtocolScenarios
+    }
+
+    private struct MakeAssertAlgorithm: ScenarioParameter {
+        let idSuffix: String
+        let displayName: String
+        let requirements: Requirements
+        let algorithm: COSE.Algorithm
+
+        init(_ idSuffix: String, _ algorithm: COSE.Algorithm, minVersion: Version? = nil, maxVersion: Version? = nil) {
+            self.idSuffix = idSuffix
+            self.displayName = "make + assert round-trips a \(idSuffix) credential through the WebAuthn client"
+            self.requirements = Requirements(
+                capabilities: [.fido2],
+                minVersion: minVersion,
+                maxVersion: maxVersion
+            )
+            self.algorithm = algorithm
+        }
+    }
+
+    private static var makeAssertScenarios: [Scenario] {
+        let algorithms: [MakeAssertAlgorithm] = [
+            MakeAssertAlgorithm("es256", .es256),
+            // EdDSA (Ed25519) needs YubiKey 5.2+.
+            MakeAssertAlgorithm("edDSA", .edDSA, minVersion: Version("5.2.0")),
+            // ES384 (P-384) needs YubiKey 5.6+.
+            MakeAssertAlgorithm("es384", .es384, minVersion: Version("5.6.0")),
+            // RS256 is only available on YubiKey firmware 5.1.X and below.
+            MakeAssertAlgorithm("rs256", .rs256, maxVersion: Version("5.1.99")),
+        ]
+        return Scenario.parameterized("CTAP2.Credentials.makeAssert", over: algorithms) { context, algorithm in
+            let session = try await sessionWithPin(context)
+
+            // The authenticator may not advertise this algorithm even when firmware gating passes; skip
+            // rather than fail when the device can't honor it.
+            let info = try await session.getInfo()
+            if !info.algorithms.isEmpty, !info.algorithms.contains(algorithm.algorithm) {
+                try context.skip("\(algorithm.idSuffix) not advertised by this authenticator")
+            }
+
+            let client = WebAuthn.Client(
+                session: session,
+                origin: try WebAuthn.Origin("https://example.com"),
+                isPublicSuffix: { _ in false }
+            )
+
+            let createOptions = WebAuthn.Registration.Options(
+                challenge: randomBytes(count: 32),
+                rp: .init(id: "example.com", name: "Example RP"),
+                user: .init(
+                    id: randomBytes(count: 32),
+                    name: "makeassert@example.com",
+                    displayName: "Make Assert User"
+                ),
+                residentKey: .discouraged,
+                pubKeyCredParams: [algorithm.algorithm]
+            )
+
+            context.touch("Touch the key to create the \(algorithm.idSuffix) credential")
+            let createResponse: WebAuthn.Registration.Response
+            do {
+                createResponse = try await client.makeCredential(createOptions, authorization: .pin(defaultTestPin))
+                    .value
+            } catch let error as WebAuthn.ClientError {
+                if case .unsupportedAlgorithm = error {
+                    try context.skip("\(algorithm.idSuffix) not supported by this authenticator")
+                }
+                throw error
+            }
+
+            let keyAlgorithm = try context.require(
+                createResponse.publicKey.algorithm,
+                "credential public key should carry an algorithm"
+            )
+            context.expectEqual(
+                keyAlgorithm,
+                algorithm.algorithm,
+                "credential public key should use the requested algorithm"
+            )
+
+            let requestOptions = WebAuthn.Authentication.Options(
+                challenge: randomBytes(count: 32),
+                rpId: "example.com",
+                allowCredentials: [.init(id: createResponse.credentialId)]
+            )
+
+            context.touch("Touch the key to authenticate (\(algorithm.idSuffix))")
+            let matches = try await client.getAssertion(requestOptions, authorization: .pin(defaultTestPin)).value
+            let assertResponse = try context.require(
+                matches.first { $0.credentialId == createResponse.credentialId },
+                "expected an assertion for the created \(algorithm.idSuffix) credential"
+            )
+            context.expect(assertResponse.signature.count > 0, "signature should be present")
+        }
+    }
+
+    // MARK: PIN/UV protocol parametrization
+
+    /// One PIN/UV protocol (`.v1` / `.v2`). CredentialManagement and largeBlob suites run under both;
+    /// the protocol rides on the token (`token.protocolVersion`), so minting the token with an explicit
+    /// `protocol:` forces every operation built from it to use it.
+    private struct PinProtocolCase: ScenarioParameter {
+        let idSuffix: String
+        let displayName: String
+        let requirements: Requirements
+        let pinProtocol: CTAP2.ClientPin.ProtocolVersion
+
+        init(_ pinProtocol: CTAP2.ClientPin.ProtocolVersion, _ describing: String) {
+            let name = pinProtocol == .v1 ? "v1" : "v2"
+            self.idSuffix = name
+            self.displayName = "\(describing) (PIN/UV protocol \(name))"
+            self.requirements = Requirements(capabilities: [.fido2])
+            self.pinProtocol = pinProtocol
+        }
+    }
+
+    private static let pinProtocols = [
+        PinProtocolCase(.v1, "credential-management lifecycle round-trips"),
+        PinProtocolCase(.v2, "credential-management lifecycle round-trips"),
+    ]
+
+    private static var credManagementProtocolScenarios: [Scenario] {
+        Scenario.parameterized("CTAP2.CredentialManagement.lifecycle", over: pinProtocols) { context, proto in
+            let session = try await sessionWithPin(context)
+            guard try await CTAP2.CredentialManagement.isSupported(by: session) else {
+                try context.skip("Credential management not supported")
+            }
+            try await deleteAllCredentials(session)
+
+            // Create one resident credential, authorizing makeCredential with an explicit-protocol token.
+            let makeToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.makeCredential],
+                rpId: cmTestRpId,
+                protocol: proto.pinProtocol
+            )
+            let params = CTAP2.MakeCredential.Parameters(
+                clientDataHash: defaultClientDataHash,
+                rp: cmTestRp,
+                user: cmTestUser,
+                pubKeyCredParams: [.es256],
+                rk: true
+            )
+            context.touch("Touch the key to create the test credential (\(proto.idSuffix))")
+            _ = try await session.makeCredential(parameters: params, token: makeToken).value
+
+            // Drive credential management with a token minted under the same protocol.
+            let cmToken = try await session.getPinUVToken(
+                using: .pin(defaultTestPin),
+                permissions: [.credentialManagement],
+                protocol: proto.pinProtocol
+            )
+            let credMgmt = try await session.credentialManagement(token: cmToken)
+            context.expectEqual(
+                try await credMgmt.getMetadata().existingCredentialsCount,
+                1,
+                "one credential after creation"
+            )
+
+            var credentialIds: [WebAuthn.CredentialDescriptor] = []
+            for try await rp in credMgmt.rps {
+                context.expect(rp.rp.id == cmTestRpId, "RP id should match")
+                for try await credential in credMgmt.credentials(for: rp.rpIdHash) {
+                    context.expect(credential.user.id == cmTestUserId, "user id should match")
+                    credentialIds.append(credential.credentialId)
+                }
+            }
+            context.expectEqual(credentialIds.count, 1, "enumerate should return the one credential")
+
+            for credentialId in credentialIds {
+                try await credMgmt.deleteCredential(credentialId)
+            }
+            context.expectEqual(
+                try await credMgmt.getMetadata().existingCredentialsCount,
+                0,
+                "no credentials after delete"
+            )
+        }
+    }
+
+    private static var largeBlobsProtocolScenarios: [Scenario] {
+        let cases = [
+            PinProtocolCase(.v1, "largeBlob array write/read/delete round-trips"),
+            PinProtocolCase(.v2, "largeBlob array write/read/delete round-trips"),
+        ]
+        return Scenario.parameterized("CTAP2.LargeBlobs.pinProtocol", over: cases) { context, proto in
+            let session = try await sessionWithPin(context)
+            guard try await session.supportsLargeBlobs() else {
+                try context.skip("LargeBlobs not supported by this authenticator")
+            }
+            await context.addTeardown { try await context.deleteResidentCredentials() }
+            let key = try await makeLargeBlobKeyCredential(
+                session,
+                context,
+                userByte: 0x73,
+                rpId: "lbproto.example"
+            )
+            let blob = Data("largeBlob under PIN/UV protocol \(proto.idSuffix)".utf8)
+            func writeToken() async throws -> CTAP2.Token {
+                try await session.getPinUVToken(
+                    using: .pin(defaultTestPin),
+                    permissions: [.largeBlobWrite],
+                    protocol: proto.pinProtocol
+                )
+            }
+
+            try await session.deleteBlob(key: key, token: try await writeToken())
+            context.expect(try await session.getBlob(key: key) == nil, "blob should start empty")
+            try await session.putBlob(key: key, data: blob, token: try await writeToken())
+            context.expectEqual(
+                try await session.getBlob(key: key),
+                blob,
+                "blob should round-trip under PIN/UV protocol \(proto.idSuffix)"
+            )
+            try await session.deleteBlob(key: key, token: try await writeToken())
+            context.expect(try await session.getBlob(key: key) == nil, "blob should be gone after delete")
+        }
+    }
+}
+
+// MARK: - CTAP error expectations
+
+extension Scenario.Context {
+    /// Expects `body` to throw a `CTAP2.SessionError.ctapError` carrying one of `codes`. Records a
+    /// failure (without aborting the scenario) if it returns or throws anything else.
+    func expectCTAPError(
+        _ codes: CTAP2.Error...,
+        during action: String,
+        file: String = #fileID,
+        line: Int = #line,
+        _ body: () async throws -> Void
+    ) async {
+        await expectThrows(
+            action,
+            matching: { error in
+                guard case let CTAP2.SessionError.ctapError(code, _) = error else { return false }
+                return codes.contains(code)
+            },
+            file: file,
+            line: line,
+            body
+        )
+    }
+}
+
 // MARK: - Shared constants
 
 private let defaultTestPin = Scenario.Context.defaultTestPin
+private let defaultClientDataHash = Data(repeating: 0xCD, count: 32)
 
 private let cmTestRpId = "test.example.com"
 private let cmTestRp = WebAuthn.RelyingParty(id: cmTestRpId, name: "Test RP")
@@ -1471,7 +2503,6 @@ private let cmTestUserId = Data([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]
 private let cmTestUserName = "testuser@example.com"
 private let cmTestUserDisplayName = "Test User"
 private let cmTestUser = WebAuthn.User(id: cmTestUserId, name: cmTestUserName, displayName: cmTestUserDisplayName)
-private let cmClientDataHash = Data(repeating: 0xCD, count: 32)
 
 // MARK: - Signature verification
 
@@ -1517,7 +2548,7 @@ private func makeCredentialAlgorithmScenario(
         let session = try await context.ctap2Session()
         context.touch("Touch the key to create the credential")
         let params = CTAP2.MakeCredential.Parameters(
-            clientDataHash: Data(repeating: 0xCD, count: 32),
+            clientDataHash: defaultClientDataHash,
             rp: WebAuthn.RelyingParty(id: "example.com", name: "Example Corp"),
             user: WebAuthn.User(
                 id: Data(repeating: userByte, count: 32),
@@ -1549,6 +2580,12 @@ private func sessionWithPin(_ context: Scenario.Context) async throws -> CTAP2.S
     return session
 }
 
+/// A makeCredential token for `rpId`, or nil when the key has no PIN (UP-only resident creation).
+private func makeCredentialToken(_ session: CTAP2.Session, rpId: String) async throws -> CTAP2.Token? {
+    guard try await session.getInfo().options.clientPin == true else { return nil }
+    return try await session.getPinUVToken(using: .pin(defaultTestPin), permissions: [.makeCredential], rpId: rpId)
+}
+
 private func getCredentialManagement(_ session: CTAP2.Session) async throws -> CTAP2.CredentialManagement {
     let token = try await session.getPinUVToken(using: .pin(defaultTestPin), permissions: [.credentialManagement])
     return try await session.credentialManagement(token: token)
@@ -1561,7 +2598,7 @@ private func createTestCredential(_ session: CTAP2.Session, _ context: Scenario.
         rpId: cmTestRpId
     )
     let params = CTAP2.MakeCredential.Parameters(
-        clientDataHash: cmClientDataHash,
+        clientDataHash: defaultClientDataHash,
         rp: cmTestRp,
         user: cmTestUser,
         pubKeyCredParams: [.es256],
@@ -1569,6 +2606,82 @@ private func createTestCredential(_ session: CTAP2.Session, _ context: Scenario.
     )
     context.touch("Touch the key to create the test credential")
     _ = try await session.makeCredential(parameters: params, token: pinToken).value
+}
+
+/// Creates a resident credential requesting the largeBlobKey extension and returns its 32-byte key.
+private func makeLargeBlobKeyCredential(
+    _ session: CTAP2.Session,
+    _ context: Scenario.Context,
+    userByte: UInt8,
+    rpId: String
+) async throws -> Data {
+    let largeBlobKey = try await CTAP2.Extension.LargeBlobKey(session: session)
+    let token = try await session.getPinUVToken(
+        using: .pin(defaultTestPin),
+        permissions: [.makeCredential],
+        rpId: rpId
+    )
+    let params = CTAP2.MakeCredential.Parameters(
+        clientDataHash: defaultClientDataHash,
+        rp: WebAuthn.RelyingParty(id: rpId, name: rpId),
+        user: WebAuthn.User(
+            id: Data(repeating: userByte, count: 32),
+            name: "\(rpId)@example.com",
+            displayName: rpId
+        ),
+        pubKeyCredParams: [.es256],
+        extensions: [largeBlobKey.makeCredential.input()],
+        rk: true
+    )
+    context.touch("Touch the key to create the \(rpId) credential")
+    let response = try await session.makeCredential(parameters: params, token: token).value
+    return try context.require(
+        largeBlobKey.makeCredential.output(from: response),
+        "expected a largeBlobKey from makeCredential for \(rpId)"
+    )
+}
+
+/// Creates a resident credential at the given credProtect level and returns its credential id.
+private func makeCredProtectCredential(
+    _ session: CTAP2.Session,
+    _ context: Scenario.Context,
+    level: CTAP2.Extension.CredProtect.Level,
+    userByte: UInt8,
+    rpId: String
+) async throws -> Data {
+    let credProtect = try await CTAP2.Extension.CredProtect(level: level, session: session, enforce: true)
+    let token = try await session.getPinUVToken(
+        using: .pin(defaultTestPin),
+        permissions: [.makeCredential],
+        rpId: rpId
+    )
+    let params = CTAP2.MakeCredential.Parameters(
+        clientDataHash: defaultClientDataHash,
+        rp: WebAuthn.RelyingParty(id: rpId, name: rpId),
+        user: WebAuthn.User(
+            id: Data(repeating: userByte, count: 32),
+            name: "\(rpId)@example.com",
+            displayName: rpId
+        ),
+        pubKeyCredParams: [.es256],
+        extensions: [credProtect.input()],
+        rk: true
+    )
+    context.touch("Touch the key to create the \(rpId) credential (credProtect \(level.rawValue))")
+    let response = try await session.makeCredential(parameters: params, token: token).value
+    // L2/L3 must echo the applied level back; L1 (default) may legitimately omit it.
+    if level != .userVerificationOptional {
+        context.expectEqual(
+            credProtect.output(from: response),
+            level,
+            "\(rpId): credProtect output should echo the requested level"
+        )
+    }
+    let attested = try context.require(
+        response.authenticatorData.attestedCredentialData,
+        "\(rpId): makeCredential must return attested credential data"
+    )
+    return attested.credentialId
 }
 
 private func deleteAllCredentials(_ session: CTAP2.Session) async throws {
@@ -1595,7 +2708,7 @@ private func verifyReadOnlyOperations(
     context.expectEqual(rps.count, 1)
     let credentials = try await credMgmt.credentials(for: rpIdHash).enumerate()
     context.expectEqual(credentials.count, 1)
-    let credentialId = credentials[0].credentialId
+    let credentialId = try context.require(credentials.first, "expected one credential").credentialId
 
     // Writes must fail with pinAuthInvalid.
     do {
@@ -1649,9 +2762,8 @@ private func enrollOneFingerprint(_ bio: CTAP2.BioEnrollment, _ context: Scenari
     return try context.require(templateId, "failed to enroll fingerprint")
 }
 
-private func cleanupEnrollment(_ session: CTAP2.Session, _ templateId: Data) async {
-    guard let token = try? await session.getPinUVToken(using: .pin(defaultTestPin), permissions: [.bioEnrollment]),
-        let bio = try? await session.bioEnrollment(token: token)
-    else { return }
-    try? await bio.removeEnrollment(templateId)
+private func cleanupEnrollment(_ session: CTAP2.Session, _ templateId: Data) async throws {
+    let token = try await session.getPinUVToken(using: .pin(defaultTestPin), permissions: [.bioEnrollment])
+    let bio = try await session.bioEnrollment(token: token)
+    try await bio.removeEnrollment(templateId)
 }

--- a/YubiKit/IntegrationScenarios/Scenarios/CTAPHID.swift
+++ b/YubiKit/IntegrationScenarios/Scenarios/CTAPHID.swift
@@ -19,7 +19,7 @@ import Foundation
 #endif
 
 /// CTAPHID transport-layer scenarios.
-public enum CTAPHIDScenario: CaseIterable {
+public enum CTAPHIDScenario: CaseIterable, ScenarioSuite {
 
     case initialize
     case getInfo
@@ -43,8 +43,6 @@ public enum CTAPHIDScenario: CaseIterable {
                 let version = await fido.version
                 context.expect(!version.description.isEmpty, "interface should report a version")
                 context.expect(await fido.capabilities != [], "interface should report capabilities")
-                #else
-                try context.skip("CTAPHID scenarios are macOS-only")
                 #endif
             }
         case .getInfo:
@@ -70,8 +68,6 @@ public enum CTAPHIDScenario: CaseIterable {
                 #if os(macOS)
                 let fido = try await Self.openInterface(context)
                 context.expect(await fido.supports(CTAP2.Capabilities.wink), "YubiKey should support WINK")
-                #else
-                try context.skip("CTAPHID scenarios are macOS-only")
                 #endif
             }
         // MARK: - Commands
@@ -89,27 +85,32 @@ public enum CTAPHIDScenario: CaseIterable {
                 }
                 try await fido.wink()
                 context.log("WINK completed")
-                #else
-                try context.skip("CTAPHID scenarios are macOS-only")
                 #endif
             }
         // MARK: - Ping
         case .echo:
             return Scenario(
                 "CTAPHID.Ping.echo",
-                "CTAPHID PING echoes empty and non-empty payloads",
+                "CTAPHID PING echoes the payload unchanged",
                 requirements: Requirements(requiresFIDOTransport: true),
                 platform: .macOS
             ) { context in
                 #if os(macOS)
                 let fido = try await Self.openInterface(context)
                 let empty = try await fido.ping()
-                context.expect(empty.isEmpty, "empty PING should echo an empty payload")
+                context.expect(empty.isEmpty, "empty PING should echo an empty payload unchanged")
                 let payload = Data([0x01, 0x02, 0x03, 0x04])
                 let echoed = try await fido.ping(data: payload)
-                context.expect(echoed == payload, "PING should echo back the same data")
-                #else
-                try context.skip("CTAPHID scenarios are macOS-only")
+                context.expect(echoed == payload, "PING should echo the payload unchanged")
+
+                // Also exercise a 12-byte message, 12 spaces, and an empty message.
+                for message in [Data("hello world!".utf8), Data("            ".utf8), Data()] {
+                    let roundTrip = try await fido.ping(data: message)
+                    context.expect(
+                        roundTrip == message,
+                        "PING should echo back a \(message.count)-byte message unchanged"
+                    )
+                }
                 #endif
             }
         // MARK: - Errors
@@ -128,8 +129,6 @@ public enum CTAPHIDScenario: CaseIterable {
                 } catch {
                     context.log("invalid command correctly failed: \(error)")
                 }
-                #else
-                try context.skip("CTAPHID scenarios are macOS-only")
                 #endif
             }
         }

--- a/YubiKit/IntegrationScenarios/Scenarios/Connection.swift
+++ b/YubiKit/IntegrationScenarios/Scenarios/Connection.swift
@@ -17,14 +17,12 @@ import Foundation
 import YubiKit
 
 /// Connection scenarios.
-public enum ConnectionScenario: CaseIterable {
+public enum ConnectionScenario: CaseIterable, ScenarioSuite {
 
     case open
     case closeNotifies
     case serial
     case cancellation
-    case withDeviceSmartCard
-    case withSlot
     case sendManually
     case selectWrongApp
     case withDeviceFIDOHID
@@ -37,10 +35,11 @@ public enum ConnectionScenario: CaseIterable {
         case .open:
             return Scenario(
                 "Connection.SmartCard.open",
-                "opens a SmartCard connection"
+                "acquires a usable SmartCard connection (acquisition succeeding is the assertion)"
             ) { context in
                 let connection = try await context.smartCardConnection()
-                context.log("got a SmartCard connection: \(connection)")
+                _ = try await Management.Session.makeSession(connection: connection).getDeviceInfo()
+                context.log("acquired a usable SmartCard connection: \(connection)")
             }
         case .closeNotifies:
             return Scenario(
@@ -99,24 +98,6 @@ public enum ConnectionScenario: CaseIterable {
                 context.expect(connections.count == 1, "exactly one concurrent connection should succeed")
 
                 for connection in connections { await connection.close(error: nil) }
-            }
-        case .withDeviceSmartCard:
-            return Scenario(
-                "Connection.SmartCard.withDevice",
-                "opens a selected USB SmartCard connection",
-                requirements: Requirements(transports: [.usb], requiresRealHardware: true)
-            ) { context in
-                let connection = try await context.smartCardConnection()
-                context.log("got a connection: \(connection)")
-            }
-        case .withSlot:
-            return Scenario(
-                "Connection.SmartCard.withSlot",
-                "opens a USB SmartCard connection to a slot from availableDevices()",
-                requirements: Requirements(transports: [.usb], requiresRealHardware: true)
-            ) { context in
-                let connection = try await connectToSelectedUSBSlot(context)
-                await connection.close(error: nil)
             }
         // MARK: - Raw APDU
         case .sendManually:
@@ -226,24 +207,6 @@ public enum ConnectionScenario: CaseIterable {
 // MARK: - Suite-private helpers
 
 private struct ConnectionTestError: Error {}
-
-private func connectToSelectedUSBSlot(_ context: Scenario.Context) async throws -> any SmartCardConnection {
-    let expectedSerial = try await context.provider.deviceInfo().serialNumber
-    let slots = try await USBSmartCardConnection.availableDevices()
-    for slot in slots.shuffled() {
-        guard let connection = try? await USBSmartCardConnection.makeConnection(slot: slot) else { continue }
-        do {
-            let session = try await Management.Session.makeSession(connection: connection)
-            let info = try await session.getDeviceInfo()
-            if info.serialNumber == expectedSerial {
-                context.log("got a connection to \(slot.name)")
-                return connection
-            }
-        } catch {}
-        await connection.close(error: nil)
-    }
-    throw ProviderError.unavailable("No USB SmartCard slot matched the selected YubiKey.")
-}
 
 private func selectAPDU(aid: [UInt8]) -> Data {
     Data([0x00, 0xA4, 0x04, 0x00, UInt8(aid.count)] + aid)

--- a/YubiKit/IntegrationScenarios/Scenarios/Management.swift
+++ b/YubiKit/IntegrationScenarios/Scenarios/Management.swift
@@ -16,7 +16,7 @@ import Foundation
 import YubiKit
 
 /// Management application scenarios.
-public enum ManagementScenario: CaseIterable {
+public enum ManagementScenario: CaseIterable, ScenarioSuite {
 
     case version
     case deviceInfo
@@ -65,6 +65,8 @@ public enum ManagementScenario: CaseIterable {
                 context.expect(info.config.autoEjectTimeout == 320.0, "autoEjectTimeout == 320")
             }
         case .chaining:
+            // (test_disable_oath / test_disable_piv / test_disable_openpgp / test_disable_fido2): each disables
+            // an application then re-reads config to confirm it is gone (here chained in one updateDeviceConfig).
             return Scenario(
                 "Management.Config.chaining",
                 "chained enable/disable across applications round-trips",
@@ -82,7 +84,7 @@ public enum ManagementScenario: CaseIterable {
                     .enable(application: .fido2, over: transport)
                 try await session.updateDeviceConfig(chained, reboot: false)
                 // Restore via teardown so a failure below can't leave applications disabled.
-                await context.addTeardown { try? await session.updateDeviceConfig(initialConfig, reboot: false) }
+                await context.addTeardown { try await session.updateDeviceConfig(initialConfig, reboot: false) }
                 let updated = try await session.getDeviceInfo()
 
                 if info.isApplicationSupported(.oath, over: transport) {
@@ -99,10 +101,12 @@ public enum ManagementScenario: CaseIterable {
                 }
             }
         case .disableEnableApplication:
+            // `config usb --list`); re-enable corresponds to that suite's enable_all fixture (`config usb --enable-all`).
+            // Goes further than the CLI test by also asserting the applet can no longer be selected while disabled.
             return Scenario(
                 "Management.Config.disableEnableApplication",
                 "a disabled application can no longer be selected (then re-enabled)",
-                requirements: Requirements(minVersion: Version("5.0.0"))
+                requirements: Requirements(capabilities: [.oath], minVersion: Version("5.0.0"))
             ) { context in
                 let connection = try await context.smartCardConnection()
                 // Build sessions directly (multiple selects on one connection), so thread the run's
@@ -119,10 +123,8 @@ public enum ManagementScenario: CaseIterable {
                 // Restore via teardown (on a fresh session — the body selects other applets meanwhile)
                 // so a mid-body failure can't leave OATH disabled for the rest of the run.
                 await context.addTeardown {
-                    guard
-                        let mgmt = try? await Management.Session.makeSession(connection: connection, scpKeyParams: scp)
-                    else { return }
-                    try? await mgmt.updateDeviceConfig(initialConfig, reboot: false)
+                    let mgmt = try await Management.Session.makeSession(connection: connection, scpKeyParams: scp)
+                    try await mgmt.updateDeviceConfig(initialConfig, reboot: false)
                 }
                 let disabled = try await session.getDeviceInfo()
                 context.expect(!disabled.config.isApplicationEnabled(.oath, over: transport), "OATH reported disabled")
@@ -140,10 +142,12 @@ public enum ManagementScenario: CaseIterable {
                 )
             }
         case .lockCode:
+            // teardown); also exercises test_set_invalid_lock_code's premise that a config change without the correct
+            // lock code is rejected.
             return Scenario(
                 "Management.Config.lockCode",
                 "a set lock code is required to change configuration",
-                requirements: Requirements(minVersion: Version("5.0.0")),
+                requirements: Requirements(minVersion: Version("5.0.0"))
             ) { context in
                 let lockCode = Data(hexString: "01020304050607080102030405060708")!
                 let clearLockCode = Data(hexString: "00000000000000000000000000000000")!
@@ -154,7 +158,7 @@ public enum ManagementScenario: CaseIterable {
                 // From here the device is lock-coded — clear it via teardown so a failure below can't
                 // leave the key permanently locked.
                 await context.addTeardown {
-                    try? await session.updateDeviceConfig(
+                    try await session.updateDeviceConfig(
                         config,
                         reboot: false,
                         lockCode: lockCode,
@@ -174,10 +178,11 @@ public enum ManagementScenario: CaseIterable {
                 )
             }
         case .nfcRestricted:
+            // "restrict NFC until next USB insertion" flag (nfcRestricted / isNFCRestricted)
             return Scenario(
                 "Management.Config.nfcRestricted",
                 "NFC can be restricted until next USB insertion",
-                requirements: Requirements(minVersion: Version("5.7.0")),
+                requirements: Requirements(minVersion: Version("5.7.0"))
             ) { context in
                 let session = try await context.managementSession()
                 let config = try await session.getDeviceInfo().config.with(nfcRestricted: true)
@@ -190,7 +195,7 @@ public enum ManagementScenario: CaseIterable {
             return Scenario(
                 "Management.Reset.bioDeviceReset",
                 "device-wide reset restores the default PIV PIN (Bio MPE)",
-                requirements: Requirements(capabilities: [.piv], minVersion: Version("5.6.0"), requiresBio: true),
+                requirements: Requirements(capabilities: [.piv], minVersion: Version("5.6.0"), requiresBio: true)
             ) { context in
                 let connection = try await context.smartCardConnection()
                 // resetDevice wipes the applications but not the Security Domain, so the SCP keys survive;

--- a/YubiKit/IntegrationScenarios/Scenarios/OATH.swift
+++ b/YubiKit/IntegrationScenarios/Scenarios/OATH.swift
@@ -16,9 +16,8 @@ import Foundation
 import YubiKit
 
 /// OATH application scenarios.
-public enum OATHScenario: CaseIterable {
+public enum OATHScenario: CaseIterable, ScenarioSuite {
 
-    case chunkedData
     case credentials
     case allCodes
     case codes
@@ -33,39 +32,22 @@ public enum OATHScenario: CaseIterable {
     case unlock
     case wrong
     case deleteAccessKey
+    case deleteAccessKeyRejectedOnFIPS
     case lockedListRejected
+    case lockedCalculateRejected
+    case lockedCalculateAllRejected
+    case lockedDeleteRejected
+    case lockedRenameRejected
+    case toExistingDistinct
     case response
-    case hmacSha256
-    case hmacSha512
-    case totpSha1_59
-    case hotpSha1
+    case maxCredentials
+    case unicodeName
 
     public var scenario: Scenario { definition }
 
     private var definition: Scenario {
         switch self {
-        // MARK: - Functions
-        case .chunkedData:
-            return Scenario(
-                "OATH.Calculate.chunkedData",
-                "calculateCredentialCodes reassembles a response that spans multiple frames",
-                requirements: Requirements(capabilities: [.oath])
-            ) { context in
-                let session = try await populatedOATHSession(context)
-                for n in 0...14 {
-                    let template = OATHSession.CredentialTemplate(
-                        type: .totp(),
-                        algorithm: .sha1,
-                        secret: base32Decoded("abba"),
-                        issuer: "Yubico-\(n)",
-                        name: "test@yubico.com",
-                        digits: 6
-                    )
-                    try await session.addCredential(template: template)
-                }
-                let result = try await session.calculateCredentialCodes()
-                context.expectEqual(result.count, 20, "expected 5 populated + 15 added credentials")
-            }
+        // MARK: - TestFunctions
         case .credentials:
             return Scenario(
                 "OATH.List.credentials",
@@ -268,6 +250,39 @@ public enum OATHScenario: CaseIterable {
                     "existing credential should remain present"
                 )
             }
+        case .toExistingDistinct:
+            return Scenario(
+                "OATH.Rename.toExistingDistinct",
+                "renaming a credential onto another existing credential's identifier is rejected",
+                requirements: Requirements(capabilities: [.oath], minVersion: Version("5.3.0"))
+            ) { context in
+                let session = try await freshOATHSession(context)
+                let firstTemplate = OATHSession.CredentialTemplate(
+                    type: .totp(),
+                    algorithm: .sha1,
+                    secret: base32Decoded("abba"),
+                    issuer: "Issuer One",
+                    name: "Name One",
+                    digits: 6
+                )
+                let secondTemplate = OATHSession.CredentialTemplate(
+                    type: .totp(),
+                    algorithm: .sha1,
+                    secret: base32Decoded("abba"),
+                    issuer: "Issuer Two",
+                    name: "Name Two",
+                    digits: 6
+                )
+                try await session.addCredential(template: firstTemplate)
+                let second = try await session.addCredential(template: secondTemplate)
+                // Renaming the second credential onto the first's existing identifier must fail.
+                do {
+                    try await session.renameCredential(second, newName: "Name One", newIssuer: "Issuer One")
+                    context.record("renaming onto another credential's existing identifier should have failed")
+                } catch OATHSessionError.failedResponse(let response, _) {
+                    context.log("rename onto distinct existing identifier rejected with \(response.status)")
+                }
+            }
         case .credentialDelete:
             return Scenario(
                 "OATH.Delete.credential",
@@ -374,7 +389,7 @@ public enum OATHScenario: CaseIterable {
                 _ = try await populatedOATHSession(context)
                 context.log("reset and re-populated with the standard test accounts")
             }
-        // MARK: - Password lock
+        // MARK: - TestLockPreventsAccess
         case .unlock:
             return Scenario(
                 "OATH.Password.unlock",
@@ -408,7 +423,7 @@ public enum OATHScenario: CaseIterable {
             return Scenario(
                 "OATH.Password.deleteAccessKey",
                 "deleteAccessKey removes the password so a fresh session needs no unlock",
-                requirements: Requirements(capabilities: [.oath])
+                requirements: Requirements(capabilities: [.oath], excludesFIPS: true)
             ) { context in
                 let session = try await populatedOATHSession(context, password: oathPassword)
                 try await session.unlock(password: oathPassword)
@@ -425,6 +440,25 @@ public enum OATHScenario: CaseIterable {
                     "expected 5 credentials without unlocking after deleting the access key"
                 )
             }
+        // FIPS OATH must stay access-key protected once approved.
+        case .deleteAccessKeyRejectedOnFIPS:
+            return Scenario(
+                "OATH.Password.deleteAccessKeyRejectedOnFIPS",
+                "a FIPS OATH application rejects access-key removal",
+                requirements: Requirements(capabilities: [.oath], requiresFIPS: true)
+            ) { context in
+                let session = try await populatedOATHSession(context, password: oathPassword)
+                try await session.unlock(password: oathPassword)
+                do {
+                    try await session.deleteAccessKey()
+                    context.record("FIPS OATH should reject deleting the access key")
+                } catch OATHSessionError.failedResponse(let response, _) {
+                    context.expect(
+                        response.status == .conditionsNotSatisfied,
+                        "expected conditionsNotSatisfied (0x6985) rejecting OATH access-key removal, got \(response.status)"
+                    )
+                }
+            }
         case .lockedListRejected:
             return Scenario(
                 "OATH.Password.lockedListRejected",
@@ -438,7 +472,7 @@ public enum OATHScenario: CaseIterable {
                 } catch OATHSessionError.failedResponse(let response, _) {
                     context.expect(
                         response.status == .securityConditionNotSatisfied,
-                        "expected securityConditionNotSatisfied (0x6982) while locked"
+                        "sw should be SECURITY_CONDITION_NOT_SATISFIED (0x6982)"
                     )
                 }
                 // Unlocking restores access.
@@ -446,7 +480,76 @@ public enum OATHScenario: CaseIterable {
                 let credentials = try await session.listCredentials()
                 context.expectEqual(credentials.count, 5, "expected 5 credentials after unlocking")
             }
+        case .lockedCalculateRejected:
+            return Scenario(
+                "OATH.Password.lockedCalculateRejected",
+                "a locked OATH application rejects calculating a single credential until it is unlocked",
+                requirements: Requirements(capabilities: [.oath])
+            ) { context in
+                let (session, credential) = try await lockedOATHSession(context)
+                do {
+                    _ = try await session.calculateCredentialCode(for: credential)
+                    context.record("calculating on a locked OATH application should have failed")
+                } catch OATHSessionError.failedResponse(let response, _) {
+                    context.expect(
+                        response.status == .securityConditionNotSatisfied,
+                        "sw should be SECURITY_CONDITION_NOT_SATISFIED (0x6982)"
+                    )
+                }
+            }
+        case .lockedCalculateAllRejected:
+            return Scenario(
+                "OATH.Password.lockedCalculateAllRejected",
+                "a locked OATH application rejects calculating all credentials until it is unlocked",
+                requirements: Requirements(capabilities: [.oath])
+            ) { context in
+                let (session, _) = try await lockedOATHSession(context)
+                do {
+                    _ = try await session.calculateCredentialCodes()
+                    context.record("calculateCredentialCodes on a locked OATH application should have failed")
+                } catch OATHSessionError.failedResponse(let response, _) {
+                    context.expect(
+                        response.status == .securityConditionNotSatisfied,
+                        "sw should be SECURITY_CONDITION_NOT_SATISFIED (0x6982)"
+                    )
+                }
+            }
+        case .lockedDeleteRejected:
+            return Scenario(
+                "OATH.Password.lockedDeleteRejected",
+                "a locked OATH application rejects deleting a credential until it is unlocked",
+                requirements: Requirements(capabilities: [.oath])
+            ) { context in
+                let (session, credential) = try await lockedOATHSession(context)
+                do {
+                    try await session.deleteCredential(credential)
+                    context.record("deleting on a locked OATH application should have failed")
+                } catch OATHSessionError.failedResponse(let response, _) {
+                    context.expect(
+                        response.status == .securityConditionNotSatisfied,
+                        "sw should be SECURITY_CONDITION_NOT_SATISFIED (0x6982)"
+                    )
+                }
+            }
+        case .lockedRenameRejected:
+            return Scenario(
+                "OATH.Password.lockedRenameRejected",
+                "a locked OATH application rejects renaming a credential until it is unlocked",
+                requirements: Requirements(capabilities: [.oath], minVersion: Version("5.3.0"))
+            ) { context in
+                let (session, credential) = try await lockedOATHSession(context)
+                do {
+                    try await session.renameCredential(credential, newName: "renamed", newIssuer: nil)
+                    context.record("renaming on a locked OATH application should have failed")
+                } catch OATHSessionError.failedResponse(let response, _) {
+                    context.expect(
+                        response.status == .securityConditionNotSatisfied,
+                        "sw should be SECURITY_CONDITION_NOT_SATISFIED (0x6982)"
+                    )
+                }
+            }
         // MARK: - RFC vectors
+        // calculateCredentialResponse op as TestHmacVectors, which uses RFC 4231 vectors)
         case .response:
             return Scenario(
                 "OATH.Calculate.response",
@@ -473,104 +576,320 @@ public enum OATHScenario: CaseIterable {
                 ])
                 context.expectEqual(response, expected, "HMAC-SHA1 response should match RFC 2202 vector 1")
             }
-        // RFC 4231 HMAC-SHA256 vector 1 (key = 0x0b×20, message = "Hi There"):
-        // calculateCredentialResponse returns the full-length HMAC digest.
-        case .hmacSha256:
+        // MARK: - TestOATH (cli)
+        case .maxCredentials:
             return Scenario(
-                "OATH.Vector.hmacSha256",
-                "calculateCredentialResponse matches the RFC 4231 HMAC-SHA256 vector",
+                "OATH.Add.maxCredentials",
+                "the OATH application accepts the firmware-dependent credential limit and rejects one more",
                 requirements: Requirements(capabilities: [.oath])
             ) { context in
                 let session = try await freshOATHSession(context)
-                let template = OATHSession.CredentialTemplate(
+                // Credential limit depends on firmware: 32 before 5.7.0, 64 from 5.7.0 onward.
+                let version = await session.version
+                let limit = version >= Version("5.7.0")! ? 64 : 32
+                context.log("device firmware \(version), credential limit \(limit)")
+                for i in 0..<limit {
+                    let template = OATHSession.CredentialTemplate(
+                        type: .totp(),
+                        algorithm: .sha1,
+                        secret: base32Decoded("abba"),
+                        issuer: nil,
+                        name: "test\(i)",
+                        digits: 6
+                    )
+                    try await session.addCredential(template: template)
+                    let count = try await session.listCredentials().count
+                    context.expectEqual(count, i + 1, "credential count should grow by one after adding test\(i)")
+                }
+                // Adding one beyond the limit must fail (storage full).
+                let overflow = OATHSession.CredentialTemplate(
                     type: .totp(),
-                    algorithm: .sha256,
-                    secret: Data(repeating: 0x0b, count: 20),
-                    issuer: "RFC4231",
-                    name: "hmacSha256",
+                    algorithm: .sha1,
+                    secret: base32Decoded("abba"),
+                    issuer: nil,
+                    name: "test\(limit)",
                     digits: 6
                 )
-                let credential = try await session.addCredential(template: template)
-                let response = try await session.calculateCredentialResponse(
-                    for: credential.id,
-                    challenge: Data("Hi There".utf8)
-                )
-                let expected = Data(hexString: "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7")!
-                context.expectEqual(response, expected, "HMAC-SHA256 response should match RFC 4231 vector 1")
+                do {
+                    _ = try await session.addCredential(template: overflow)
+                    context.record("adding beyond the max should have failed")
+                } catch OATHSessionError.failedResponse(let response, _) {
+                    context.log("storage full correctly rejected with \(response.status)")
+                }
             }
-        // RFC 4231 HMAC-SHA512 vector 1. SHA-512 OATH credentials need firmware ≥ 4.3.1.
-        case .hmacSha512:
+        case .unicodeName:
             return Scenario(
-                "OATH.Vector.hmacSha512",
-                "calculateCredentialResponse matches the RFC 4231 HMAC-SHA512 vector",
-                requirements: Requirements(capabilities: [.oath], minVersion: Version("4.3.1"))
-            ) { context in
-                let session = try await freshOATHSession(context)
-                let template = OATHSession.CredentialTemplate(
-                    type: .totp(),
-                    algorithm: .sha512,
-                    secret: Data(repeating: 0x0b, count: 20),
-                    issuer: "RFC4231",
-                    name: "hmacSha512",
-                    digits: 6
-                )
-                let credential = try await session.addCredential(template: template)
-                let response = try await session.calculateCredentialResponse(
-                    for: credential.id,
-                    challenge: Data("Hi There".utf8)
-                )
-                let expected = Data(
-                    hexString: "87aa7cdea5ef619d4ff0b4241a1d6cb02379f4e2ce4ec2787ad0b30545e17cde"
-                        + "daa833b7d6b8a702038b274eaea3f4e4be9d914eeb61f1702e696c203a126854"
-                )!
-                context.expectEqual(response, expected, "HMAC-SHA512 response should match RFC 4231 vector 1")
-            }
-        // RFC 6238 TOTP vector (key = ASCII "12345678901234567890", SHA1, 8 digits): at T0+59s the
-        // 30-second step is 1, giving 94287082.
-        case .totpSha1_59:
-            return Scenario(
-                "OATH.Vector.totpSha1_59",
-                "calculateCredentialCode matches the RFC 6238 TOTP-SHA1 vector at t=59",
+                "OATH.Add.unicodeName",
+                "a credential with a unicode name can be added, calculated, listed and deleted",
                 requirements: Requirements(capabilities: [.oath])
             ) { context in
                 let session = try await freshOATHSession(context)
                 let template = OATHSession.CredentialTemplate(
                     type: .totp(),
                     algorithm: .sha1,
-                    secret: Data("12345678901234567890".utf8),
-                    issuer: "RFC6238",
-                    name: "totpSha1",
-                    digits: 8
-                )
-                let credential = try await session.addCredential(template: template)
-                let code = try await session.calculateCredentialCode(
-                    for: credential,
-                    timestamp: Date(timeIntervalSince1970: 59)
-                )
-                context.expectEqual(code.code, "94287082", "TOTP-SHA1 code at t=59 should match RFC 6238")
-            }
-        // RFC 4226 HOTP vectors (key = ASCII "12345678901234567890", SHA1, 6 digits): each calculate
-        // advances the moving factor, so successive calls walk the published counter values.
-        case .hotpSha1:
-            return Scenario(
-                "OATH.Vector.hotpSha1",
-                "successive calculateCredentialCode calls match the RFC 4226 HOTP-SHA1 vectors",
-                requirements: Requirements(capabilities: [.oath])
-            ) { context in
-                let session = try await freshOATHSession(context)
-                let template = OATHSession.CredentialTemplate(
-                    type: .hotp(),
-                    algorithm: .sha1,
-                    secret: Data("12345678901234567890".utf8),
-                    issuer: "RFC4226",
-                    name: "hotpSha1",
+                    secret: base32Decoded("abba"),
+                    issuer: nil,
+                    name: "😃",
                     digits: 6
                 )
                 let credential = try await session.addCredential(template: template)
-                let first = try await session.calculateCredentialCode(for: credential)
-                context.expectEqual(first.code, "755224", "HOTP code at counter 0 should match RFC 4226")
-                let second = try await session.calculateCredentialCode(for: credential)
-                context.expectEqual(second.code, "287082", "HOTP code at counter 1 should match RFC 4226")
+                let code = try await session.calculateCredentialCode(for: credential)
+                context.expect(!code.code.isEmpty, "calculated code should not be empty")
+                let listed = try await session.listCredentials()
+                context.expect(listed.contains { $0.name == "😃" }, "listed credentials should contain the unicode name")
+                try await session.deleteCredential(credential)
+                let remaining = try await session.listCredentials()
+                context.expect(
+                    !remaining.contains { $0.name == "😃" },
+                    "the unicode credential should be gone after deletion"
+                )
+            }
+        }
+    }
+}
+
+// MARK: - Parameterized RFC test-vector families
+
+extension OATHScenario {
+
+    /// RFC test vectors: HMAC (RFC 4231 SHA256/512), TOTP (RFC 6238 SHA1/256/512 × timestamps × digit
+    /// counts), and HOTP (RFC 4226 SHA1 × digit counts).
+    static var parameterizedScenarios: [Scenario] {
+        hmacVectorScenarios + totpVectorScenarios + hotpVectorScenarios
+    }
+
+    // RFC 4231 §2: a TOTP credential is used purely as an HMAC key, and the full-length response is
+    // compared to the published digest. Short keys (`Jefe`) are zero-padded by CredentialTemplate,
+    // which leaves the HMAC unchanged.
+    private struct HMACVector: ScenarioParameter {
+        let idSuffix: String
+        let displayName: String
+        let requirements: Requirements
+        let algorithm: OATHSession.HashAlgorithm
+        let secret: Data
+        let challenge: Data
+        let expected: Data
+
+        init(
+            _ idSuffix: String,
+            _ algorithm: OATHSession.HashAlgorithm,
+            secret: Data,
+            challenge: Data,
+            expected: String
+        ) {
+            self.idSuffix = idSuffix
+            self.displayName = "calculateCredentialResponse matches the RFC 4231 HMAC vector \(idSuffix)"
+            self.requirements = Requirements(
+                capabilities: [.oath],
+                minVersion: algorithm == .sha512 ? Version("4.3.1") : nil
+            )
+            self.algorithm = algorithm
+            self.secret = secret
+            self.challenge = challenge
+            self.expected = Data(hexString: expected)!
+        }
+    }
+
+    private static var hmacVectorScenarios: [Scenario] {
+        let key0b = Data(repeating: 0x0b, count: 20)
+        let keyAa = Data(repeating: 0xaa, count: 20)
+        let keyInc = Data(hexString: "0102030405060708090a0b0c0d0e0f10111213141516171819")!
+        let hiThere = Data("Hi There".utf8)
+        let jefe = Data("what do ya want for nothing?".utf8)
+        let dd = Data(repeating: 0xdd, count: 50)
+        let cd = Data(repeating: 0xcd, count: 50)
+        let vectors: [HMACVector] = [
+            HMACVector(
+                "tc1.sha256",
+                .sha256,
+                secret: key0b,
+                challenge: hiThere,
+                expected: "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7"
+            ),
+            HMACVector(
+                "tc1.sha512",
+                .sha512,
+                secret: key0b,
+                challenge: hiThere,
+                expected: "87aa7cdea5ef619d4ff0b4241a1d6cb02379f4e2ce4ec2787ad0b30545e17cde"
+                    + "daa833b7d6b8a702038b274eaea3f4e4be9d914eeb61f1702e696c203a126854"
+            ),
+            HMACVector(
+                "tc2.sha256",
+                .sha256,
+                secret: Data("Jefe".utf8),
+                challenge: jefe,
+                expected: "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843"
+            ),
+            HMACVector(
+                "tc2.sha512",
+                .sha512,
+                secret: Data("Jefe".utf8),
+                challenge: jefe,
+                expected: "164b7a7bfcf819e2e395fbe73b56e0a387bd64222e831fd610270cd7ea250554"
+                    + "9758bf75c05a994a6d034f65f8f0e6fdcaeab1a34d4a6b4b636e070a38bce737"
+            ),
+            HMACVector(
+                "tc3.sha256",
+                .sha256,
+                secret: keyAa,
+                challenge: dd,
+                expected: "773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe"
+            ),
+            HMACVector(
+                "tc3.sha512",
+                .sha512,
+                secret: keyAa,
+                challenge: dd,
+                expected: "fa73b0089d56a284efb0f0756c890be9b1b5dbdd8ee81a3655f83e33b2279d39"
+                    + "bf3e848279a722c806b485a47e67c807b946a337bee8942674278859e13292fb"
+            ),
+            HMACVector(
+                "tc4.sha256",
+                .sha256,
+                secret: keyInc,
+                challenge: cd,
+                expected: "82558a389a443c0ea4cc819899f2083a85f0faa3e578f8077a2e3ff46729665b"
+            ),
+            HMACVector(
+                "tc4.sha512",
+                .sha512,
+                secret: keyInc,
+                challenge: cd,
+                expected: "b0ba465637458c6990e5a8c5f61d4af7e576d97ff94b872de76f8050361ee3db"
+                    + "a91ca5c11aa25eb4d679275cc5788063a5f19741120c4f2de2adebeb10a298dd"
+            ),
+        ]
+        return Scenario.parameterized("OATH.Vector.HMAC", over: vectors) { context, vector in
+            let session = try await freshOATHSession(context)
+            let template = OATHSession.CredentialTemplate(
+                type: .totp(),
+                algorithm: vector.algorithm,
+                secret: vector.secret,
+                issuer: "RFC4231",
+                name: vector.idSuffix,
+                digits: 6
+            )
+            let credential = try await session.addCredential(template: template)
+            let response = try await session.calculateCredentialResponse(
+                for: credential.id,
+                challenge: vector.challenge
+            )
+            context.expectEqual(response, vector.expected, "HMAC \(vector.idSuffix) should match RFC 4231")
+        }
+    }
+
+    // RFC 6238 Appendix B: SHA1/256/512 seeds at two reference timestamps, each checked at 6 and 8
+    // digits (the 8-digit value is the suffix of the 6-digit one).
+    private struct TOTPVector: ScenarioParameter {
+        let idSuffix: String
+        let displayName: String
+        let requirements: Requirements
+        let algorithm: OATHSession.HashAlgorithm
+        let secret: Data
+        let timestamp: TimeInterval
+        let expected8: String
+        let digits: UInt8
+    }
+
+    private static var totpVectorScenarios: [Scenario] {
+        let keys: [(String, OATHSession.HashAlgorithm, Data)] = [
+            ("sha1", .sha1, Data("12345678901234567890".utf8)),
+            ("sha256", .sha256, Data("12345678901234567890123456789012".utf8)),
+            ("sha512", .sha512, Data(("12345678901234567890123456789012" + "34567890123456789012345678901234").utf8)),
+        ]
+        let table: [(TimeInterval, [String: String])] = [
+            (59, ["sha1": "94287082", "sha256": "46119246", "sha512": "90693936"]),
+            (1_111_111_109, ["sha1": "07081804", "sha256": "68084774", "sha512": "25091201"]),
+        ]
+        var vectors: [TOTPVector] = []
+        for (label, algorithm, secret) in keys {
+            let minVersion = algorithm == .sha512 ? Version("4.3.1") : nil
+            for (timestamp, expected) in table {
+                for digits in [UInt8(6), UInt8(8)] {
+                    let seconds = Int(timestamp)
+                    let name =
+                        "calculateCredentialCode matches the RFC 6238 TOTP \(label) vector at t=\(seconds), \(digits) digits"
+                    vectors.append(
+                        TOTPVector(
+                            idSuffix: "\(label).t\(seconds).d\(digits)",
+                            displayName: name,
+                            requirements: Requirements(capabilities: [.oath], minVersion: minVersion),
+                            algorithm: algorithm,
+                            secret: secret,
+                            timestamp: timestamp,
+                            expected8: expected[label]!,
+                            digits: digits
+                        )
+                    )
+                }
+            }
+        }
+        return Scenario.parameterized("OATH.Vector.TOTP", over: vectors) { context, vector in
+            let session = try await freshOATHSession(context)
+            let template = OATHSession.CredentialTemplate(
+                type: .totp(),
+                algorithm: vector.algorithm,
+                secret: vector.secret,
+                issuer: "RFC6238",
+                name: "totp.\(vector.idSuffix)",
+                digits: vector.digits
+            )
+            let credential = try await session.addCredential(template: template)
+            let code = try await session.calculateCredentialCode(
+                for: credential,
+                timestamp: Date(timeIntervalSince1970: vector.timestamp)
+            )
+            context.expectEqual(UInt8(code.code.count), vector.digits, "TOTP code length should match the digit count")
+            context.expect(
+                vector.expected8.hasSuffix(code.code),
+                "TOTP \(vector.idSuffix) should match RFC 6238 (\(vector.expected8))"
+            )
+        }
+    }
+
+    // RFC 4226 Appendix D: the HOTP-SHA1 counter sequence, walked by successive calculate calls, at
+    // both 6 and 8 digits.
+    private struct HOTPVector: ScenarioParameter {
+        let idSuffix: String
+        let displayName: String
+        let requirements: Requirements
+        let digits: UInt8
+
+        init(digits: UInt8) {
+            self.idSuffix = "sha1.d\(digits)"
+            self.displayName =
+                "successive calculateCredentialCode calls match the RFC 4226 HOTP-SHA1 vectors, \(digits) digits"
+            self.requirements = Requirements(capabilities: [.oath])
+            self.digits = digits
+        }
+    }
+
+    private static var hotpVectorScenarios: [Scenario] {
+        let sequence8 = [
+            "84755224", "94287082", "37359152", "26969429", "40338314",
+            "68254676", "18287922", "82162583", "73399871", "45520489",
+        ]
+        let vectors = [HOTPVector(digits: 6), HOTPVector(digits: 8)]
+        return Scenario.parameterized("OATH.Vector.HOTP", over: vectors) { context, vector in
+            let session = try await freshOATHSession(context)
+            let template = OATHSession.CredentialTemplate(
+                type: .hotp(),
+                algorithm: .sha1,
+                secret: Data("12345678901234567890".utf8),
+                issuer: "RFC4226",
+                name: "hotp.\(vector.digits)",
+                digits: vector.digits
+            )
+            let credential = try await session.addCredential(template: template)
+            for expected8 in sequence8 {
+                let code = try await session.calculateCredentialCode(for: credential)
+                context.expectEqual(
+                    UInt8(code.code.count),
+                    vector.digits,
+                    "HOTP code length should match the digit count"
+                )
+                context.expect(expected8.hasSuffix(code.code), "HOTP code should match RFC 4226 (\(expected8))")
             }
         }
     }
@@ -586,10 +905,8 @@ private func freshOATHSession(_ context: Scenario.Context) async throws -> OATHS
     let scp = try await context.scpKeyParams()
     try await OATHSession.makeSession(connection: connection, scpKeyParams: scp).reset()
     await context.addTeardown {
-        guard let cleanup = try? await OATHSession.makeSession(connection: connection, scpKeyParams: scp) else {
-            return
-        }
-        try? await cleanup.reset()
+        let cleanup = try await OATHSession.makeSession(connection: connection, scpKeyParams: scp)
+        try await cleanup.reset()
     }
     return try await OATHSession.makeSession(connection: connection, scpKeyParams: scp)
 }
@@ -613,6 +930,31 @@ private func populatedOATHSession(
     }
 
     return session
+}
+
+/// Add a single credential, password-lock the OATH application, then re-select so the next session
+/// reports the locked state. Returns the locked session along with the `Credential` captured before
+/// locking (a locked session cannot list, so the credential must be obtained up front).
+private func lockedOATHSession(
+    _ context: Scenario.Context
+) async throws -> (OATHSession, OATHSession.Credential) {
+    let session = try await freshOATHSession(context)
+    let template = OATHSession.CredentialTemplate(
+        type: .totp(),
+        algorithm: .sha1,
+        secret: base32Decoded("abba"),
+        issuer: "Locked Issuer",
+        name: "Locked Name",
+        digits: 6
+    )
+    let credential = try await session.addCredential(template: template)
+    try await session.setPassword(oathPassword)
+    // Select another applet so the next OATH SELECT reports the locked state.
+    let connection = try await context.smartCardConnection()
+    let scp = try await context.scpKeyParams()
+    _ = try await Management.Session.makeSession(connection: connection, scpKeyParams: scp)
+    let locked = try await OATHSession.makeSession(connection: connection, scpKeyParams: scp)
+    return (locked, credential)
 }
 
 private func standardOATHCredentials() -> [OATHSession.CredentialTemplate] {

--- a/YubiKit/IntegrationScenarios/Scenarios/PIV.swift
+++ b/YubiKit/IntegrationScenarios/Scenarios/PIV.swift
@@ -18,7 +18,7 @@ import Security
 import YubiKit
 
 /// PIV application scenarios.
-public enum PIVScenario: CaseIterable {
+public enum PIVScenario: CaseIterable, ScenarioSuite {
 
     case eccp256Message
     case eccp256Digest
@@ -38,6 +38,8 @@ public enum PIVScenario: CaseIterable {
     case eccp384KeyImport
     case ed25519KeyImport
     case x25519KeyImport
+    case importPinPolicyAlways
+    case importTouchPolicyAlways
     case rsa1024KeyGeneration
     case rsa2048KeyGeneration
     case rsa3072KeyGeneration
@@ -49,6 +51,7 @@ public enum PIVScenario: CaseIterable {
     case rsa
     case ed25519Attestation
     case x25519Attestation
+    case exportAttestationCertificate
     case putGet
     case putCompressedGet
     case putDelete
@@ -67,8 +70,11 @@ public enum PIVScenario: CaseIterable {
     case changePukUnblock
     case unblockWrongPuk
     case pinPolicyAlways
+    case pinPolicyOnce
+    case pinPolicyNever
+    case slotMetadataPut
+    case setPinRetriesRoundTrip
     case version
-    case serialNumber
     case managementKey
     case slot
     case aesManagementKey
@@ -78,12 +84,15 @@ public enum PIVScenario: CaseIterable {
     case authentication
     case pinPolicyErrorNonBio
     case verifyUvWithoutFingerprints
+    case generateKeyRequiresAuth
+    case putCertificateRequiresAuth
+    case putKeyRequiresAuth
 
     public var scenario: Scenario { definition }
 
     private var definition: Scenario {
         switch self {
-        // MARK: - Certificate Signatures
+        // MARK: - TestOperations
         case .eccp256Message:
             return Scenario(
                 "PIV.Signatures.eccp256Message",
@@ -161,17 +170,19 @@ public enum PIVScenario: CaseIterable {
                     "Ed25519 signature must verify"
                 )
             }
-        // MARK: - Decrypt
+        // MARK: - TestDecrypt
+        // See importDecryptScenarios for the import port.
         case .rsa1024Decryption: return rsaDecryptScenario(.bits1024, "PIV.Decryption.rsa1024")
         case .rsa2048Decryption: return rsaDecryptScenario(.bits2048, "PIV.Decryption.rsa2048")
-        // MARK: - Key Agreement
+        // MARK: - TestKeyAgreement
         case .ecdhP256: return ecdhScenario(.secp256r1, "PIV.KeyAgreement.ecdhP256", curveName: "P-256")
         case .ecdhP384: return ecdhScenario(.secp384r1, "PIV.KeyAgreement.ecdhP384", curveName: "P-384")
         case .x25519KeyAgreement:
             return Scenario(
                 "PIV.KeyAgreement.x25519",
                 "computes an X25519 shared secret matching software ECDH",
-                requirements: Requirements(capabilities: [.piv], minVersion: Version("5.7.0"))
+                // X25519 is outside the FIPS-approved set; a FIPS device rejects it at the wire.
+                requirements: Requirements(capabilities: [.piv], minVersion: Version("5.7.0"), excludesFIPS: true)
             ) { context in
                 let session = try await context.pivSession(authenticated: true)
                 let publicKey = try await session.generateKey(in: .signature, type: .x25519)
@@ -196,7 +207,7 @@ public enum PIVScenario: CaseIterable {
                 let softwareSecretData = softwareSecret.withUnsafeBytes { Data($0) }
                 context.expectEqual(softwareSecretData, yubiKeySecret, "X25519 shared secrets must match")
             }
-        // MARK: - Key Import
+        // MARK: - TestKeyManagement (put_key)
         case .rsa1024KeyImport:
             return rsaImportScenario(
                 .bits1024,
@@ -221,8 +232,10 @@ public enum PIVScenario: CaseIterable {
                 "PIV.KeyImport.rsa4096",
                 requirements: Requirements(capabilities: [.piv], minVersion: Version("5.7.0"))
             )
+        // the CLI only imports the ECCP256 key, while this also signs with it to confirm the round-trip).
         case .eccp256KeyImport: return ecImportScenario(.secp256r1, "PIV.KeyImport.eccp256")
         case .eccp384KeyImport: return ecImportScenario(.secp384r1, "PIV.KeyImport.eccp384")
+        // (import_key puts an Ed25519 key, then signs; Ed25519 ∈ SIGN_KEY_TYPES)
         case .ed25519KeyImport:
             return Scenario(
                 "PIV.KeyImport.ed25519",
@@ -261,7 +274,8 @@ public enum PIVScenario: CaseIterable {
             return Scenario(
                 "PIV.KeyImport.x25519",
                 "imports an X25519 key and performs key agreement",
-                requirements: Requirements(capabilities: [.piv], minVersion: Version("5.7.0"))
+                // X25519 is outside the FIPS-approved set; a FIPS device rejects it at the wire.
+                requirements: Requirements(capabilities: [.piv], minVersion: Version("5.7.0"), excludesFIPS: true)
             ) { context in
                 let session = try await context.pivSession(authenticated: true)
                 let cryptoKitPrivateKey = Curve25519.KeyAgreement.PrivateKey()
@@ -297,6 +311,46 @@ public enum PIVScenario: CaseIterable {
                 let softwareSecret = try cryptoKitPrivateKey.sharedSecretFromKeyAgreement(with: otherCryptoKitPublicKey)
                 let softwareSecretData = softwareSecret.withUnsafeBytes { Data($0) }
                 context.expectEqual(softwareSecretData, yubiKeySecret, "imported X25519 key agreement must match")
+            }
+        case .importPinPolicyAlways:
+            return Scenario(
+                "PIV.KeyImport.pinPolicyAlways",
+                "imports an EC P-256 key with PIN policy ALWAYS and reads it back from metadata",
+                requirements: Requirements(capabilities: [.piv], minVersion: Version("5.3.0"))
+            ) { context in
+                let session = try await context.pivSession(authenticated: true)
+                let privateKey = try context.require(
+                    EC.PrivateKey(x963: P256.Signing.PrivateKey().x963Representation, curve: .secp256r1),
+                    "Failed to build EC private key"
+                )
+                try await session.putPrivateKey(
+                    privateKey,
+                    in: .authentication,
+                    pinPolicy: .always,
+                    touchPolicy: .defaultPolicy
+                )
+                let metadata = try await session.getMetadata(in: .authentication)
+                context.expectEqual(metadata.pinPolicy, .always, "imported key should report PIN policy ALWAYS")
+            }
+        case .importTouchPolicyAlways:
+            return Scenario(
+                "PIV.KeyImport.touchPolicyAlways",
+                "imports an EC P-256 key with touch policy ALWAYS and reads it back from metadata",
+                requirements: Requirements(capabilities: [.piv], minVersion: Version("5.3.0"))
+            ) { context in
+                let session = try await context.pivSession(authenticated: true)
+                let privateKey = try context.require(
+                    EC.PrivateKey(x963: P256.Signing.PrivateKey().x963Representation, curve: .secp256r1),
+                    "Failed to build EC private key"
+                )
+                try await session.putPrivateKey(
+                    privateKey,
+                    in: .authentication,
+                    pinPolicy: .defaultPolicy,
+                    touchPolicy: .always
+                )
+                let metadata = try await session.getMetadata(in: .authentication)
+                context.expectEqual(metadata.touchPolicy, .always, "imported key should report touch policy ALWAYS")
             }
         // MARK: - Key Generation
         case .rsa1024KeyGeneration:
@@ -348,7 +402,8 @@ public enum PIVScenario: CaseIterable {
             return Scenario(
                 "PIV.KeyGeneration.x25519",
                 "generates an X25519 key",
-                requirements: Requirements(capabilities: [.piv], minVersion: Version("5.7.0"))
+                // X25519 is outside the FIPS-approved set; a FIPS device rejects it at the wire.
+                requirements: Requirements(capabilities: [.piv], minVersion: Version("5.7.0"), excludesFIPS: true)
             ) { context in
                 let session = try await context.pivSession(authenticated: true)
                 let result = try await session.generateKey(
@@ -364,11 +419,13 @@ public enum PIVScenario: CaseIterable {
                 context.expectEqual(publicKey.keyData.count, 32, "X25519 public key should be 32 bytes")
             }
         // MARK: - Attestation
+        // then attests; here an RSA key is generated and the attested public key is checked against it).
         case .rsa:
             return Scenario(
                 "PIV.Attestation.rsa",
                 "attests a generated RSA key",
-                requirements: Requirements(capabilities: [.piv], requiresRealHardware: true)
+                // Uses RSA-1024, which a FIPS device rejects; skip on FIPS hardware.
+                requirements: Requirements(capabilities: [.piv], excludesFIPS: true, requiresRealHardware: true)
             ) { context in
                 let session = try await context.pivSession(authenticated: true)
                 let result = try await session.generateKey(in: .signature, type: .rsa(.bits1024))
@@ -410,9 +467,11 @@ public enum PIVScenario: CaseIterable {
             return Scenario(
                 "PIV.Attestation.x25519",
                 "attests a generated X25519 key",
+                // X25519 is outside the FIPS-approved set; skip on FIPS hardware.
                 requirements: Requirements(
                     capabilities: [.piv],
                     minVersion: Version("5.7.0"),
+                    excludesFIPS: true,
                     requiresRealHardware: true
                 )
             ) { context in
@@ -431,7 +490,26 @@ public enum PIVScenario: CaseIterable {
                     context.expect(cert.der.count > 0, "attestation certificate should be generated")
                 }
             }
-        // MARK: - Certificate Management
+        case .exportAttestationCertificate:
+            return Scenario(
+                "PIV.Attestation.exportCertificate",
+                "reads the static attestation certificate from slot f9",
+                requirements: Requirements(capabilities: [.piv])
+            ) { context in
+                // Reading a stored certificate needs no management-key authentication.
+                let session = try await context.pivSession(reset: false)
+                do {
+                    let cert = try await session.getCertificate(in: .attestation)
+                    // A real attestation cert always carries a parsable public key (RSA/EC, Yubico-provisioned).
+                    context.expect(cert.publicKey != nil, "attestation certificate should expose a public key")
+                } catch PIVSessionError.failedResponse(let response, _) {
+                    // The static attestation cert is Yubico-provisioned; a twin may not provision slot f9.
+                    try context.skip("no attestation certificate in slot f9: \(response.status)")
+                }
+            }
+        // MARK: - TestCompressedCertificate / TestKeyManagement (certificates)
+        // (the CLI writes a cert into the AUTHENTICATION object and reads it back as DER; here the same
+        // uncompressed put+get round-trip via putCertificate/getCertificate).
         case .putGet:
             return Scenario(
                 "PIV.Certificates.putGet",
@@ -489,7 +567,7 @@ public enum PIVScenario: CaseIterable {
                     "certificate should be readable without authentication"
                 )
             }
-        // MARK: - Move and Delete
+        // MARK: - TestMoveAndDelete
         case .move:
             return Scenario(
                 "PIV.KeyManagement.move",
@@ -499,9 +577,10 @@ public enum PIVScenario: CaseIterable {
                 let session = try await context.pivSession(authenticated: true)
                 try await session.putCertificate(testCertificate, in: .authentication)
                 try await session.putCertificate(testCertificate, in: .signature)
+                // EC P-256 (not RSA-1024) so this key-management test runs on FIPS too.
                 let publicKey = try await session.generateKey(
                     in: .authentication,
-                    type: .rsa(.bits1024),
+                    type: .ec(.secp256r1),
                     pinPolicy: .always,
                     touchPolicy: .always
                 )
@@ -527,9 +606,10 @@ public enum PIVScenario: CaseIterable {
             ) { context in
                 let session = try await context.pivSession(authenticated: true)
                 try await session.putCertificate(testCertificate, in: .authentication, compressed: true)
+                // EC P-256 (not RSA-1024) so this key-management test runs on FIPS too.
                 let publicKey = try await session.generateKey(
                     in: .authentication,
-                    type: .rsa(.bits1024),
+                    type: .ec(.secp256r1),
                     pinPolicy: .always,
                     touchPolicy: .always
                 )
@@ -544,7 +624,8 @@ public enum PIVScenario: CaseIterable {
                     context.expect(response.status == .referencedDataNotFound, "slot should be empty after delete")
                 }
             }
-        // MARK: - Management Key
+        // MARK: - TestManagementKeyReadWrite
+        // Authenticate with the default management key and verify it does not throw.
         case .authenticateDefault:
             return Scenario(
                 "PIV.ManagementKey.authenticateDefault",
@@ -554,6 +635,7 @@ public enum PIVScenario: CaseIterable {
                 let session = try await context.pivSession()
                 try await session.authenticate(with: Scenario.Context.defaultManagementKey)
             }
+        // Authenticating with the wrong management key should raise an ApduError.
         case .authenticateWrong:
             return Scenario(
                 "PIV.ManagementKey.authenticateWrong",
@@ -599,7 +681,8 @@ public enum PIVScenario: CaseIterable {
                 let withNewKey = try await context.pivSession(reset: false)
                 try await withNewKey.authenticate(with: newKey)
             }
-        // MARK: - PIN / PUK
+        // MARK: - TestUnblockPin / TestMetadata (PIN/PUK)
+        // the retry counter resets; the metadata round-trip is its own TestMetadata::test_pin_metadata).
         case .verify:
             return Scenario(
                 "PIV.PinPuk.verify",
@@ -619,6 +702,8 @@ public enum PIVScenario: CaseIterable {
                     context.record("Got unexpected result from verifyPin: \(result)")
                 }
             }
+        // loops wrong-PIN attempts until "PIN tries remaining: 0"; here each wrong verifyPin is asserted to
+        // decrement the counter and the final attempt locks the PIN).
         case .verifyRetryCount:
             return Scenario(
                 "PIV.PinPuk.verifyRetryCount",
@@ -645,6 +730,7 @@ public enum PIVScenario: CaseIterable {
                 }
                 context.expectEqual(try await session.verifyPin("740737"), .pinLocked, "PIN should remain locked")
             }
+        // (the metadata half: set retries, then read back the new PIN/PUK totals).
         case .setAttempts:
             return Scenario(
                 "PIV.PinPuk.setAttempts",
@@ -660,6 +746,8 @@ public enum PIVScenario: CaseIterable {
                 let pukResult = try await session.getPukMetadata()
                 context.expectEqual(pukResult.retriesRemaining, 6, "PUK attempts should be 6")
             }
+        // change-pin with a now-wrong old PIN raises SystemExit; here the wrong old PIN reports the
+        // remaining retries, which the CLI does not assert).
         case .changePinFailure:
             return Scenario(
                 "PIV.PinPuk.changePinFailure",
@@ -675,6 +763,8 @@ public enum PIVScenario: CaseIterable {
                     context.expectEqual(retries, total - 1, "one retry should have been consumed")
                 }
             }
+        // change-pin to a non-default value succeeds; here the change is followed by a verify with the
+        // new PIN, which the CLI does not do).
         case .changePinSuccess:
             return Scenario(
                 "PIV.PinPuk.changePinSuccess",
@@ -724,6 +814,8 @@ public enum PIVScenario: CaseIterable {
                     context.record("PIN still blocked after unblocking with the PUK")
                 }
             }
+        // separately in TestPuk::test_change_puk and TestPuk::test_unblock_pin, but never changes the PUK
+        // and then uses the new PUK to unblock the PIN in one flow).
         case .changePukUnblock:
             return Scenario(
                 "PIV.PinPuk.changePukUnblock",
@@ -760,7 +852,7 @@ public enum PIVScenario: CaseIterable {
                     context.expectEqual(retries, total - 1, "one PUK retry should have been consumed")
                 }
             }
-        // MARK: - Operations (PIN policy)
+        // MARK: - TestOperations (PIN policy)
         case .pinPolicyAlways:
             return Scenario(
                 "PIV.Operations.pinPolicyAlways",
@@ -828,7 +920,181 @@ public enum PIVScenario: CaseIterable {
                 )
                 context.expect(!secondSignature.isEmpty, "signing after re-verifying the PIN should succeed")
             }
+        case .pinPolicyOnce:
+            return Scenario(
+                "PIV.Operations.pinPolicyOnce",
+                "a key with PIN policy ONCE needs one verify per session, then re-verify after a fresh session",
+                // The cross-session half (re-SELECT clears the PIN-ONCE verification) needs real silicon:
+                // the twin can't both clear PIN state and keep the generated key, since a fresh twin
+                // connection is factory-clean NVRAM.
+                requirements: Requirements(
+                    capabilities: [.piv],
+                    minVersion: Version("4.0.0"),
+                    requiresRealHardware: true
+                )
+            ) { context in
+                let session = try await context.pivSession(authenticated: true)
+                // touchPolicy .never keeps the flow PIN-only; pinPolicy .once demands a single verify per session.
+                _ = try await session.generateKey(
+                    in: .authentication,
+                    type: .ec(.secp256r1),
+                    pinPolicy: .once,
+                    touchPolicy: .never
+                )
+
+                // Without a PIN verification, signing must be rejected.
+                do {
+                    _ = try await session.sign(
+                        testMessage,
+                        in: .authentication,
+                        keyType: .ec(.secp256r1),
+                        using: .hash(.sha256)
+                    )
+                    context.record("signing without a PIN should have failed under PIN policy ONCE")
+                } catch PIVSessionError.failedResponse(let response, _) {
+                    context.expect(
+                        response.status == .securityConditionNotSatisfied,
+                        "expected securityConditionNotSatisfied when signing without a PIN"
+                    )
+                }
+
+                // One verify permits multiple signatures within the same session.
+                try await session.verifyPin(defaultPIN)
+                let firstSignature = try await session.sign(
+                    testMessage,
+                    in: .authentication,
+                    keyType: .ec(.secp256r1),
+                    using: .hash(.sha256)
+                )
+                context.expect(!firstSignature.isEmpty, "first signature after verifying the PIN should succeed")
+                let secondSignature = try await session.sign(
+                    testMessage,
+                    in: .authentication,
+                    keyType: .ec(.secp256r1),
+                    using: .hash(.sha256)
+                )
+                context.expect(!secondSignature.isEmpty, "a second signature in the same session should succeed")
+
+                // A fresh SELECT (no reset, so the key persists) clears the verification; the PIN is required again.
+                let fresh = try await context.pivSession(reset: false)
+                do {
+                    _ = try await fresh.sign(
+                        testMessage,
+                        in: .authentication,
+                        keyType: .ec(.secp256r1),
+                        using: .hash(.sha256)
+                    )
+                    context.record("signing in a fresh session without re-verifying should have failed")
+                } catch PIVSessionError.failedResponse(let response, _) {
+                    context.expect(
+                        response.status == .securityConditionNotSatisfied,
+                        "expected securityConditionNotSatisfied in a fresh session before re-verifying"
+                    )
+                }
+
+                // Re-verifying in the fresh session restores the ability to sign.
+                try await fresh.verifyPin(defaultPIN)
+                let thirdSignature = try await fresh.sign(
+                    testMessage,
+                    in: .authentication,
+                    keyType: .ec(.secp256r1),
+                    using: .hash(.sha256)
+                )
+                context.expect(!thirdSignature.isEmpty, "signing after re-verifying in a fresh session should succeed")
+            }
+        case .pinPolicyNever:
+            return Scenario(
+                "PIV.Operations.pinPolicyNever",
+                "a key with PIN policy NEVER signs without any PIN verification",
+                requirements: Requirements(capabilities: [.piv], minVersion: Version("4.0.0"), excludesFIPS: true)
+            ) { context in
+                let session = try await context.pivSession(authenticated: true)
+                _ = try await session.generateKey(
+                    in: .authentication,
+                    type: .ec(.secp256r1),
+                    pinPolicy: .never,
+                    touchPolicy: .never
+                )
+                // No verifyPin: the NEVER policy lets the key sign straight away.
+                let signature = try await session.sign(
+                    testMessage,
+                    in: .authentication,
+                    keyType: .ec(.secp256r1),
+                    using: .hash(.sha256)
+                )
+                context.expect(!signature.isEmpty, "signing under PIN policy NEVER should succeed without a PIN")
+            }
+        // MARK: - TestMetadata (slot put)
+        case .slotMetadataPut:
+            return Scenario(
+                "PIV.Metadata.slotPut",
+                "reads slot metadata for an imported (generated == false) key",
+                requirements: Requirements(capabilities: [.piv], minVersion: Version("5.3.0"))
+            ) { context in
+                let session = try await context.pivSession(authenticated: true)
+
+                // Import a software EC P-256 key, then assert the slot metadata reflects an imported key.
+                let cryptoKitPrivateKey = P256.Signing.PrivateKey()
+                let privateKey = try context.require(
+                    EC.PrivateKey(x963: cryptoKitPrivateKey.x963Representation, curve: .secp256r1),
+                    "Failed to build EC private key"
+                )
+                try await session.putPrivateKey(
+                    privateKey,
+                    in: .signature,
+                    pinPolicy: .always,
+                    touchPolicy: .never
+                )
+
+                let metadata = try await session.getMetadata(in: .signature)
+                context.expectEqual(metadata.keyType, .ec(.secp256r1), "key type")
+                context.expectEqual(metadata.pinPolicy, .always, "pin policy")
+                context.expectEqual(metadata.touchPolicy, .never, "touch policy")
+                context.expect(metadata.generated == false, "imported key should report generated == false")
+                context.expectEqual(
+                    metadata.publicKey,
+                    .ec(privateKey.publicKey),
+                    "metadata public key should match the imported key"
+                )
+            }
+        // MARK: - TestUnblockPin (set pin retries)
+        case .setPinRetriesRoundTrip:
+            return Scenario(
+                "PIV.PinPuk.setPinRetriesRoundTrip",
+                "setRetries takes effect, and wrong PIN/PUK then report the new remaining counts",
+                requirements: Requirements(capabilities: [.piv], minVersion: Version("5.3.0"), excludesBio: true)
+            ) { context in
+                let session = try await context.pivSession(authenticated: true)
+                let pinTries: UInt8 = 9
+                let pukTries: UInt8 = 7
+
+                try await session.verifyPin(defaultPIN)
+                try await session.setRetries(pin: pinTries, puk: pukTries)
+
+                context.expectEqual(
+                    try await session.getPinMetadata().retriesTotal,
+                    Int(pinTries),
+                    "PIN total retries should be the new value"
+                )
+
+                // A wrong PIN now reports pinTries - 1 remaining.
+                let pinResult = try await session.verifyPin("000000")
+                context.expectEqual(
+                    pinResult,
+                    .fail(Int(pinTries) - 1),
+                    "a wrong PIN should leave pinTries - 1 attempts"
+                )
+
+                // A wrong PUK (via change-PUK) reports pukTries - 1 remaining.
+                do {
+                    try await session.changePuk(from: "00000000", to: defaultPUK)
+                    context.record("changing the PUK with a wrong old PUK should have failed")
+                } catch let PIVSessionError.invalidPin(retries, _) {
+                    context.expectEqual(retries, Int(pukTries) - 1, "a wrong PUK should leave pukTries - 1 attempts")
+                }
+            }
         // MARK: - Device Information
+        // `piv info`; here the firmware version is read and checked to be v5).
         case .version:
             return Scenario(
                 "PIV.DeviceInfo.version",
@@ -840,18 +1106,7 @@ public enum PIVScenario: CaseIterable {
                 context.expect(version.major == 5, "expected firmware v5, got \(version)")
                 context.log("version: \(version.major).\(version.minor).\(version.micro)")
             }
-        case .serialNumber:
-            return Scenario(
-                "PIV.DeviceInfo.serialNumber",
-                "reports a serial number",
-                requirements: Requirements(capabilities: [.piv], minVersion: Version("5.0.0"))
-            ) { context in
-                let session = try await context.pivSession()
-                let serialNumber = try await session.getSerialNumber()
-                context.expect(serialNumber > 0, "serial number should be greater than 0")
-                context.log("serial number: \(serialNumber)")
-            }
-        // MARK: - Metadata
+        // MARK: - TestMetadata
         case .managementKey:
             return Scenario(
                 "PIV.Metadata.managementKey",
@@ -864,11 +1119,13 @@ public enum PIVScenario: CaseIterable {
                 context.log("management key type: \(metadata.keyType)")
                 context.log("management touch policy: \(metadata.touchPolicy)")
             }
+        // (generate per PIN/touch policy and assert key type, policies, generated flag, public key).
         case .slot:
             return Scenario(
                 "PIV.Metadata.slot",
                 "reads slot metadata for generated keys across PIN/touch policies",
-                requirements: Requirements(capabilities: [.piv], minVersion: Version("5.3.0"))
+                // Exercises PIN policy NEVER, which a FIPS device forbids; skip on FIPS.
+                requirements: Requirements(capabilities: [.piv], minVersion: Version("5.3.0"), excludesFIPS: true)
             ) { context in
                 let session = try await context.pivSession(authenticated: true)
 
@@ -937,6 +1194,7 @@ public enum PIVScenario: CaseIterable {
                 // An untouched PIN reports full retries; the default count is SKU-dependent (3 on a 5, 8 on Bio).
                 context.expectEqual(result.retriesRemaining, result.retriesTotal, "remaining retries should be full")
             }
+        // failed verify to assert the consumed retry rather than reading the default-state metadata).
         case .pinRetries:
             return Scenario(
                 "PIV.Metadata.pinRetries",
@@ -950,6 +1208,7 @@ public enum PIVScenario: CaseIterable {
                 // One failed verification consumes exactly one retry (the total is SKU-dependent: 3 on a 5, 8 on Bio).
                 context.expectEqual(result.retriesRemaining, result.retriesTotal - 1, "remaining after one failure")
             }
+        // cli/piv reads PUK tries only as `piv info` text).
         case .puk:
             return Scenario(
                 "PIV.Metadata.puk",
@@ -962,7 +1221,8 @@ public enum PIVScenario: CaseIterable {
                 context.expectEqual(result.retriesTotal, 3, "total retries")
                 context.expectEqual(result.retriesRemaining, 3, "remaining retries")
             }
-        // MARK: - Bio (multi-protocol)
+        // MARK: - TestBioMpe
+        // fingerprints and cli/piv has no Bio coverage; the full biometric + temporary-PIN flow is not covered).
         case .authentication:
             return Scenario(
                 "PIV.Bio.authentication",
@@ -994,6 +1254,7 @@ public enum PIVScenario: CaseIterable {
 
                 try await session.verify(temporaryPin: pinData)
             }
+        // rejected on a non-Bio YubiKey).
         case .pinPolicyErrorNonBio:
             return Scenario(
                 "PIV.Bio.pinPolicyErrorNonBio",
@@ -1042,6 +1303,70 @@ public enum PIVScenario: CaseIterable {
                     context.log("verifyUV correctly rejected with invalidPin")
                 }
             }
+        // MARK: - TestKeyManagement (generate requires auth)
+        case .generateKeyRequiresAuth:
+            return Scenario(
+                "PIV.KeyManagement.generateKeyRequiresAuth",
+                "generateKey without a prior management-key authenticate is rejected",
+                // The twin does not gate generateKey on management-key auth (it succeeds there),
+                // so this only meaningfully runs on real silicon.
+                requirements: Requirements(capabilities: [.piv], requiresRealHardware: true)
+            ) { context in
+                // No authenticate(): a fresh, reset session has not unlocked the management key.
+                let session = try await context.pivSession(authenticated: false, reset: true)
+                do {
+                    _ = try await session.generateKey(in: .authentication, type: .ec(.secp256r1))
+                    context.record("generateKey without authentication should have failed")
+                } catch PIVSessionError.failedResponse(let response, _) {
+                    context.expect(
+                        response.status == .securityConditionNotSatisfied,
+                        "expected securityConditionNotSatisfied generating a key without auth, got \(response.status)"
+                    )
+                }
+            }
+        case .putCertificateRequiresAuth:
+            return Scenario(
+                "PIV.KeyManagement.putCertificateRequiresAuth",
+                "putCertificate without a prior management-key authenticate is rejected",
+                requirements: Requirements(capabilities: [.piv], requiresRealHardware: true)
+            ) { context in
+                let session = try await context.pivSession(authenticated: false, reset: true)
+                do {
+                    try await session.putCertificate(testCertificate, in: .authentication)
+                    context.record("putCertificate without authentication should have failed")
+                } catch PIVSessionError.failedResponse(let response, _) {
+                    context.expect(
+                        response.status == .securityConditionNotSatisfied,
+                        "expected securityConditionNotSatisfied putting a certificate without auth, got \(response.status)"
+                    )
+                }
+            }
+        case .putKeyRequiresAuth:
+            return Scenario(
+                "PIV.KeyManagement.putKeyRequiresAuth",
+                "putKey without a prior management-key authenticate is rejected",
+                requirements: Requirements(capabilities: [.piv], requiresRealHardware: true)
+            ) { context in
+                let session = try await context.pivSession(authenticated: false, reset: true)
+                let privateKey = try context.require(
+                    EC.PrivateKey(x963: P256.Signing.PrivateKey().x963Representation, curve: .secp256r1),
+                    "Failed to build EC private key"
+                )
+                do {
+                    try await session.putPrivateKey(
+                        privateKey,
+                        in: .authentication,
+                        pinPolicy: .defaultPolicy,
+                        touchPolicy: .defaultPolicy
+                    )
+                    context.record("putPrivateKey without authentication should have failed")
+                } catch PIVSessionError.failedResponse(let response, _) {
+                    context.expect(
+                        response.status == .securityConditionNotSatisfied,
+                        "expected securityConditionNotSatisfied putting a key without auth, got \(response.status)"
+                    )
+                }
+            }
         }
     }
 }
@@ -1061,11 +1386,18 @@ private let testCertificate = X509Cert(
 
 // MARK: - Parameterized scenario builders
 
+/// Key types outside the FIPS-approved set (RSA-1024 and X25519). A YubiKey 5 FIPS rejects
+/// generating or importing them at the wire with `incorrectParameters` (0x6A80).
+private func fipsForbidden(_ keyType: PIV.KeyType) -> Bool {
+    keyType == .rsa(.bits1024) || keyType == .x25519
+}
+
 private func rsaSignScenario(_ keySize: RSA.KeySize, _ id: String) -> Scenario {
     Scenario(
         id,
         "signs a message with an RSA-\(keySize.bitCount) key (PKCS#1 v1.5 SHA-512)",
-        requirements: Requirements(capabilities: [.piv])
+        // RSA-1024 is below the FIPS-approved set; a FIPS device rejects it at the wire.
+        requirements: Requirements(capabilities: [.piv], excludesFIPS: keySize == .bits1024)
     ) { context in
         let session = try await context.pivSession(authenticated: true)
         let publicKey = try await session.generateKey(in: .signature, type: .rsa(keySize))
@@ -1094,7 +1426,8 @@ private func rsaDecryptScenario(_ keySize: RSA.KeySize, _ id: String) -> Scenari
     Scenario(
         id,
         "decrypts with a generated RSA-\(keySize.bitCount) key (PKCS#1 v1.5)",
-        requirements: Requirements(capabilities: [.piv])
+        // RSA-1024 is below the FIPS-approved set; a FIPS device rejects it at the wire.
+        requirements: Requirements(capabilities: [.piv], excludesFIPS: keySize == .bits1024)
     ) { context in
         let session = try await context.pivSession(authenticated: true)
         let publicKey = try await session.generateKey(in: .signature, type: .rsa(keySize))
@@ -1158,7 +1491,10 @@ private func rsaImportScenario(
     _ id: String,
     requirements: Requirements
 ) -> Scenario {
-    Scenario(
+    var requirements = requirements
+    // RSA-1024 is below the FIPS-approved set; a FIPS device rejects it at the wire.
+    if keySize == .bits1024 { requirements.excludesFIPS = true }
+    return Scenario(
         id,
         "imports an RSA-\(keySize.bitCount) key and decrypts with it",
         requirements: requirements
@@ -1243,7 +1579,10 @@ private func rsaGenerateScenario(
     _ id: String,
     requirements: Requirements
 ) -> Scenario {
-    Scenario(
+    var requirements = requirements
+    // RSA-1024 is below the FIPS-approved set; a FIPS device rejects it at the wire.
+    if keySize == .bits1024 { requirements.excludesFIPS = true }
+    return Scenario(
         id,
         "generates an RSA-\(keySize.bitCount) key",
         requirements: requirements
@@ -1343,5 +1682,352 @@ extension EC.PublicKey {
             kSecAttrKeySizeInBits: curve.keySizeInBits,
         ]
         return SecKeyCreateWithData(x963 as CFData, attributes as CFDictionary, nil)
+    }
+}
+
+// MARK: - Parameterized scenario families
+//
+// Parameterized families: import-decrypt, slot-metadata-generate, import-ECDH, FIPS key-type rejection,
+// and weak-PIN rejection.
+
+extension PIVScenario {
+
+    static var parameterizedScenarios: [Scenario] {
+        importDecryptScenarios + slotMetadataGenerateScenarios + importEcdhScenarios + fipsRejectionScenarios
+            + weakPinRejectionScenarios
+    }
+
+    // MARK: - TestPinComplexity
+    // complexity enabled, changing the PIN to a weak value (all-repeated digits, or a known-weak pattern)
+    // is rejected with 0x6985 (conditions-not-satisfied). PIN complexity is a 5.7 feature; there is no
+    // `requiresPinComplexity` requirement, so each scenario reads DeviceInfo at runtime and skips
+    // when the device does not enforce complexity.
+    private struct WeakPinParam: ScenarioParameter {
+        let idSuffix: String
+        let displayName: String
+        let requirements: Requirements
+        let weakPin: String
+
+        init(_ idSuffix: String, _ weakPin: String) {
+            self.idSuffix = idSuffix
+            self.displayName = "PIN complexity rejects changing the PIN to the weak value \(idSuffix)"
+            // PIN complexity is a YubiKey 5.7 feature; gate on the firmware as a floor, then
+            // confirm complexity is actually enabled inside the body before asserting rejection.
+            self.requirements = Requirements(capabilities: [.piv], minVersion: Version("5.7.0"))
+            self.weakPin = weakPin
+        }
+    }
+
+    private static var weakPinRejectionScenarios: [Scenario] {
+        // Repeated-digit PINs of varied lengths plus a known-weak repeated pattern.
+        let params: [WeakPinParam] = [
+            WeakPinParam("111111", "111111"),
+            WeakPinParam("22222222", "22222222"),
+            WeakPinParam("333333", "333333"),
+            WeakPinParam("123123", "123123"),
+        ]
+        return Scenario.parameterized("PIV.PinComplexity.rejectsWeakPins", over: params) { context, param in
+            let info = try await context.provider.deviceInfo()
+            guard info.pinComplexity else {
+                try context.skip("device does not enforce PIN complexity")
+            }
+            let session = try await context.pivSession(authenticated: true)
+            try await session.verifyPin(defaultPIN)
+            do {
+                try await session.changePin(from: defaultPIN, to: param.weakPin)
+                context.record("weak PIN \(param.idSuffix) should have been rejected under PIN complexity")
+            } catch PIVSessionError.failedResponse(let response, _) {
+                context.expect(
+                    response.status == .conditionsNotSatisfied,
+                    "expected conditionsNotSatisfied (0x6985) rejecting weak PIN \(param.idSuffix), got \(response.status)"
+                )
+            }
+        }
+    }
+
+    // MARK: - FIPS enforcement
+    // condition/skip rather than asserting they are rejected; these mirror the `excludesFIPS` scenarios, run only on FIPS).
+    private struct FIPSRejectionParam: ScenarioParameter {
+        let idSuffix: String
+        let displayName: String
+        let requirements: Requirements
+        let keyType: PIV.KeyType
+
+        init(_ idSuffix: String, _ keyType: PIV.KeyType) {
+            self.idSuffix = idSuffix
+            self.displayName = "a FIPS device rejects generating a \(idSuffix) key (outside the approved set)"
+            self.requirements = Requirements(capabilities: [.piv], minVersion: Version("5.7.0"), requiresFIPS: true)
+            self.keyType = keyType
+        }
+    }
+
+    private static var fipsRejectionScenarios: [Scenario] {
+        let keyTypeRejections = Scenario.parameterized(
+            "PIV.FIPS.rejectsForbiddenKeyType",
+            over: [FIPSRejectionParam("rsa1024", .rsa(.bits1024)), FIPSRejectionParam("x25519", .x25519)]
+        ) { context, param in
+            let session = try await context.pivSession(authenticated: true)
+            do {
+                _ = try await session.generateKey(in: .signature, type: param.keyType)
+                context.record("a FIPS device should reject generating a \(param.idSuffix) key")
+            } catch PIVSessionError.failedResponse(let response, _) {
+                context.expect(
+                    response.status == .incorrectParameters,
+                    "expected incorrectParameters (0x6A80) rejecting \(param.idSuffix), got \(response.status)"
+                )
+            }
+        }
+
+        let neverPolicyRejection = Scenario(
+            "PIV.FIPS.rejectsPinPolicyNever",
+            "a FIPS device rejects generating a key with PIN policy NEVER",
+            requirements: Requirements(capabilities: [.piv], minVersion: Version("5.7.0"), requiresFIPS: true)
+        ) { context in
+            let session = try await context.pivSession(authenticated: true)
+            do {
+                _ = try await session.generateKey(
+                    in: .signature,
+                    type: .ec(.secp256r1),
+                    pinPolicy: .never,
+                    touchPolicy: .never
+                )
+                context.record("a FIPS device should reject a key with PIN policy NEVER")
+            } catch PIVSessionError.failedResponse(let response, _) {
+                context.expect(
+                    response.status == .incorrectParameters,
+                    "expected incorrectParameters (0x6A80) rejecting PIN policy NEVER, got \(response.status)"
+                )
+            }
+        }
+
+        return keyTypeRejections + [neverPolicyRejection]
+    }
+
+    // MARK: - TestDecrypt
+    // a random plaintext in software (PKCS#1 v1.5), and verify the on-device decrypt round-trips.
+    private struct ImportDecryptParam: ScenarioParameter {
+        let idSuffix: String
+        let displayName: String
+        let requirements: Requirements
+        let keySize: RSA.KeySize
+
+        init(_ keySize: RSA.KeySize, minVersion: Version?) {
+            self.idSuffix = "rsa\(keySize.bitCount)"
+            self.displayName =
+                "imports an RSA-\(keySize.bitCount) key into KEY_MANAGEMENT and decrypts a random plaintext"
+            // RSA-1024 is below the FIPS-approved set; a FIPS device rejects it at the wire.
+            self.requirements = Requirements(
+                capabilities: [.piv],
+                minVersion: minVersion,
+                excludesFIPS: keySize == .bits1024
+            )
+            self.keySize = keySize
+        }
+    }
+
+    private static var importDecryptScenarios: [Scenario] {
+        let params: [ImportDecryptParam] = [
+            ImportDecryptParam(.bits1024, minVersion: nil),
+            ImportDecryptParam(.bits2048, minVersion: nil),
+            ImportDecryptParam(.bits3072, minVersion: Version("5.7.0")),
+            ImportDecryptParam(.bits4096, minVersion: Version("5.7.0")),
+        ]
+        return Scenario.parameterized("PIV.Decrypt.import", over: params) { context, param in
+            let session = try await context.pivSession(authenticated: true)
+            let privateKey = try context.require(
+                randomRSAPrivateKey(param.keySize),
+                "Failed to generate a software RSA-\(param.keySize.bitCount) key"
+            )
+            let publicKey = privateKey.publicKey
+
+            let keyType = try await session.putPrivateKey(
+                privateKey,
+                in: .keyManagement,
+                pinPolicy: .always,
+                touchPolicy: .never
+            )
+            context.expectEqual(keyType, PIV.RSAKey.rsa(param.keySize), "stored key type")
+
+            // Encrypt 32 random bytes in software with the public key (PKCS#1 v1.5), mirroring os.urandom(32).
+            let plaintext = randomBytes(count: 32)
+            let secKey = try context.require(publicKey.asSecKey(), "Failed to convert RSA public key to SecKey")
+            let encryptedData = try context.require(
+                SecKeyCreateEncryptedData(secKey, .rsaEncryptionPKCS1, plaintext as CFData, nil) as Data?,
+                "Failed to encrypt plaintext with SecKeyCreateEncryptedData"
+            )
+
+            try await session.verifyPin(defaultPIN)
+            let decryptedData = try await session.decrypt(encryptedData, in: .keyManagement, using: .pkcs1v15)
+            context.expectEqual(plaintext, decryptedData, "decrypted data should match the random plaintext")
+        }
+    }
+
+    // MARK: - TestMetadata (slot generate)
+    // metadata (keyType, pinPolicy ALWAYS, touchPolicy NEVER, generated == true, public-key match).
+    private struct SlotMetadataGenerateParam: ScenarioParameter {
+        let idSuffix: String
+        let displayName: String
+        let requirements: Requirements
+        let keyType: PIV.KeyType
+
+        init(_ idSuffix: String, _ keyType: PIV.KeyType, minVersion: Version?) {
+            self.idSuffix = idSuffix
+            self.displayName = "reads slot metadata for a generated \(idSuffix) key"
+            self.requirements = Requirements(
+                capabilities: [.piv],
+                minVersion: minVersion ?? Version("5.3.0"),
+                excludesFIPS: fipsForbidden(keyType)
+            )
+            self.keyType = keyType
+        }
+    }
+
+    private static var slotMetadataGenerateScenarios: [Scenario] {
+        let v570 = Version("5.7.0")
+        let params: [SlotMetadataGenerateParam] = [
+            SlotMetadataGenerateParam("rsa1024", .rsa(.bits1024), minVersion: nil),
+            SlotMetadataGenerateParam("rsa2048", .rsa(.bits2048), minVersion: nil),
+            SlotMetadataGenerateParam("rsa3072", .rsa(.bits3072), minVersion: v570),
+            SlotMetadataGenerateParam("rsa4096", .rsa(.bits4096), minVersion: v570),
+            SlotMetadataGenerateParam("eccp256", .ec(.secp256r1), minVersion: nil),
+            SlotMetadataGenerateParam("eccp384", .ec(.secp384r1), minVersion: nil),
+            SlotMetadataGenerateParam("ed25519", .ed25519, minVersion: v570),
+            SlotMetadataGenerateParam("x25519", .x25519, minVersion: v570),
+        ]
+        return Scenario.parameterized("PIV.Metadata.slotGenerate", over: params) { context, param in
+            let session = try await context.pivSession(authenticated: true)
+            // pin_policy DEFAULT resolves to ALWAYS and touch_policy to NEVER for the SIGNATURE slot.
+            let publicKey = try await session.generateKey(
+                in: .signature,
+                type: param.keyType,
+                pinPolicy: .always,
+                touchPolicy: .never
+            )
+            let metadata = try await session.getMetadata(in: .signature)
+            context.expectEqual(metadata.keyType, param.keyType, "key type")
+            context.expectEqual(metadata.pinPolicy, .always, "pin policy")
+            context.expectEqual(metadata.touchPolicy, .never, "touch policy")
+            context.expect(metadata.generated == true, "generated key should report generated == true")
+            context.expectEqual(metadata.publicKey, publicKey, "metadata public key should match the generated key")
+        }
+    }
+
+    // MARK: - TestKeyAgreement (import)
+    // on-device shared secret matches a software ECDH against a fresh peer key.
+    private struct ImportEcdhParam: ScenarioParameter {
+        let idSuffix: String
+        let displayName: String
+        let requirements: Requirements
+        let keyType: PIV.KeyType
+
+        init(_ idSuffix: String, _ keyType: PIV.KeyType, minVersion: Version?) {
+            self.idSuffix = idSuffix
+            self.displayName = "imports a \(idSuffix) key and computes a shared secret matching software ECDH"
+            self.requirements = Requirements(
+                capabilities: [.piv],
+                minVersion: minVersion,
+                excludesFIPS: fipsForbidden(keyType)
+            )
+            self.keyType = keyType
+        }
+    }
+
+    private static var importEcdhScenarios: [Scenario] {
+        let params: [ImportEcdhParam] = [
+            ImportEcdhParam("eccp256", .ec(.secp256r1), minVersion: nil),
+            ImportEcdhParam("eccp384", .ec(.secp384r1), minVersion: nil),
+            ImportEcdhParam("x25519", .x25519, minVersion: Version("5.7.0")),
+        ]
+        return Scenario.parameterized("PIV.KeyAgreement.import", over: params) { context, param in
+            let session = try await context.pivSession(authenticated: true)
+
+            switch param.keyType {
+            case .ec(let curve):
+                let peerSecret: Data
+                let peerPublicKey: EC.PublicKey
+                let importedPrivateKey: EC.PrivateKey
+                switch curve {
+                case .secp256r1:
+                    let deviceKey = P256.KeyAgreement.PrivateKey()
+                    importedPrivateKey = try context.require(
+                        EC.PrivateKey(x963: deviceKey.x963Representation, curve: curve),
+                        "Failed to build EC private key"
+                    )
+                    let peer = P256.KeyAgreement.PrivateKey()
+                    peerPublicKey = try context.require(
+                        EC.PublicKey(x963: peer.publicKey.x963Representation, curve: curve),
+                        "Failed to build peer public key"
+                    )
+                    let devicePublicKey = try P256.KeyAgreement.PublicKey(
+                        x963Representation: importedPrivateKey.publicKey.x963
+                    )
+                    peerSecret = try peer.sharedSecretFromKeyAgreement(with: devicePublicKey)
+                        .withUnsafeBytes { Data($0) }
+                case .secp384r1:
+                    let deviceKey = P384.KeyAgreement.PrivateKey()
+                    importedPrivateKey = try context.require(
+                        EC.PrivateKey(x963: deviceKey.x963Representation, curve: curve),
+                        "Failed to build EC private key"
+                    )
+                    let peer = P384.KeyAgreement.PrivateKey()
+                    peerPublicKey = try context.require(
+                        EC.PublicKey(x963: peer.publicKey.x963Representation, curve: curve),
+                        "Failed to build peer public key"
+                    )
+                    let devicePublicKey = try P384.KeyAgreement.PublicKey(
+                        x963Representation: importedPrivateKey.publicKey.x963
+                    )
+                    peerSecret = try peer.sharedSecretFromKeyAgreement(with: devicePublicKey)
+                        .withUnsafeBytes { Data($0) }
+                }
+
+                try await session.putPrivateKey(
+                    importedPrivateKey,
+                    in: .keyManagement,
+                    pinPolicy: .always,
+                    touchPolicy: .never
+                )
+                try await session.verifyPin(defaultPIN)
+                let yubiKeySecret = try await session.deriveSharedSecret(in: .keyManagement, with: peerPublicKey)
+                context.expectEqual(peerSecret, yubiKeySecret, "imported EC key agreement must match software ECDH")
+
+            case .x25519:
+                let deviceKey = Curve25519.KeyAgreement.PrivateKey()
+                let importedPublicKey = try context.require(
+                    X25519.PublicKey(keyData: deviceKey.publicKey.rawRepresentation),
+                    "Failed to create YubiKit X25519 public key"
+                )
+                let importedPrivateKey = try context.require(
+                    X25519.PrivateKey(scalar: deviceKey.rawRepresentation, publicKey: importedPublicKey),
+                    "Failed to create YubiKit X25519 private key"
+                )
+
+                let peer = Curve25519.KeyAgreement.PrivateKey()
+                let peerPublicKey = try context.require(
+                    X25519.PublicKey(keyData: peer.publicKey.rawRepresentation),
+                    "Failed to create peer X25519 public key"
+                )
+                let peerSecret = try peer.sharedSecretFromKeyAgreement(
+                    with: Curve25519.KeyAgreement.PublicKey(rawRepresentation: importedPublicKey.keyData)
+                ).withUnsafeBytes { Data($0) }
+
+                try await session.putPrivateKey(
+                    importedPrivateKey,
+                    in: .keyManagement,
+                    pinPolicy: .always,
+                    touchPolicy: .never
+                )
+                try await session.verifyPin(defaultPIN)
+                let yubiKeySecret = try await session.deriveSharedSecret(in: .keyManagement, with: peerPublicKey)
+                context.expectEqual(
+                    peerSecret,
+                    yubiKeySecret,
+                    "imported X25519 key agreement must match software ECDH"
+                )
+
+            case .rsa, .ed25519:
+                try context.skip("key agreement is only defined for EC and X25519 keys")
+            }
+        }
     }
 }

--- a/YubiKit/IntegrationScenarios/Scenarios/SCP.swift
+++ b/YubiKit/IntegrationScenarios/Scenarios/SCP.swift
@@ -18,10 +18,9 @@ import Foundation
 import YubiKit
 
 /// Secure Channel Protocol scenarios.
-public enum SCPScenario: CaseIterable {
+public enum SCPScenario: CaseIterable, ScenarioSuite {
 
     case defaultKeys
-    case managementDeviceInfo
     case importKeySCP03
     case deleteKey
     case replaceKey
@@ -43,7 +42,7 @@ public enum SCPScenario: CaseIterable {
 
     private var definition: Scenario {
         switch self {
-        // MARK: - SCP03
+        // MARK: - TestScp03
         case .defaultKeys:
             return Scenario(
                 "SCP.SCP03.defaultKeys",
@@ -57,20 +56,6 @@ public enum SCPScenario: CaseIterable {
                 )
                 let info = try await management.getDeviceInfo()
                 context.expect(info.version.major >= 4, "authenticated SCP03 session returns a device info")
-            }
-        case .managementDeviceInfo:
-            return Scenario(
-                "SCP.SCP03.managementDeviceInfo",
-                "Management.getDeviceInfo over an SCP03 secure channel",
-                requirements: Requirements(requiresSCP: true)
-            ) { context in
-                let connection = try await resetSecurityDomain(context)
-                let management = try await Management.Session.makeSession(
-                    connection: connection,
-                    scpKeyParams: scpDefaultKeyParams
-                )
-                let deviceInfo = try await management.getDeviceInfo()
-                context.expect(deviceInfo.serialNumber > 0, "device info via SCP03 should carry a serial number")
             }
         case .importKeySCP03:
             return Scenario(
@@ -121,8 +106,16 @@ public enum SCPScenario: CaseIterable {
             ) { context in
                 let connection = try await resetSecurityDomain(context)
 
-                let staticKeys1 = StaticKeys(enc: randomKeyBytes(), mac: randomKeyBytes(), dek: randomKeyBytes())
-                let staticKeys2 = StaticKeys(enc: randomKeyBytes(), mac: randomKeyBytes(), dek: randomKeyBytes())
+                let staticKeys1 = StaticKeys(
+                    enc: randomBytes(count: 16),
+                    mac: randomBytes(count: 16),
+                    dek: randomBytes(count: 16)
+                )
+                let staticKeys2 = StaticKeys(
+                    enc: randomBytes(count: 16),
+                    mac: randomBytes(count: 16),
+                    dek: randomBytes(count: 16)
+                )
 
                 let keyRef1 = SCPKeyRef(kid: .scp03, kvn: 0x10)
                 let keyRef2 = SCPKeyRef(kid: .scp03, kvn: 0x55)
@@ -172,8 +165,16 @@ public enum SCPScenario: CaseIterable {
             ) { context in
                 let connection = try await resetSecurityDomain(context)
 
-                let sk1 = StaticKeys(enc: randomKeyBytes(), mac: randomKeyBytes(), dek: randomKeyBytes())
-                let sk2 = StaticKeys(enc: randomKeyBytes(), mac: randomKeyBytes(), dek: randomKeyBytes())
+                let sk1 = StaticKeys(
+                    enc: randomBytes(count: 16),
+                    mac: randomBytes(count: 16),
+                    dek: randomBytes(count: 16)
+                )
+                let sk2 = StaticKeys(
+                    enc: randomBytes(count: 16),
+                    mac: randomBytes(count: 16),
+                    dek: randomBytes(count: 16)
+                )
 
                 let keyRef1 = SCPKeyRef(kid: .scp03, kvn: 0x10)
                 let keyRef2 = SCPKeyRef(kid: .scp03, kvn: 0x55)
@@ -210,7 +211,11 @@ public enum SCPScenario: CaseIterable {
             ) { context in
                 let connection = try await resetSecurityDomain(context)
 
-                let sk = StaticKeys(enc: randomKeyBytes(), mac: randomKeyBytes(), dek: randomKeyBytes())
+                let sk = StaticKeys(
+                    enc: randomBytes(count: 16),
+                    mac: randomBytes(count: 16),
+                    dek: randomBytes(count: 16)
+                )
                 let keyRef = SCPKeyRef(kid: .scp03, kvn: 0x01)
                 let params = try SCP03KeyParams(keyRef: keyRef, staticKeys: sk)
 
@@ -243,7 +248,8 @@ public enum SCPScenario: CaseIterable {
                 _ = try await session.getKeyInformation()
                 context.log("default key authenticates after a wrong-key failure")
             }
-        // MARK: - SCP11a
+        // MARK: - TestScp11
+        // MARK: SCP11a
         case .authenticateSCP11a:
             return Scenario(
                 "SCP.SCP11a.authenticate",
@@ -382,7 +388,7 @@ public enum SCPScenario: CaseIterable {
 
                 context.log("allow-list correctly blocked and then allowed SCP11a authentication")
             }
-        // MARK: - SCP11b
+        // MARK: SCP11b
         case .authenticateSCP11b:
             return Scenario(
                 "SCP.SCP11b.authenticate",
@@ -474,7 +480,7 @@ public enum SCPScenario: CaseIterable {
 
                 context.log("successfully imported SCP11b key pair and authenticated")
             }
-        // MARK: - SCP11c
+        // MARK: SCP11c
         case .authenticateSCP11c:
             return Scenario(
                 "SCP.SCP11c.authenticate",
@@ -515,7 +521,7 @@ public enum SCPScenario: CaseIterable {
                     }
                 }
             }
-        // MARK: - Security Domain
+        // MARK: - Security Domain free functions
         // MARK: Key info
         case .keyInformation:
             return Scenario(
@@ -585,7 +591,7 @@ public enum SCPScenario: CaseIterable {
                 )
             }
         // MARK: Reset
-        // Also asserts that reset restores the default SCP03 key set.
+        // Verifies the default SCP03 key set (KID 0x01 / KVN 0xFF) is present in getKeyInformation after reset.
         case .resetRestoresDefaultKeys:
             return Scenario(
                 "SCP.SecurityDomain.resetRestoresDefaultKeys",
@@ -616,20 +622,16 @@ private func resetSecurityDomain(_ context: Scenario.Context) async throws -> an
     let connection = try await context.smartCardConnection()
     try await SecurityDomainSession.makeSession(connection: connection).reset()
     await context.addTeardown {
-        guard let cleanup = try? await SecurityDomainSession.makeSession(connection: connection) else { return }
-        try? await cleanup.reset()
+        let cleanup = try await SecurityDomainSession.makeSession(connection: connection)
+        try await cleanup.reset()
     }
     return connection
-}
-
-private func randomKeyBytes() -> Data {
-    Data((0..<16).map { _ in UInt8.random(in: 0x00...0xFF) })
 }
 
 /// Imports a fresh random SCP03 key set.
 private func importScp03Key(connection: any SmartCardConnection) async throws -> SCP03KeyParams {
     let scp03Ref = SCPKeyRef(kid: 0x01, kvn: 0x01)
-    let staticKeys = StaticKeys(enc: randomKeyBytes(), mac: randomKeyBytes(), dek: randomKeyBytes())
+    let staticKeys = StaticKeys(enc: randomBytes(count: 16), mac: randomBytes(count: 16), dek: randomBytes(count: 16))
 
     let session = try await SecurityDomainSession.makeSession(
         connection: connection,

--- a/YubiKit/IntegrationScenarios/Scenarios/WebAuthn.swift
+++ b/YubiKit/IntegrationScenarios/Scenarios/WebAuthn.swift
@@ -16,23 +16,21 @@ import Foundation
 import YubiKit
 
 /// WebAuthn `Client` scenarios.
-public enum WebAuthnScenario: CaseIterable {
+public enum WebAuthnScenario: CaseIterable, ScenarioSuite {
 
     case makeCredentialGetAssertion
     case allowCredentials
+    case allowCredentialsMultiple
+    case allowCredentialsIneligible
     case allowListNoMatch
     case excludeCredentials
+    case excludeCredentialsMultiple
+    case excludeCredentialsMax
+    case excludeCredentialsOthers
     case multipleCredentialsCeremony
     case rpIdMismatch
     case publicSuffixRejected
-    case wrongPin
-    case clientDataJSON
-    case statusStream
     case discoverableNoCredentials
-    case prefetchedPinMakeCredential
-    case prefetchedPinGetAssertion
-    case cancelMakeCredential
-    case allLevels
     case derive
     case makeCredential
     case storeRetrieveLargeBlob
@@ -41,9 +39,6 @@ public enum WebAuthnScenario: CaseIterable {
     case storeRetrieveCredBlob
     case notReturnedWithoutExtension
     case oversizedRejected
-    case discoverable
-    case nonDiscoverable
-    case notRequested
     case returnsValue
     case noOutputWithoutInput
     case generateKey
@@ -84,10 +79,12 @@ public enum WebAuthnScenario: CaseIterable {
                 )
 
                 context.touch("Touch the key to authenticate")
-                let assertResponse = try await assertionAfterNFCReconnect(
-                    context,
+                let authClient = try await context.webAuthnClientAfterNFCReconnect()
+                let assertResponse = try await assertion(
+                    from: authClient,
                     options: requestOptions,
                     matching: createResponse.credentialId,
+                    context
                 )
 
                 context.expect(assertResponse.rawAuthenticatorData.count > 0, "authenticator data should be present")
@@ -131,6 +128,82 @@ public enum WebAuthnScenario: CaseIterable {
                 context.expect(assertResponse.credentialId == createResponse.credentialId, "credentialId should match")
                 context.expect(assertResponse.signature.count > 0, "signature should be present")
             }
+        case .allowCredentialsMultiple:
+            return Scenario(
+                "WebAuthn.Ceremony.allowCredentialsMultiple",
+                "getAssertion picks the real credential out of an allow-list padded with decoys",
+                requirements: Requirements(capabilities: [.fido2])
+            ) { context in
+                try await ensurePinSet(context)
+                let client = try await context.webAuthnClient()
+
+                let createOptions = WebAuthn.Registration.Options(
+                    challenge: randomBytes(count: 32),
+                    rp: .init(id: testRpId, name: testRpName),
+                    user: .init(
+                        id: randomBytes(count: 32),
+                        name: "allow-multi@example.com",
+                        displayName: "Allow Multi User"
+                    ),
+                    residentKey: .required
+                )
+
+                context.touch("Touch the key to create a credential")
+                let createResponse = try await client.makeCredential(createOptions, authorization: .pin(defaultTestPin))
+                    .value
+
+                // Decoys with the real credential inserted at a middle index, mirroring the Python test.
+                var allowCredentials = (0..<5).map { _ in
+                    WebAuthn.CredentialDescriptor(id: randomBytes(count: 32))
+                }
+                allowCredentials.insert(.init(id: createResponse.credentialId), at: 3)
+
+                let requestOptions = WebAuthn.Authentication.Options(
+                    challenge: randomBytes(count: 32),
+                    rpId: testRpId,
+                    allowCredentials: allowCredentials
+                )
+
+                context.touch("Touch the key to authenticate")
+                let assertResponse = try await assertion(
+                    from: client,
+                    options: requestOptions,
+                    matching: createResponse.credentialId,
+                    context
+                )
+
+                context.expect(
+                    assertResponse.credentialId == createResponse.credentialId,
+                    "asserted credentialId should be the real one, not a decoy"
+                )
+                context.expect(assertResponse.signature.count > 0, "signature should be present")
+            }
+        case .allowCredentialsIneligible:
+            return Scenario(
+                "WebAuthn.Ceremony.allowCredentialsIneligible",
+                "getAssertion with an allow-list of only decoys throws noCredentials",
+                requirements: Requirements(capabilities: [.fido2])
+            ) { context in
+                try await ensurePinSet(context)
+                let client = try await context.webAuthnClient()
+
+                let allowCredentials = (0..<5).map { _ in
+                    WebAuthn.CredentialDescriptor(id: randomBytes(count: 32))
+                }
+                let requestOptions = WebAuthn.Authentication.Options(
+                    challenge: randomBytes(count: 32),
+                    rpId: testRpId,
+                    allowCredentials: allowCredentials
+                )
+
+                context.touch("Touch the key to authenticate")
+                await context.expectThrows(
+                    "getAssertion with an ineligible allow-list",
+                    matching: { if case WebAuthn.ClientError.noCredentials = $0 { true } else { false } }
+                ) {
+                    _ = try await client.getAssertion(requestOptions, authorization: .pin(defaultTestPin)).value
+                }
+            }
         case .allowListNoMatch:
             return Scenario(
                 "WebAuthn.Ceremony.allowListNoMatch",
@@ -147,15 +220,11 @@ public enum WebAuthnScenario: CaseIterable {
                 )
 
                 context.touch("Touch the key to authenticate")
-                do {
+                await context.expectThrows(
+                    "getAssertion with an allow-list that matches nothing",
+                    matching: { if case WebAuthn.ClientError.noCredentials = $0 { true } else { false } }
+                ) {
                     _ = try await client.getAssertion(requestOptions, authorization: .pin(defaultTestPin)).value
-                    context.record("Should have thrown noCredentials error")
-                } catch let error as WebAuthn.ClientError {
-                    if case .noCredentials = error {
-                        context.log("Correctly received noCredentials error")
-                    } else {
-                        context.record("Expected noCredentials error, got: \(error)")
-                    }
                 }
             }
         case .excludeCredentials:
@@ -191,21 +260,140 @@ public enum WebAuthnScenario: CaseIterable {
                 )
 
                 context.touch("Touch the key for the excluded credential attempt")
-                do {
-                    let excludeClient = try await context.webAuthnClientAfterNFCReconnect()
-                    _ = try await excludeClient.makeCredential(
-                        excludeOptions,
-                        authorization: .pin(defaultTestPin)
-                    ).value
-                    context.record("Should have thrown credentialExcluded error")
-                } catch let error as WebAuthn.ClientError {
-                    if case .credentialExcluded = error {
-                        context.log("Correctly received credentialExcluded error")
-                    } else {
-                        context.record("Expected credentialExcluded error, got: \(error)")
-                    }
+                await context.expectThrows(
+                    "makeCredential excluding an already-registered credential",
+                    matching: { if case WebAuthn.ClientError.credentialExcluded = $0 { true } else { false } }
+                ) {
+                    _ = try await client.makeCredential(excludeOptions, authorization: .pin(defaultTestPin)).value
                 }
             }
+        case .excludeCredentialsMultiple:
+            return Scenario(
+                "WebAuthn.Ceremony.excludeCredentialsMultiple",
+                "makeCredential rejects when the excluded credential sits among decoys",
+                requirements: Requirements(capabilities: [.fido2])
+            ) { context in
+                try await ensurePinSet(context)
+                let client = try await context.webAuthnClient()
+
+                let createOptions = WebAuthn.Registration.Options(
+                    challenge: randomBytes(count: 32),
+                    rp: .init(id: testRpId, name: testRpName),
+                    user: .init(
+                        id: randomBytes(count: 32),
+                        name: "exclude-multi@example.com",
+                        displayName: "Exclude Multi User"
+                    ),
+                    residentKey: .required
+                )
+
+                context.touch("Touch the key to create the initial credential")
+                let createResponse = try await client.makeCredential(createOptions, authorization: .pin(defaultTestPin))
+                    .value
+
+                // Decoys with the real (registered) credential inserted at a middle index.
+                var excludeCredentials = (0..<5).map { _ in
+                    WebAuthn.CredentialDescriptor(id: randomBytes(count: 32))
+                }
+                excludeCredentials.insert(.init(id: createResponse.credentialId), at: 3)
+
+                let excludeOptions = WebAuthn.Registration.Options(
+                    challenge: randomBytes(count: 32),
+                    rp: .init(id: testRpId, name: testRpName),
+                    user: .init(
+                        id: randomBytes(count: 32),
+                        name: "exclude-multi2@example.com",
+                        displayName: "Exclude Multi User 2"
+                    ),
+                    excludeCredentials: excludeCredentials,
+                    residentKey: .required
+                )
+
+                context.touch("Touch the key for the excluded credential attempt")
+                await context.expectThrows(
+                    "makeCredential excluding a credential hidden among decoys",
+                    matching: { if case WebAuthn.ClientError.credentialExcluded = $0 { true } else { false } }
+                ) {
+                    _ = try await client.makeCredential(excludeOptions, authorization: .pin(defaultTestPin)).value
+                }
+            }
+        case .excludeCredentialsMax:
+            return Scenario(
+                "WebAuthn.Ceremony.excludeCredentialsMax",
+                "makeCredential succeeds with a non-matching exclude list that overflows a single batch",
+                requirements: Requirements(capabilities: [.fido2])
+            ) { context in
+                try await ensurePinSet(context)
+                let session = try await context.ctap2Session()
+                let info = try await session.getInfo()
+
+                // Build more excludes than fit one batch, each maxCredentialIdLength bytes, none matching —
+                // this forces the client to chunk the exclude list across multiple authenticator calls.
+                let maxIdLength = Int(info.maxCredentialIdLength ?? 32)
+                let countInList = Int(info.maxCredentialCountInList ?? 1)
+                let excludeCount = countInList + 2
+                let excludeCredentials = (0..<excludeCount).map { _ in
+                    WebAuthn.CredentialDescriptor(id: randomBytes(count: maxIdLength))
+                }
+
+                let client = WebAuthn.Client(
+                    session: session,
+                    origin: try WebAuthn.Origin(testOrigin),
+                    isPublicSuffix: { _ in false }
+                )
+                let createOptions = WebAuthn.Registration.Options(
+                    challenge: randomBytes(count: 32),
+                    rp: .init(id: testRpId, name: testRpName),
+                    user: .init(
+                        id: randomBytes(count: 32),
+                        name: "exclude-max@example.com",
+                        displayName: "Exclude Max User"
+                    ),
+                    excludeCredentials: excludeCredentials,
+                    residentKey: .required
+                )
+
+                context.touch("Touch the key to create a credential")
+                let createResponse = try await client.makeCredential(createOptions, authorization: .pin(defaultTestPin))
+                    .value
+                context.expect(
+                    createResponse.credentialId.count > 0,
+                    "registration should succeed when no exclude entry matches"
+                )
+            }
+        case .excludeCredentialsOthers:
+            return Scenario(
+                "WebAuthn.Ceremony.excludeCredentialsOthers",
+                "makeCredential succeeds when the exclude list holds only decoys",
+                requirements: Requirements(capabilities: [.fido2])
+            ) { context in
+                try await ensurePinSet(context)
+                let client = try await context.webAuthnClient()
+
+                let excludeCredentials = (0..<5).map { _ in
+                    WebAuthn.CredentialDescriptor(id: randomBytes(count: 32))
+                }
+                let createOptions = WebAuthn.Registration.Options(
+                    challenge: randomBytes(count: 32),
+                    rp: .init(id: testRpId, name: testRpName),
+                    user: .init(
+                        id: randomBytes(count: 32),
+                        name: "exclude-others@example.com",
+                        displayName: "Exclude Others User"
+                    ),
+                    excludeCredentials: excludeCredentials,
+                    residentKey: .required
+                )
+
+                context.touch("Touch the key to create a credential")
+                let createResponse = try await client.makeCredential(createOptions, authorization: .pin(defaultTestPin))
+                    .value
+                context.expect(
+                    createResponse.credentialId.count > 0,
+                    "registration should succeed when no exclude entry matches"
+                )
+            }
+        // extended here to register several residents and assert one match per credential for selection)
         case .multipleCredentialsCeremony:
             return Scenario(
                 "WebAuthn.Ceremony.multipleCredentials",
@@ -319,175 +507,6 @@ public enum WebAuthnScenario: CaseIterable {
                     }
                 }
             }
-        case .wrongPin:
-            return Scenario(
-                "WebAuthn.Ceremony.wrongPin",
-                "makeCredential with the wrong PIN throws pinRejected and decrements retries",
-                requirements: Requirements(capabilities: [.fido2])
-            ) { context in
-                try await ensurePinSet(context)
-                let client = try await context.webAuthnClient()
-
-                let options = WebAuthn.Registration.Options(
-                    challenge: randomBytes(count: 32),
-                    rp: .init(id: testRpId, name: testRpName),
-                    user: .init(
-                        id: randomBytes(count: 32),
-                        name: "wrongpin@example.com",
-                        displayName: "Wrong PIN User"
-                    ),
-                    residentKey: .discouraged
-                )
-
-                do {
-                    _ = try await client.makeCredential(options, authorization: .pin("wrongpin123")).value
-                    context.record("Should have thrown pinRejected error")
-                } catch let error as WebAuthn.ClientError {
-                    if case .pinRejected(let retries, _) = error {
-                        context.expect(retries < 8, "Retry counter should have decremented")
-                        context.log("Correctly received pinRejected with \(retries) retries remaining")
-                    } else {
-                        context.record("Expected pinRejected error, got: \(error)")
-                    }
-                }
-            }
-        case .clientDataJSON:
-            return Scenario(
-                "WebAuthn.Ceremony.clientDataJSON",
-                "clientDataJSON serializes with spec key ordering",
-                requirements: Requirements(capabilities: [.fido2])
-            ) { context in
-                try await ensurePinSet(context)
-                let client = try await context.webAuthnClient()
-                let challenge = randomBytes(count: 32)
-
-                let options = WebAuthn.Registration.Options(
-                    challenge: challenge,
-                    rp: .init(id: testRpId, name: testRpName),
-                    user: .init(
-                        id: randomBytes(count: 32),
-                        name: "clientdata@example.com",
-                        displayName: "ClientData Test"
-                    ),
-                    residentKey: .required
-                )
-
-                let clientData = WebAuthn.ClientData.webauthn(
-                    type: "webauthn.create",
-                    challenge: challenge,
-                    origin: try WebAuthn.Origin(testOrigin),
-                    rpId: testRpId,
-                    crossOrigin: false
-                )
-
-                context.touch("Touch the key to create a credential")
-                let response = try await client.makeCredential(
-                    options,
-                    clientData: clientData,
-                    authorization: .pin(defaultTestPin)
-                ).value
-
-                // Recover the serialized clientDataJSON from the public JSON envelope.
-                let envelope = try JSONSerialization.jsonObject(with: response.toJSON(), options: []) as? [String: Any]
-                let inner = envelope?["response"] as? [String: Any]
-                let clientDataB64 = try context.require(
-                    inner?["clientDataJSON"] as? String,
-                    "clientDataJSON should be present in toJSON output"
-                )
-                let clientDataJSON = try context.require(
-                    decodeBase64URL(clientDataB64),
-                    "clientDataJSON should base64url-decode"
-                )
-                let jsonString = try context.require(
-                    String(data: clientDataJSON, encoding: .utf8),
-                    "clientDataJSON should be valid UTF-8"
-                )
-                context.log("clientDataJSON: \(jsonString)")
-
-                context.expect(jsonString.contains("\"type\""), "should contain type")
-                context.expect(jsonString.contains("\"challenge\""), "should contain challenge")
-                context.expect(jsonString.contains("\"origin\""), "should contain origin")
-                context.expect(jsonString.contains("\"crossOrigin\""), "should contain crossOrigin")
-                context.expect(jsonString.contains("webauthn.create"), "should contain webauthn.create")
-                context.expect(jsonString.contains("example.com"), "should contain example.com")
-
-                // Verify key ordering per WebAuthn spec: type, challenge, origin, crossOrigin.
-                let typeIndex = try context.require(jsonString.range(of: "\"type\"")?.lowerBound, "type key present")
-                let challengeIndex = try context.require(
-                    jsonString.range(of: "\"challenge\"")?.lowerBound,
-                    "challenge key present"
-                )
-                let originIndex = try context.require(
-                    jsonString.range(of: "\"origin\"")?.lowerBound,
-                    "origin key present"
-                )
-                let crossOriginIndex = try context.require(
-                    jsonString.range(of: "\"crossOrigin\"")?.lowerBound,
-                    "crossOrigin key present"
-                )
-                context.expect(typeIndex < challengeIndex, "type should come before challenge")
-                context.expect(challengeIndex < originIndex, "challenge should come before origin")
-                context.expect(originIndex < crossOriginIndex, "origin should come before crossOrigin")
-            }
-        case .statusStream:
-            return Scenario(
-                "WebAuthn.Ceremony.statusStream",
-                "getAssertion status stream delivers user-presence events and pulls the PIN via closure",
-                requirements: Requirements(capabilities: [.fido2])
-            ) { context in
-                try await ensurePinSet(context)
-                let client = try await context.webAuthnClient()
-
-                let createOptions = WebAuthn.Registration.Options(
-                    challenge: randomBytes(count: 32),
-                    rp: .init(id: testRpId, name: testRpName),
-                    user: .init(id: randomBytes(count: 32), name: "stream@example.com", displayName: "Stream User"),
-                    residentKey: .required
-                )
-
-                context.touch("Touch the key to create a credential")
-                _ = try await client.makeCredential(createOptions, authorization: .pin(defaultTestPin)).value
-
-                let requestOptions = WebAuthn.Authentication.Options(
-                    challenge: randomBytes(count: 32),
-                    rpId: testRpId
-                )
-
-                let pinAsks = Box(0)
-                var sawWaitingForUser = false
-                var matches: [WebAuthn.Authentication.Response]?
-
-                context.touch("Touch the key to authenticate")
-                let authClient = try await context.webAuthnClientAfterNFCReconnect()
-                let stream = await authClient.getAssertion(
-                    requestOptions,
-                    authorization: .init(
-                        providePIN: {
-                            pinAsks.value += 1
-                            return .pin(defaultTestPin)
-                        },
-                        uv: .skipped
-                    )
-                )
-                for try await status in stream {
-                    switch status {
-                    case .processing:
-                        break
-                    case .waitingForUser:
-                        sawWaitingForUser = true
-                    case .waitingForUserVerification:
-                        context.record("UV should be skipped under .pin authorization")
-                    case .finished(let result):
-                        matches = result
-                    }
-                }
-
-                context.expect(pinAsks.value == 1, "PIN closure should have been invoked exactly once")
-                context.expect(sawWaitingForUser, "Stream should have delivered waitingForUser")
-                let resolved = try context.require(matches, "Stream should have delivered .finished with matches")
-                context.expect(!resolved.isEmpty, "Should have at least one matched credential")
-                context.expect((resolved.first?.signature.count ?? 0) > 0, "signature should be present")
-            }
         case .discoverableNoCredentials:
             return Scenario(
                 "WebAuthn.Ceremony.discoverableNoCredentials",
@@ -504,236 +523,12 @@ public enum WebAuthnScenario: CaseIterable {
                 )
 
                 context.touch("Touch the key to authenticate")
-                do {
-                    _ = try await client.getAssertion(requestOptions, authorization: .pin(defaultTestPin)).value
-                    context.record("Should have thrown noCredentials error")
-                } catch let error as WebAuthn.ClientError {
-                    if case .noCredentials = error {
-                        context.log("Correctly received noCredentials error for discoverable path")
-                    } else {
-                        context.record("Expected noCredentials error, got: \(error)")
-                    }
-                }
-            }
-        case .prefetchedPinMakeCredential:
-            return Scenario(
-                "WebAuthn.Ceremony.prefetchedPinMakeCredential",
-                "makeCredential consumes a pre-supplied PIN silently while still emitting waitingForUser",
-                requirements: Requirements(capabilities: [.fido2])
-            ) { context in
-                try await ensurePinSet(context)
-                let client = try await context.webAuthnClient()
-
-                let options = WebAuthn.Registration.Options(
-                    challenge: randomBytes(count: 32),
-                    rp: .init(id: testRpId, name: testRpName),
-                    user: .init(
-                        id: randomBytes(count: 32),
-                        name: "prefetched-pin@example.com",
-                        displayName: "Prefetched PIN User"
-                    ),
-                    residentKey: .discouraged
-                )
-
-                var sawWaitingForUser = false
-                var finished = false
-
-                context.touch("Touch the key to create a credential")
-                for try await status in await client.makeCredential(options, authorization: .pin(defaultTestPin)) {
-                    switch status {
-                    case .processing:
-                        break
-                    case .waitingForUser:
-                        sawWaitingForUser = true
-                    case .waitingForUserVerification:
-                        context.record("UV should be skipped under .pin authorization")
-                    case .finished:
-                        finished = true
-                    }
-                }
-
-                context.expect(sawWaitingForUser, "Stream should still deliver waitingForUser")
-                context.expect(finished, "Stream should reach .finished")
-            }
-        case .prefetchedPinGetAssertion:
-            return Scenario(
-                "WebAuthn.Ceremony.prefetchedPinGetAssertion",
-                "getAssertion consumes a pre-supplied PIN silently",
-                requirements: Requirements(capabilities: [.fido2])
-            ) { context in
-                try await ensurePinSet(context)
-                let client = try await context.webAuthnClient()
-
-                let createOptions = WebAuthn.Registration.Options(
-                    challenge: randomBytes(count: 32),
-                    rp: .init(id: testRpId, name: testRpName),
-                    user: .init(
-                        id: randomBytes(count: 32),
-                        name: "prefetched-ga@example.com",
-                        displayName: "Prefetched GA"
-                    ),
-                    residentKey: .required
-                )
-
-                context.touch("Touch the key to create a credential")
-                _ = try await client.makeCredential(createOptions, authorization: .pin(defaultTestPin)).value
-
-                let requestOptions = WebAuthn.Authentication.Options(
-                    challenge: randomBytes(count: 32),
-                    rpId: testRpId
-                )
-
-                var matches: [WebAuthn.Authentication.Response]?
-
-                context.touch("Touch the key to authenticate")
-                let authClient = try await context.webAuthnClientAfterNFCReconnect()
-                for try await status in await authClient.getAssertion(
-                    requestOptions,
-                    authorization: .pin(defaultTestPin)
+                await context.expectThrows(
+                    "discoverable getAssertion for an RP with no credentials",
+                    matching: { if case WebAuthn.ClientError.noCredentials = $0 { true } else { false } }
                 ) {
-                    if case .finished(let result) = status { matches = result }
+                    _ = try await client.getAssertion(requestOptions, authorization: .pin(defaultTestPin)).value
                 }
-
-                let resolved = try context.require(matches, "Stream should have delivered .finished with matches")
-                context.expect(!resolved.isEmpty, "should have at least one match")
-                context.expect((resolved.first?.signature.count ?? 0) > 0, "signature should be present")
-            }
-        case .cancelMakeCredential:
-            return Scenario(
-                "WebAuthn.Ceremony.cancelMakeCredential",
-                "makeCredential can be cancelled from the status stream",
-                requirements: Requirements(capabilities: [.fido2])
-            ) { context in
-                try await ensurePinSet(context)
-                let client = try await context.webAuthnClient()
-
-                let options = WebAuthn.Registration.Options(
-                    challenge: randomBytes(count: 32),
-                    rp: .init(id: testRpId, name: testRpName),
-                    user: .init(id: randomBytes(count: 32), name: "cancel@example.com", displayName: "Cancel User"),
-                    residentKey: .discouraged
-                )
-
-                context.touch("Cancellation fires automatically on waitingForUser")
-                do {
-                    let stream = await client.makeCredential(options, authorization: .pin(defaultTestPin))
-                    for try await status in stream {
-                        switch status {
-                        case .processing:
-                            break
-                        case .waitingForUser(let cancel):
-                            await cancel()
-                        case .waitingForUserVerification:
-                            context.record("UV should be skipped under .pin authorization")
-                        case .finished:
-                            context.record("makeCredential should have been cancelled")
-                        }
-                    }
-                    context.record("makeCredential should have thrown cancellation error")
-                } catch let error as WebAuthn.ClientError {
-                    if case .cancelled = error {
-                        context.log("Cancellation successful")
-                    } else {
-                        context.record("Expected cancelled error, got: \(error)")
-                    }
-                }
-            }
-        // MARK: - credProtect
-        case .allLevels:
-            return Scenario(
-                "WebAuthn.CredProtect.allLevels",
-                "credProtect echoes the applied protection level for each policy",
-                requirements: Requirements(capabilities: [.fido2])
-            ) { context in
-                try await ensurePinSet(context)
-                var client = try await context.webAuthnClient()
-
-                let createOptionsNone = WebAuthn.Registration.Options(
-                    challenge: randomBytes(count: 32),
-                    rp: .init(id: testRpId, name: "CredProtect Test"),
-                    user: .init(
-                        id: randomBytes(count: 32),
-                        name: "noext@example.com",
-                        displayName: "No Extension User"
-                    ),
-                    residentKey: .discouraged
-                )
-
-                context.touch("Touch the key (no credProtect)")
-                let createResponseNone = try await client.makeCredential(
-                    createOptionsNone,
-                    authorization: .pin(defaultTestPin)
-                ).value
-                context.expect(
-                    createResponseNone.clientExtensionResults.credProtect?.policy == nil,
-                    "no credProtect should be returned when not requested"
-                )
-
-                let createOptions1 = WebAuthn.Registration.Options(
-                    challenge: randomBytes(count: 32),
-                    rp: .init(id: testRpId, name: "CredProtect Test"),
-                    user: .init(id: randomBytes(count: 32), name: "level1@example.com", displayName: "Level 1 User"),
-                    residentKey: .discouraged,
-                    extensions: .init(credProtect: .init(policy: .userVerificationOptional))
-                )
-
-                context.touch("Touch the key (credProtect level 1)")
-                client = try await context.webAuthnClientAfterNFCReconnect()
-                let createResponse1 = try await client.makeCredential(
-                    createOptions1,
-                    authorization: .pin(defaultTestPin)
-                )
-                .value
-
-                if createResponse1.clientExtensionResults.credProtect?.policy == nil {
-                    try context.skip("credProtect not supported")
-                }
-                context.expect(
-                    createResponse1.clientExtensionResults.credProtect?.policy == .userVerificationOptional,
-                    "level 1 policy should be echoed"
-                )
-
-                let createOptions2 = WebAuthn.Registration.Options(
-                    challenge: randomBytes(count: 32),
-                    rp: .init(id: testRpId, name: "CredProtect Test"),
-                    user: .init(id: randomBytes(count: 32), name: "level2@example.com", displayName: "Level 2 User"),
-                    residentKey: .discouraged,
-                    extensions: .init(credProtect: .init(policy: .userVerificationOptionalWithCredentialIDList))
-                )
-
-                context.touch("Touch the key (credProtect level 2)")
-                client = try await context.webAuthnClientAfterNFCReconnect()
-                let createResponse2 = try await client.makeCredential(
-                    createOptions2,
-                    authorization: .pin(defaultTestPin)
-                )
-                .value
-                context.expect(
-                    createResponse2.clientExtensionResults.credProtect?.policy
-                        == .userVerificationOptionalWithCredentialIDList,
-                    "level 2 policy should be echoed"
-                )
-
-                // credProtect level 3 requires a resident key.
-                let createOptions3 = WebAuthn.Registration.Options(
-                    challenge: randomBytes(count: 32),
-                    rp: .init(id: testRpId, name: "CredProtect Test"),
-                    user: .init(id: randomBytes(count: 32), name: "level3@example.com", displayName: "Level 3 User"),
-                    residentKey: .required,
-                    extensions: .init(credProtect: .init(policy: .userVerificationRequired))
-                )
-
-                context.touch("Touch the key (credProtect level 3)")
-                client = try await context.webAuthnClientAfterNFCReconnect()
-                let createResponse3 = try await client.makeCredential(
-                    createOptions3,
-                    authorization: .pin(defaultTestPin)
-                )
-                .value
-                context.expect(
-                    createResponse3.clientExtensionResults.credProtect?.policy == .userVerificationRequired,
-                    "level 3 policy should be echoed"
-                )
             }
         // MARK: - prf
         case .derive:
@@ -1081,16 +876,11 @@ public enum WebAuthnScenario: CaseIterable {
                 )
 
                 context.touch("Touch the key to attempt the oversized write")
-                do {
-                    let writeClient = try await context.webAuthnClientAfterNFCReconnect()
-                    _ = try await writeClient.getAssertion(writeOptions, authorization: .pin(defaultTestPin)).value
-                    context.record("Expected storageFull error for oversized blob")
-                } catch let error as WebAuthn.ClientError {
-                    if case .storageFull = error {
-                        context.log("Correctly received storageFull error")
-                    } else {
-                        context.record("Expected storageFull error, got: \(error)")
-                    }
+                await context.expectThrows(
+                    "writing an oversized largeBlob",
+                    matching: { if case WebAuthn.ClientError.storageFull = $0 { true } else { false } }
+                ) {
+                    _ = try await client.getAssertion(writeOptions, authorization: .pin(defaultTestPin)).value
                 }
             }
         // MARK: - credBlob
@@ -1126,16 +916,19 @@ public enum WebAuthnScenario: CaseIterable {
                 )
 
                 context.touch("Touch the key to retrieve the credBlob")
-                let authResponse = try await assertionAfterNFCReconnect(
-                    context,
+                let authClient = try await context.webAuthnClientAfterNFCReconnect()
+                let authResponse = try await assertion(
+                    from: authClient,
                     options: authOptions,
                     matching: createResponse.credentialId,
+                    context
                 )
                 context.expect(
                     authResponse.clientExtensionResults.credBlob?.blob == testBlob,
                     "credBlob should round-trip"
                 )
             }
+        // is not requested at authentication)
         case .notReturnedWithoutExtension:
             return Scenario(
                 "WebAuthn.CredBlob.notReturnedWithoutExtension",
@@ -1167,10 +960,12 @@ public enum WebAuthnScenario: CaseIterable {
                 )
 
                 context.touch("Touch the key to authenticate without credBlob")
-                let authResponse = try await assertionAfterNFCReconnect(
-                    context,
+                let authClient = try await context.webAuthnClientAfterNFCReconnect()
+                let authResponse = try await assertion(
+                    from: authClient,
                     options: authOptions,
                     matching: createResponse.credentialId,
+                    context
                 )
                 context.expect(
                     authResponse.clientExtensionResults.credBlob?.blob == nil,
@@ -1217,92 +1012,13 @@ public enum WebAuthnScenario: CaseIterable {
                     context.log("Correctly rejected oversized credBlob: \(error)")
                 }
             }
-        // MARK: - credProps
-        case .discoverable:
-            return Scenario(
-                "WebAuthn.CredProps.discoverable",
-                "credProps reports rk=true for a discoverable credential",
-                requirements: Requirements(capabilities: [.fido2])
-            ) { context in
-                try await ensurePinSet(context)
-                let client = try await credPropsClient(context)
-
-                let options = WebAuthn.Registration.Options(
-                    challenge: randomBytes(count: 32),
-                    rp: .init(id: testRpId, name: "CredProps Test"),
-                    user: .init(
-                        id: randomBytes(count: 32),
-                        name: "credprops-rk@example.com",
-                        displayName: "CredProps RK"
-                    ),
-                    residentKey: .required,
-                    extensions: .init(credProps: true)
-                )
-
-                context.touch("Touch the key to create a discoverable credential")
-                let response = try await client.makeCredential(options, authorization: .pin(defaultTestPin)).value
-                context.expect(response.clientExtensionResults.credProps != nil, "credProps should be present")
-                context.expect(response.clientExtensionResults.credProps?.rk == true, "rk should be true")
-            }
-        case .nonDiscoverable:
-            return Scenario(
-                "WebAuthn.CredProps.nonDiscoverable",
-                "credProps reports rk=false for a non-discoverable credential",
-                requirements: Requirements(capabilities: [.fido2])
-            ) { context in
-                try await ensurePinSet(context)
-                let client = try await credPropsClient(context)
-
-                let options = WebAuthn.Registration.Options(
-                    challenge: randomBytes(count: 32),
-                    rp: .init(id: testRpId, name: "CredProps Test"),
-                    user: .init(
-                        id: randomBytes(count: 32),
-                        name: "credprops-nork@example.com",
-                        displayName: "CredProps No RK"
-                    ),
-                    residentKey: .discouraged,
-                    extensions: .init(credProps: true)
-                )
-
-                context.touch("Touch the key to create a non-discoverable credential")
-                let response = try await client.makeCredential(options, authorization: .pin(defaultTestPin)).value
-                context.expect(response.clientExtensionResults.credProps != nil, "credProps should be present")
-                context.expect(response.clientExtensionResults.credProps?.rk == false, "rk should be false")
-            }
-        case .notRequested:
-            return Scenario(
-                "WebAuthn.CredProps.notRequested",
-                "credProps is nil when not requested",
-                requirements: Requirements(capabilities: [.fido2])
-            ) { context in
-                try await ensurePinSet(context)
-                let client = try await credPropsClient(context)
-
-                let options = WebAuthn.Registration.Options(
-                    challenge: randomBytes(count: 32),
-                    rp: .init(id: testRpId, name: "CredProps Test"),
-                    user: .init(
-                        id: randomBytes(count: 32),
-                        name: "credprops-none@example.com",
-                        displayName: "CredProps None"
-                    ),
-                    residentKey: .required
-                )
-
-                context.touch("Touch the key to create a credential")
-                let response = try await client.makeCredential(options, authorization: .pin(defaultTestPin)).value
-                context.expect(
-                    response.clientExtensionResults.credProps == nil,
-                    "credProps should be nil when not requested"
-                )
-            }
         // MARK: - minPinLength
+        // once the RP ID is on the minPinLength allowlist)
         case .returnsValue:
             return Scenario(
                 "WebAuthn.MinPinLength.returnsValue",
                 "minPinLength returns the enforced length once the RP is configured",
-                requirements: Requirements(capabilities: [.fido2]),
+                requirements: Requirements(capabilities: [.fido2])
             ) { context in
                 try await ensurePinSet(context)
                 let session = try await context.ctap2Session()
@@ -1356,6 +1072,7 @@ public enum WebAuthnScenario: CaseIterable {
                 }
             }
         // MARK: - previewSign
+        // when the extension input is omitted)
         case .noOutputWithoutInput:
             return Scenario(
                 "WebAuthn.PreviewSign.noOutputWithoutInput",
@@ -1405,6 +1122,7 @@ public enum WebAuthnScenario: CaseIterable {
                     )
                 }
             }
+        // handle, public key, and attestation)
         case .generateKey:
             return Scenario(
                 "WebAuthn.PreviewSign.generateKey",
@@ -1467,6 +1185,7 @@ public enum WebAuthnScenario: CaseIterable {
                 }
             }
         // MARK: - thirdPartyPayment
+        // credential not registered for payment)
         case .echoedFalse:
             return Scenario(
                 "WebAuthn.ThirdPartyPayment.echoedFalse",
@@ -1475,6 +1194,7 @@ public enum WebAuthnScenario: CaseIterable {
             ) { context in
                 try await runThirdPartyPayment(context, registerWithPayment: false, expectedEcho: false)
             }
+        // credential registered for payment)
         case .echoedTrue:
             return Scenario(
                 "WebAuthn.ThirdPartyPayment.echoedTrue",
@@ -1500,6 +1220,8 @@ private func ensurePinSet(_ context: Scenario.Context) async throws {
     if try await session.getInfo().options.clientPin != true {
         try await session.setPin(defaultTestPin)
     }
+    // Common entry point for credential scenarios: clean up any residents they create on teardown.
+    await context.addTeardown { try await context.deleteResidentCredentials() }
 }
 
 private func firstAssertion(
@@ -1543,33 +1265,6 @@ private func assertion(
         file: file,
         line: line
     )
-}
-
-private func assertionAfterNFCReconnect(
-    _ context: Scenario.Context,
-    options: WebAuthn.Authentication.Options,
-    matching credentialId: Data,
-    origin: String = testOrigin,
-    allowedExtensions: Set<WebAuthn.Extension.Identifier> = .standard,
-    file: String = #fileID,
-    line: Int = #line
-) async throws -> WebAuthn.Authentication.Response {
-    let client = try await context.webAuthnClientAfterNFCReconnect(
-        origin: origin,
-        allowedExtensions: allowedExtensions
-    )
-    return try await assertion(
-        from: client,
-        options: options,
-        matching: credentialId,
-        context,
-        file: file,
-        line: line
-    )
-}
-
-private func credPropsClient(_ context: Scenario.Context) async throws -> WebAuthn.Client {
-    try await context.webAuthnClient(allowedExtensions: [.credProps])
 }
 
 private func runThirdPartyPayment(
@@ -1633,23 +1328,4 @@ private func runThirdPartyPayment(
             "echoed payment bit should be \(expectedEcho) (discoverable=\(discoverable))"
         )
     }
-}
-
-private func randomBytes(count: Int) -> Data {
-    var bytes = [UInt8](repeating: 0, count: count)
-    let status = SecRandomCopyBytes(kSecRandomDefault, count, &bytes)
-    precondition(status == errSecSuccess, "SecRandomCopyBytes failed: \(status)")
-    return Data(bytes)
-}
-
-private func decodeBase64URL(_ string: String) -> Data? {
-    var s = string.replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
-    let remainder = s.count % 4
-    if remainder > 0 { s += String(repeating: "=", count: 4 - remainder) }
-    return Data(base64Encoded: s)
-}
-
-private final class Box<T>: @unchecked Sendable {
-    var value: T
-    init(_ value: T) { self.value = value }
 }

--- a/YubiKit/UnitTests/Connection/MockSmartCardConnection.swift
+++ b/YubiKit/UnitTests/Connection/MockSmartCardConnection.swift
@@ -1,0 +1,63 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+@testable import YubiKit
+
+/// A `SmartCardConnection` test double that answers `send(data:)` with a programmed response
+/// for each request, in order. Construct it directly with the test initializer and hand it to
+/// `SmartCardInterface(connection:)`; the protocol's required `init()` / `makeConnection()`
+/// are unreachable in tests and trap.
+final actor MockSmartCardConnection: SmartCardConnection {
+
+    /// The programmed responses, one per `send(data:)` call, each including trailing SW1/SW2.
+    private let responses: [Data]
+    private var nextResponse = 0
+
+    /// Every request passed to `send(data:)`, in the order they were received.
+    private(set) var sentRequests: [Data] = []
+
+    /// Number of `send(data:)` calls observed.
+    var sendCount: Int { sentRequests.count }
+
+    /// Create a mock that returns the given responses in sequence, one per `send(data:)` call.
+    init(responses: [Data]) {
+        self.responses = responses
+    }
+
+    // MARK: - SmartCardConnection
+
+    init() async throws(SmartCardConnectionError) {
+        fatalError("use the test initializer")
+    }
+
+    static func makeConnection() async throws(SmartCardConnectionError) -> MockSmartCardConnection {
+        fatalError("use the test initializer")
+    }
+
+    @discardableResult
+    func send(data: Data) async throws(SmartCardConnectionError) -> Data {
+        sentRequests.append(data)
+        precondition(nextResponse < responses.count, "MockSmartCardConnection ran out of programmed responses")
+        defer { nextResponse += 1 }
+        return responses[nextResponse]
+    }
+
+    // MARK: - Connection
+
+    func close(error: Error?) async {}
+
+    func waitUntilClosed() async -> Error? { nil }
+}

--- a/YubiKit/UnitTests/Connection/SmartCardInterfaceTests.swift
+++ b/YubiKit/UnitTests/Connection/SmartCardInterfaceTests.swift
@@ -1,0 +1,112 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Testing
+
+@testable import YubiKit
+
+/// Unit coverage for `SmartCardInterface`'s multi-frame APDU reassembly. When a card answers with
+/// SW1=0x61 (more data), the interface issues a GET RESPONSE APDU and accumulates payload until it
+/// sees SW=0x9000. This was previously only exercised by the `OATH.Calculate.chunkedData`
+/// integration scenario.
+@Suite("SmartCardInterface multi-frame reassembly")
+struct SmartCardInterfaceTests {
+
+    /// Minimal SELECT reply that lets `SmartCardInterface(application: .oath)` init succeed:
+    /// any payload terminated by SW=0x9000.
+    private static let selectSuccess = Data([0x01, 0x02, 0x90, 0x00])
+
+    private let testApdu = APDU(cla: 0x00, ins: 0x01, p1: 0x00, p2: 0x00)
+
+    @Test("a two-frame response is reassembled across one GET RESPONSE")
+    func twoFrameReassembly() async throws {
+        let chunk1 = Data([0xaa, 0xbb, 0xcc])
+        let chunk2 = Data([0xdd, 0xee])
+
+        let mock = MockSmartCardConnection(responses: [
+            Self.selectSuccess,
+            // frame 1: <chunk1> 0x61 0x02 (two more bytes available)
+            chunk1 + Data([0x61, UInt8(chunk2.count)]),
+            // frame 2: <chunk2> 0x90 0x00 (done)
+            chunk2 + Data([0x90, 0x00]),
+        ])
+
+        let interface = try await SmartCardInterface<OATHSessionError>(connection: mock, application: .oath)
+        let result: Data = try await interface.send(apdu: testApdu)
+
+        #expect(result == chunk1 + chunk2)
+
+        // 1 SELECT + 1 command + 1 GET RESPONSE.
+        let count = await mock.sendCount
+        #expect(count == 3)
+
+        // The continuation request is the default GET RESPONSE: 00 C0 00 00 00.
+        let requests = await mock.sentRequests
+        #expect(requests[2] == Data([0x00, 0xc0, 0x00, 0x00, 0x00]))
+    }
+
+    @Test("a three-frame response iterates the continuation loop twice")
+    func threeFrameReassembly() async throws {
+        let chunk1 = Data([0x11, 0x22])
+        let chunk2 = Data([0x33, 0x44, 0x55])
+        let chunk3 = Data([0x66])
+
+        let mock = MockSmartCardConnection(responses: [
+            Self.selectSuccess,
+            chunk1 + Data([0x61, UInt8(chunk2.count)]),
+            chunk2 + Data([0x61, UInt8(chunk3.count)]),
+            chunk3 + Data([0x90, 0x00]),
+        ])
+
+        let interface = try await SmartCardInterface<OATHSessionError>(connection: mock, application: .oath)
+        let result: Data = try await interface.send(apdu: testApdu)
+
+        #expect(result == chunk1 + chunk2 + chunk3)
+
+        // 1 SELECT + 1 command + 2 GET RESPONSE.
+        let count = await mock.sendCount
+        #expect(count == 4)
+
+        let requests = await mock.sentRequests
+        #expect(requests[2] == Data([0x00, 0xc0, 0x00, 0x00, 0x00]))
+        #expect(requests[3] == Data([0x00, 0xc0, 0x00, 0x00, 0x00]))
+    }
+
+    @Test("the OATH continuation instruction 0xa5 is used when requested")
+    func oathContinuationInstruction() async throws {
+        let chunk1 = Data([0x01, 0x02, 0x03])
+        let chunk2 = Data([0x04, 0x05, 0x06, 0x07])
+
+        let mock = MockSmartCardConnection(responses: [
+            Self.selectSuccess,
+            chunk1 + Data([0x61, UInt8(chunk2.count)]),
+            chunk2 + Data([0x90, 0x00]),
+        ])
+
+        // OATH selects/sends with insSendRemaining 0xa5 (see SmartCardSession).
+        let interface = try await SmartCardInterface<OATHSessionError>(
+            connection: mock,
+            application: .oath,
+            insSendRemaining: 0xa5
+        )
+        let result: Data = try await interface.send(apdu: testApdu, insSendRemaining: 0xa5)
+
+        #expect(result == chunk1 + chunk2)
+
+        let requests = await mock.sentRequests
+        // The GET RESPONSE uses the OATH continuation instruction byte: 00 A5 00 00 00.
+        #expect(requests[2] == Data([0x00, 0xa5, 0x00, 0x00, 0x00]))
+    }
+}

--- a/YubiKit/UnitTests/FIDO/WebAuthn/CeremonyTests.swift
+++ b/YubiKit/UnitTests/FIDO/WebAuthn/CeremonyTests.swift
@@ -1,0 +1,397 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Testing
+
+@testable import YubiKit
+
+/// SDK-surface ceremony tests for `WebAuthn.Client`, driven through
+/// `MockWebAuthnBackend`. These exercise the Swift client (status stream,
+/// pre-supplied PIN, cancellation, and the credProtect/credProps extension
+/// echoes) without touching a YubiKey — migrated from the integration
+/// `WebAuthn.Ceremony.*` / `WebAuthn.CredProtect.*` / `WebAuthn.CredProps.*`
+/// scenarios.
+@Suite("WebAuthn Ceremony Tests")
+struct CeremonyTests {
+
+    private static let registrationOptions = WebAuthn.Registration.Options(
+        challenge: Data(repeating: 0x01, count: 32),
+        rp: .init(id: "example.com", name: "Example RP"),
+        user: .init(id: Data(repeating: 0x02, count: 32), name: "user@example.com", displayName: "User"),
+        residentKey: .discouraged
+    )
+
+    private static let authenticationOptions = WebAuthn.Authentication.Options(
+        challenge: Data(repeating: 0x03, count: 32),
+        rpId: "example.com"
+    )
+
+    // A PIN-only authenticator (clientPin set, no built-in UV). `.pin(_)`
+    // authorization skips UV and goes straight to the PIN path.
+    private static func pinBackend() -> MockWebAuthnBackend {
+        let mock = MockWebAuthnBackend()
+        mock.onGetInfo = { .stub(clientPin: true, pinUvAuthToken: true) }
+        mock.onGetPinRetries = { .init(retries: 8, powerCycleState: false) }
+        mock.onGetUVRetries = { 0 }
+        mock.onGetPinUVToken = { _, _, _ throws(CTAP2.SessionError) in
+            CTAP2.Token(token: Data(repeating: 0, count: 32), protocolVersion: .v2)
+        }
+        return mock
+    }
+
+    // MARK: - Status Stream (PIN via closure)
+
+    @Test("getAssertion status stream delivers waitingForUser and pulls the PIN via the closure exactly once")
+    func testStatusStreamPullsPINOnce() async throws {
+        let mock = Self.pinBackend()
+        // The CTAP getAssertion command surfaces user presence then finishes.
+        mock.onGetAssertion = { _ in
+            waitingThenFinished(.stub(credentialId: Data([0xAA])))
+        }
+
+        let client = try WebAuthn.Client.make(backend: mock)
+
+        let pinAsks = Box(0)
+        let auth = WebAuthn.Authorization(
+            providePIN: {
+                pinAsks.value += 1
+                return .pin("1234")
+            },
+            uv: .skipped
+        )
+
+        var sawWaitingForUser = false
+        var sawUVWaiting = false
+        var matches: [WebAuthn.Authentication.Response]?
+        for try await status in await client.getAssertion(Self.authenticationOptions, authorization: auth) {
+            switch status {
+            case .processing:
+                break
+            case .waitingForUser:
+                sawWaitingForUser = true
+            case .waitingForUserVerification:
+                sawUVWaiting = true
+            case .finished(let result):
+                matches = result
+            }
+        }
+
+        #expect(pinAsks.value == 1, "PIN closure should have been invoked exactly once")
+        #expect(sawWaitingForUser, "Stream should have delivered waitingForUser")
+        #expect(!sawUVWaiting, "UV should be skipped under .pin authorization")
+        let resolved = try #require(matches, "Stream should have delivered .finished with matches")
+        #expect(!resolved.isEmpty)
+        #expect((resolved.first?.signature.count ?? 0) > 0)
+    }
+
+    // MARK: - Pre-supplied PIN
+
+    @Test("makeCredential consumes a pre-supplied PIN silently while still emitting waitingForUser")
+    func testPrefetchedPINMakeCredential() async throws {
+        let mock = Self.pinBackend()
+        let pinAsks = Box(0)
+        mock.onGetPinUVToken = { method, _, _ throws(CTAP2.SessionError) in
+            if case .pin = method { pinAsks.value += 1 }
+            return CTAP2.Token(token: Data(repeating: 0, count: 32), protocolVersion: .v2)
+        }
+        mock.onMakeCredential = { _ in
+            waitingThenFinished(makeCredentialResponse(credentialId: Data([0xBB])))
+        }
+
+        let client = try WebAuthn.Client.make(backend: mock)
+
+        var sawWaitingForUser = false
+        var sawUVWaiting = false
+        var finished = false
+        for try await status in await client.makeCredential(Self.registrationOptions, authorization: .pin("1234")) {
+            switch status {
+            case .processing:
+                break
+            case .waitingForUser:
+                sawWaitingForUser = true
+            case .waitingForUserVerification:
+                sawUVWaiting = true
+            case .finished:
+                finished = true
+            }
+        }
+
+        // `.pin(_)` supplies the PIN directly — the SDK consumes it without a
+        // second prompt, but still surfaces user presence.
+        #expect(pinAsks.value == 1, "The pre-supplied PIN should be used once")
+        #expect(sawWaitingForUser, "Stream should still deliver waitingForUser")
+        #expect(!sawUVWaiting, "UV should be skipped under .pin authorization")
+        #expect(finished, "Stream should reach .finished")
+    }
+
+    @Test("getAssertion consumes a pre-supplied PIN silently")
+    func testPrefetchedPINGetAssertion() async throws {
+        let mock = Self.pinBackend()
+        mock.onGetAssertion = { _ in
+            waitingThenFinished(.stub(credentialId: Data([0xCC])))
+        }
+
+        let client = try WebAuthn.Client.make(backend: mock)
+
+        var matches: [WebAuthn.Authentication.Response]?
+        for try await status in await client.getAssertion(Self.authenticationOptions, authorization: .pin("1234")) {
+            if case .finished(let result) = status { matches = result }
+        }
+
+        let resolved = try #require(matches, "Stream should have delivered .finished with matches")
+        #expect(!resolved.isEmpty)
+        #expect((resolved.first?.signature.count ?? 0) > 0)
+    }
+
+    // MARK: - Cancellation
+
+    @Test("makeCredential can be cancelled from the status stream")
+    func testCancelMakeCredential() async throws {
+        let mock = Self.pinBackend()
+        // Cancelling on waitingForUser aborts the in-flight CTAP command, which
+        // surfaces a keepaliveCancel — mapped to ClientError.cancelled.
+        mock.onMakeCredential = { _ in
+            CTAP2.StatusStream { continuation in
+                Task {
+                    continuation.yield(
+                        .waitingForUser(cancel: {
+                            continuation.yield(error: .ctapError(.keepaliveCancel, source: .here()))
+                        })
+                    )
+                }
+            }
+        }
+
+        let client = try WebAuthn.Client.make(backend: mock)
+
+        var caught: WebAuthn.ClientError?
+        var reachedFinished = false
+        do throws(WebAuthn.ClientError) {
+            for try await status in await client.makeCredential(Self.registrationOptions, authorization: .pin("1234")) {
+                switch status {
+                case .waitingForUser(let cancel):
+                    await cancel()
+                case .finished:
+                    reachedFinished = true
+                default:
+                    break
+                }
+            }
+        } catch {
+            caught = error
+        }
+
+        #expect(!reachedFinished, "makeCredential should have been cancelled before finishing")
+        guard case .cancelled = caught else {
+            Issue.record("Expected cancelled, got \(String(describing: caught))")
+            return
+        }
+    }
+
+    // MARK: - credProtect echo
+
+    // The client reads the applied credProtect policy from the authenticator-data
+    // extensions of the makeCredential response (`parseRegistrationOutputs`). Drive
+    // that parse directly — the credProtect *input* path needs a live session for
+    // `makeCredProtect`, which the mock backend can't provide.
+
+    @Test("credProtect echoes the applied protection level for each policy")
+    func testCredProtectAllLevels() async throws {
+        let mock = MockWebAuthnBackend()
+
+        for policy in [
+            WebAuthn.Extension.CredProtect.Policy.userVerificationOptional,
+            .userVerificationOptionalWithCredentialIDList,
+            .userVerificationRequired,
+        ] {
+            let outputs = try await mock.parseRegistrationOutputs(
+                from: makeCredentialResponse(credentialId: Data([0xDD]), credProtectLevel: policy.rawValue),
+                prf: nil,
+                previewSign: nil,
+                largeBlobRequested: false,
+                credPropsRk: nil,
+                allowedExtensions: [.credProtect]
+            )
+            #expect(outputs.credProtect?.policy == policy, "level \(policy) should be echoed")
+        }
+    }
+
+    @Test("credProtect is not echoed when the authenticator omits it from authenticator data")
+    func testCredProtectNotEchoedWhenAbsent() async throws {
+        let mock = MockWebAuthnBackend()
+        let outputs = try await mock.parseRegistrationOutputs(
+            from: makeCredentialResponse(credentialId: Data([0xDD]), credProtectLevel: nil),
+            prf: nil,
+            previewSign: nil,
+            largeBlobRequested: false,
+            credPropsRk: nil,
+            allowedExtensions: [.credProtect]
+        )
+        #expect(outputs.credProtect == nil, "no credProtect should be returned when absent")
+    }
+
+    // MARK: - credProps rk
+
+    @Test("credProps reports rk=true for a discoverable credential")
+    func testCredPropsDiscoverable() async throws {
+        let rk = try await credPropsRk(residentKey: .required, credProps: true)
+        #expect(rk == true)
+    }
+
+    @Test("credProps reports rk=false for a non-discoverable credential")
+    func testCredPropsNonDiscoverable() async throws {
+        let rk = try await credPropsRk(residentKey: .discouraged, credProps: true)
+        #expect(rk == false)
+    }
+
+    @Test("credProps is nil when not requested")
+    func testCredPropsNotRequested() async throws {
+        let mock = Self.pinBackend()
+        mock.onMakeCredential = { _ in .mocked(.finished(makeCredentialResponse(credentialId: Data([0xEE])))) }
+        let client = try makeCredPropsClient(mock)
+
+        let options = WebAuthn.Registration.Options(
+            challenge: Data(repeating: 0x01, count: 32),
+            rp: .init(id: "example.com", name: "CredProps Test"),
+            user: .init(id: Data(repeating: 0x02, count: 32), name: "cp@example.com", displayName: "CP"),
+            residentKey: .required
+        )
+
+        let response = try await client.makeCredential(options, authorization: .pin("1234")).value
+        #expect(response.clientExtensionResults.credProps == nil)
+    }
+
+    private func credPropsRk(
+        residentKey: WebAuthn.ResidentKeyPreference,
+        credProps: Bool
+    ) async throws -> Bool? {
+        let mock = Self.pinBackend()
+        // rk-capable authenticator so residentKey: .required resolves to rk=true.
+        mock.onMakeCredential = { _ in .mocked(.finished(makeCredentialResponse(credentialId: Data([0xEE])))) }
+        let client = try makeCredPropsClient(mock)
+
+        let options = WebAuthn.Registration.Options(
+            challenge: Data(repeating: 0x01, count: 32),
+            rp: .init(id: "example.com", name: "CredProps Test"),
+            user: .init(id: Data(repeating: 0x02, count: 32), name: "cp@example.com", displayName: "CP"),
+            residentKey: residentKey,
+            extensions: .init(credProps: credProps)
+        )
+
+        let response = try await client.makeCredential(options, authorization: .pin("1234")).value
+        #expect(response.clientExtensionResults.credProps != nil, "credProps should be present when requested")
+        return response.clientExtensionResults.credProps?.rk
+    }
+
+    // MARK: - clientDataJSON key ordering
+
+    @Test("clientDataJSON serializes keys in spec order: type, challenge, origin, crossOrigin")
+    func testClientDataJSONKeyOrdering() throws {
+        let clientData = WebAuthn.ClientData.webauthn(
+            type: "webauthn.create",
+            challenge: Data(repeating: 0x01, count: 32),
+            origin: try WebAuthn.Origin("https://example.com"),
+            rpId: "example.com",
+            crossOrigin: false
+        )
+        let json = try #require(clientData.clientDataJSON)
+        let string = try #require(String(data: json, encoding: .utf8))
+
+        #expect(string.contains("webauthn.create"))
+        #expect(string.contains("example.com"))
+
+        let typeIndex = try #require(string.range(of: "\"type\"")?.lowerBound)
+        let challengeIndex = try #require(string.range(of: "\"challenge\"")?.lowerBound)
+        let originIndex = try #require(string.range(of: "\"origin\"")?.lowerBound)
+        let crossOriginIndex = try #require(string.range(of: "\"crossOrigin\"")?.lowerBound)
+        #expect(typeIndex < challengeIndex, "type should come before challenge")
+        #expect(challengeIndex < originIndex, "challenge should come before origin")
+        #expect(originIndex < crossOriginIndex, "origin should come before crossOrigin")
+    }
+
+    // MARK: - Clients with specific allowed extensions
+
+    private func makeCredPropsClient(_ backend: MockWebAuthnBackend) throws -> WebAuthn.Client {
+        WebAuthn.Client(
+            backend: backend,
+            origin: try WebAuthn.Origin("https://example.com"),
+            allowedExtensions: [.credProps],
+            isPublicSuffix: { _ in false }
+        )
+    }
+}
+
+// MARK: - StatusStream helper
+
+/// Yields `.waitingForUser` (no-op cancel) and then a finished response —
+/// mirrors a CTAP command that reports user presence before completing.
+private func waitingThenFinished<R: Sendable>(_ response: R) -> CTAP2.StatusStream<R> {
+    CTAP2.StatusStream { continuation in
+        continuation.yield(.waitingForUser(cancel: {}))
+        continuation.yield(.finished(response))
+    }
+}
+
+// MARK: - MakeCredential.Response fixture
+
+/// Builds a minimal but valid `CTAP2.MakeCredential.Response` with attested
+/// credential data (ES256 P-256), optionally carrying a credProtect output in
+/// the authenticator-data extensions block.
+private func makeCredentialResponse(
+    credentialId: Data,
+    credProtectLevel: Int? = nil
+) -> CTAP2.MakeCredential.Response {
+    var authData = Data()
+    authData.append(Data(repeating: 0xAB, count: 32))  // rpIdHash
+    // flags: UP + AT (+ ED when extensions are present)
+    let edFlag: UInt8 = credProtectLevel == nil ? 0 : 0x80
+    authData.append(0x41 | edFlag)
+    authData.append(contentsOf: [0x00, 0x00, 0x00, 0x01])  // signCount = 1
+
+    // Attested credential data
+    authData.append(Data(repeating: 0, count: 16))  // aaguid
+    let len = credentialId.count
+    authData.append(contentsOf: [UInt8(len >> 8), UInt8(len & 0xFF)])  // credentialId length
+    authData.append(credentialId)
+
+    // Minimal ES256 P-256 COSE key
+    let coseKey: [CBOR.Value: CBOR.Value] = [
+        .int(1): .int(2),  // kty: EC2
+        .int(3): .int(-7),  // alg: ES256
+        .int(-1): .int(1),  // crv: P-256
+        .int(-2): .byteString(Data(repeating: 0x01, count: 32)),  // x
+        .int(-3): .byteString(Data(repeating: 0x02, count: 32)),  // y
+    ]
+    authData.append(CBOR.Value.map(coseKey).encode())
+
+    // Optional credProtect extension output (signed authenticator-data extensions).
+    if let credProtectLevel {
+        let extensions: [CBOR.Value: CBOR.Value] = [
+            .textString("credProtect"): .int(credProtectLevel)
+        ]
+        authData.append(CBOR.Value.map(extensions).encode())
+    }
+
+    let response: [CBOR.Value: CBOR.Value] = [
+        .int(0x01): .textString("none"),
+        .int(0x02): .byteString(authData),
+        .int(0x03): .map([:]),
+    ]
+    let cbor: CBOR.Value = .map(response)
+    guard let parsed = CTAP2.MakeCredential.Response(cbor: cbor) else {
+        preconditionFailure("makeCredentialResponse fixture built CBOR that MakeCredential.Response rejected")
+    }
+    return parsed
+}


### PR DESCRIPTION
Stacked on #128.

## Summary

Expands the scenario catalog to match the coverage of the other YubiKey integration suites, and makes the added scenarios deterministic and re-runnable.

## Changes

- Adds CTAP2, OATH, PIV, SCP, Connection, Management, and WebAuthn scenarios.
- Adds parameterized scenario families and their supporting plumbing.
- Strengthens cleanup so repeated runs start from a known state.
- Adds WebAuthn ceremony and smart-card interface unit tests.

## Validation

- `./linter.sh check` and `swift build` at this layer.
