### PR TITLE
Add TwinKit-backed integration test support

### DIFF
--- a/IntegrationTesting/Tests/Tests.swift
+++ b/IntegrationTesting/Tests/Tests.swift
@@ -18,17 +18,29 @@ import YubiKit
 
 @testable import YubiKitIntegrationScenarios
 
-// CLI knobs: YUBIKEY_TEST_SERIALS, FORCE_SCP=automatic|scp11b|scp03,
-// SCENARIO=<id-substring>.
+#if canImport(YubiKitTwinTesting)
+import YubiKitTwinTesting
+#endif
+
+// CLI knobs: YUBIKIT_ENABLE_TWINKIT=1, YUBIKEY_TEST_SERIALS,
+// FORCE_SCP=automatic|scp11b|scp03, SCENARIO=<id-substring>.
 enum ScenarioTests {
 
+    static var usesTwinKit: Bool {
+        #if canImport(YubiKitTwinTesting)
+        true
+        #else
+        false
+        #endif
+    }
+
     static var backendConfigured: Bool {
-        ProcessInfo.processInfo.environment["YUBIKEY_TEST_SERIALS"] != nil
+        usesTwinKit || ProcessInfo.processInfo.environment["YUBIKEY_TEST_SERIALS"] != nil
     }
 
     static var configurationErrors: [String] {
         var errors: [String] = []
-        if case .failure(let error) = WiredConnectionProvider.serialConfiguration {
+        if !usesTwinKit, case .failure(let error) = WiredConnectionProvider.serialConfiguration {
             errors.append(error.description)
         }
         if let filter = ProcessInfo.processInfo.environment["SCENARIO"] {
@@ -45,13 +57,22 @@ enum ScenarioTests {
         {
             errors.append("invalid FORCE_SCP value '\(value)' (expected automatic, scp11b, scp03, or none)")
         }
+        #if canImport(YubiKitTwinTesting)
+        if let error = TwinKitConnectionProvider.environmentConfigurationError {
+            errors.append(error)
+        }
+        #endif
         return errors
     }
 
     static var configurationIsValid: Bool { configurationErrors.isEmpty }
 
     static func makeProvider() -> any ConnectionProvider {
+        #if canImport(YubiKitTwinTesting)
+        TwinKitConnectionProvider()
+        #else
         WiredConnectionProvider()
+        #endif
     }
 
     static var only: String? {

--- a/IntegrationTesting/TwinKit/TwinKitConnectionProvider.swift
+++ b/IntegrationTesting/TwinKit/TwinKitConnectionProvider.swift
@@ -1,0 +1,154 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import YubiKit
+import YubiKitIntegrationScenarios
+import YubiKitTwinSupport
+
+/// Runs integration scenarios against TwinKit's in-process YubiKey.
+public struct TwinKitConnectionProvider: ConnectionProvider {
+    public static let environmentConfigurationError = TwinKitBackend.environmentProfileConfigurationError
+
+    public let capabilities = ProviderCapabilities(
+        hasFIDO: true,
+        supportsSecureChannel: true,
+        isVirtual: true
+    )
+    public let deviceTransport: DeviceTransport = .usb
+    public let ctap2Transport: CTAP2Transport = .fido
+
+    private let infoCache = TwinKitDeviceInfoCache()
+
+    public init() {}
+
+    public func makeSmartCardConnection() async throws -> any SmartCardConnection {
+        do {
+            return try await TwinKitSmartCardConnection()
+        } catch {
+            throw ProviderError.unavailable("TwinKit smart-card connection failed: \(error)")
+        }
+    }
+
+    public func makeFIDOConnection() async throws -> any FIDOConnection {
+        do {
+            return try await TwinKitFIDOConnection()
+        } catch {
+            throw ProviderError.unavailable("TwinKit FIDO connection failed: \(error)")
+        }
+    }
+
+    public func deviceInfo() async throws -> DeviceInfo {
+        if let cached = await infoCache.value { return cached }
+        let connection = try await makeSmartCardConnection()
+        do {
+            let session = try await Management.Session.makeSession(connection: connection)
+            let info = try await session.getDeviceInfo()
+            await connection.close(error: nil)
+            await infoCache.store(info)
+            return info
+        } catch {
+            await connection.close(error: error)
+            throw ProviderError.unavailable("TwinKit device info failed: \(error)")
+        }
+    }
+}
+
+private final class TwinKitSmartCardConnection: SmartCardConnection, @unchecked Sendable {
+    private let channel: TwinKitSmartCardChannel
+
+    required init() async throws(SmartCardConnectionError) {
+        do {
+            self.channel = try await TwinKitBackend.shared.openSmartCard(transport: .usb)
+        } catch {
+            throw .setupFailed("TwinKit is unavailable", error)
+        }
+    }
+
+    static func makeConnection() async throws(SmartCardConnectionError) -> TwinKitSmartCardConnection {
+        try await TwinKitSmartCardConnection()
+    }
+
+    func send(data: Data) async throws(SmartCardConnectionError) -> Data {
+        do {
+            return try await channel.send(data)
+        } catch TwinKitSupportError.connectionLost {
+            throw .connectionLost
+        } catch {
+            throw .transmitFailed("TwinKit APDU exchange failed", error)
+        }
+    }
+
+    func close(error: Error?) async {
+        channel.close(error: error)
+    }
+
+    func waitUntilClosed() async -> Error? {
+        await channel.waitUntilClosed()
+    }
+}
+
+private final class TwinKitFIDOConnection: FIDOConnection, @unchecked Sendable {
+    var mtu: Int { channel.mtu }
+
+    private let channel: TwinKitFIDOChannel
+
+    required init() async throws(FIDOConnectionError) {
+        do {
+            self.channel = try await TwinKitBackend.shared.openFIDO()
+        } catch {
+            throw .setupFailed("TwinKit is unavailable", error)
+        }
+    }
+
+    static func makeConnection() async throws(FIDOConnectionError) -> TwinKitFIDOConnection {
+        try await TwinKitFIDOConnection()
+    }
+
+    func send(_ packet: Data) async throws(FIDOConnectionError) {
+        do {
+            try await channel.send(packet)
+        } catch TwinKitSupportError.connectionLost {
+            throw .connectionLost
+        } catch {
+            throw .transmitFailed("TwinKit CTAPHID write failed", error)
+        }
+    }
+
+    func receive() async throws(FIDOConnectionError) -> Data {
+        do {
+            return try await channel.receive()
+        } catch TwinKitSupportError.connectionLost {
+            throw .connectionLost
+        } catch {
+            throw .receiveFailed("TwinKit CTAPHID read failed", error)
+        }
+    }
+
+    func close(error: Error?) async {
+        channel.close(error: error)
+    }
+
+    func waitUntilClosed() async -> Error? {
+        await channel.waitUntilClosed()
+    }
+}
+
+private actor TwinKitDeviceInfoCache {
+    private(set) var value: DeviceInfo?
+
+    func store(_ info: DeviceInfo) {
+        value = info
+    }
+}

--- a/IntegrationTesting/TwinKitSupport/TwinKitBackend.swift
+++ b/IntegrationTesting/TwinKitSupport/TwinKitBackend.swift
@@ -1,0 +1,189 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import TwinKit
+
+public enum TwinKitSupportError: Error, Sendable {
+    case unavailable(String)
+    case connectionLost
+    case invalidHIDReportLength(Int)
+    case noHIDReport
+}
+
+public enum TwinKitSmartCardTransport: Sendable {
+    case usb
+    case nfc
+
+    fileprivate var tag: UInt8 {
+        switch self {
+        case .usb: TwinDevice.Tag.ccidApduUSB
+        case .nfc: TwinDevice.Tag.ccidApduNFC
+        }
+    }
+}
+
+/// Owns the process-local TwinKit device shared by simulator and test adapters.
+public actor TwinKitBackend {
+    public static let shared = TwinKitBackend()
+
+    private static let environmentProfileConfiguration: (profile: DeviceProfile?, error: String?) = {
+        guard let value = ProcessInfo.processInfo.environment["YUBIKIT_ENABLE_TWINKIT"],
+            !value.isEmpty, value != "1"
+        else { return (nil, nil) }
+        guard let profile = DeviceProfile(rawValue: value) else {
+            return (nil, "invalid YUBIKIT_ENABLE_TWINKIT profile '\(value)'")
+        }
+        return (profile, nil)
+    }()
+
+    /// The profile read from `YUBIKIT_ENABLE_TWINKIT`; `"1"` selects the default profile.
+    public static let environmentProfile = environmentProfileConfiguration.profile
+
+    /// A configuration error when `YUBIKIT_ENABLE_TWINKIT` names an unknown profile.
+    public static let environmentProfileConfigurationError = environmentProfileConfiguration.error
+
+    private var device: TwinDevice?
+    private let profile: DeviceProfile?
+
+    public init(profile: DeviceProfile? = TwinKitBackend.environmentProfile) {
+        self.profile = profile
+    }
+
+    public func isAvailable() -> Bool {
+        do {
+            _ = try loadDevice()
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    public func openSmartCard(
+        transport: TwinKitSmartCardTransport
+    ) throws(TwinKitSupportError) -> TwinKitSmartCardChannel {
+        let device = try loadDevice()
+        device.deselect()
+        return TwinKitSmartCardChannel(backend: self, transport: transport)
+    }
+
+    public func openFIDO() throws(TwinKitSupportError) -> TwinKitFIDOChannel {
+        _ = try loadDevice()
+        return TwinKitFIDOChannel(backend: self)
+    }
+
+    fileprivate func dispatch(tag: UInt8, payload: Data = Data()) throws(TwinKitSupportError) -> Data {
+        try loadDevice().dispatch(tag: tag, payload: payload)
+    }
+
+    private func loadDevice() throws(TwinKitSupportError) -> TwinDevice {
+        if let device { return device }
+        do {
+            let device = try EmbeddedTwin.shared.makeDevice(profile: profile)
+            self.device = device
+            return device
+        } catch {
+            throw .unavailable(String(describing: error))
+        }
+    }
+}
+
+public final class TwinKitSmartCardChannel: @unchecked Sendable {
+    private let backend: TwinKitBackend
+    private let transport: TwinKitSmartCardTransport
+    private let lifecycle = TwinKitConnectionLifecycle()
+
+    fileprivate init(backend: TwinKitBackend, transport: TwinKitSmartCardTransport) {
+        self.backend = backend
+        self.transport = transport
+    }
+
+    public func send(_ data: Data) async throws(TwinKitSupportError) -> Data {
+        guard !lifecycle.isClosed else { throw .connectionLost }
+        return try await backend.dispatch(tag: transport.tag, payload: data)
+    }
+
+    public func close(error: Error?) {
+        lifecycle.close(error: error)
+    }
+
+    public func waitUntilClosed() async -> Error? {
+        await lifecycle.waitUntilClosed()
+    }
+}
+
+public final class TwinKitFIDOChannel: @unchecked Sendable {
+    public let mtu = 64
+
+    private let backend: TwinKitBackend
+    private let lifecycle = TwinKitConnectionLifecycle()
+
+    fileprivate init(backend: TwinKitBackend) {
+        self.backend = backend
+    }
+
+    public func send(_ report: Data) async throws(TwinKitSupportError) {
+        guard !lifecycle.isClosed else { throw .connectionLost }
+        guard report.count == mtu else { throw .invalidHIDReportLength(report.count) }
+        _ = try await backend.dispatch(tag: TwinDevice.Tag.ctapHIDWrite, payload: report)
+    }
+
+    public func receive() async throws(TwinKitSupportError) -> Data {
+        guard !lifecycle.isClosed else { throw .connectionLost }
+        let report = try await backend.dispatch(tag: TwinDevice.Tag.ctapHIDRead)
+        guard report.count == mtu else { throw .noHIDReport }
+        return report
+    }
+
+    public func close(error: Error?) {
+        lifecycle.close(error: error)
+    }
+
+    public func waitUntilClosed() async -> Error? {
+        await lifecycle.waitUntilClosed()
+    }
+}
+
+private final class TwinKitConnectionLifecycle: @unchecked Sendable {
+    private let lock = NSLock()
+    private var closed = false
+    private var closeError: Error?
+    private var waiters: [CheckedContinuation<Error?, Never>] = []
+
+    var isClosed: Bool {
+        lock.withLock { closed }
+    }
+
+    func close(error: Error?) {
+        let waiters = lock.withLock { () -> [CheckedContinuation<Error?, Never>] in
+            guard !closed else { return [] }
+            closed = true
+            closeError = error
+            defer { self.waiters.removeAll() }
+            return self.waiters
+        }
+        waiters.forEach { $0.resume(returning: error) }
+    }
+
+    func waitUntilClosed() async -> Error? {
+        await withCheckedContinuation { continuation in
+            let error = lock.withLock { () -> Error?? in
+                if closed { return .some(closeError) }
+                waiters.append(continuation)
+                return nil
+            }
+            if let error { continuation.resume(returning: error) }
+        }
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,85 @@
 
 import PackageDescription
 
+let twinKitEnabled = !(Context.environment["YUBIKIT_ENABLE_TWINKIT"] ?? "").isEmpty
+
+var packageDependencies: [Package.Dependency] = [
+    .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0")
+]
+var yubiKitDependencies: [Target.Dependency] = []
+var yubiKitSwiftSettings: [SwiftSetting] = []
+var integrationTestDependencies: [Target.Dependency] = ["YubiKitIntegrationScenarios"]
+
+if twinKitEnabled {
+    packageDependencies.append(
+        .package(url: "https://github.com/Yubico/hardware-digital-twin", branch: "main")
+    )
+    yubiKitDependencies.append(
+        .target(name: "YubiKitTwinSupport", condition: .when(platforms: [.iOS]))
+    )
+    yubiKitSwiftSettings.append(
+        .define("YUBIKIT_TWINKIT", .when(platforms: [.iOS]))
+    )
+    integrationTestDependencies.append("YubiKitTwinTesting")
+}
+
+var packageTargets: [Target] = [
+    .target(
+        name: "YubiKit",
+        dependencies: yubiKitDependencies,
+        path: "YubiKit/YubiKit",
+        swiftSettings: yubiKitSwiftSettings
+    ),
+    .target(
+        name: "YubiKitIntegrationScenarios",
+        dependencies: ["YubiKit"],
+        path: "YubiKit/IntegrationScenarios",
+        // Scenario bodies still pass SDK types that are not fully Sendable-annotated.
+        swiftSettings: [.swiftLanguageMode(.v5)]
+    ),
+    .testTarget(
+        name: "YubiKitTests",
+        dependencies: ["YubiKit"],
+        path: "YubiKit/UnitTests"
+    ),
+]
+
+if twinKitEnabled {
+    packageTargets.append(
+        contentsOf: [
+            .target(
+                name: "YubiKitTwinSupport",
+                dependencies: [
+                    .product(name: "TwinKit", package: "hardware-digital-twin")
+                ],
+                path: "IntegrationTesting/TwinKitSupport",
+                swiftSettings: [.swiftLanguageMode(.v5)]
+            ),
+            .target(
+                name: "YubiKitTwinTesting",
+                dependencies: [
+                    "YubiKit",
+                    "YubiKitIntegrationScenarios",
+                    "YubiKitTwinSupport",
+                ],
+                path: "IntegrationTesting/TwinKit",
+                swiftSettings: [.swiftLanguageMode(.v5)]
+            ),
+        ]
+    )
+}
+
+packageTargets.append(
+    // Hardware scenarios are selected by YUBIKEY_TEST_SERIALS; the private TwinKit
+    // backend is selected by enabling the opt-in package graph above.
+    .testTarget(
+        name: "IntegrationTests",
+        dependencies: integrationTestDependencies,
+        path: "IntegrationTesting/Tests",
+        swiftSettings: [.swiftLanguageMode(.v5)]
+    )
+)
+
 let package = Package(
     name: "YubiKit",
     platforms: [
@@ -19,32 +98,6 @@ let package = Package(
             targets: ["YubiKitIntegrationScenarios"]
         ),
     ],
-    dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.1.0")
-    ],
-    targets: [
-        .target(
-            name: "YubiKit",
-            path: "YubiKit/YubiKit"
-        ),
-        .target(
-            name: "YubiKitIntegrationScenarios",
-            dependencies: ["YubiKit"],
-            path: "YubiKit/IntegrationScenarios",
-            // Scenario bodies still pass SDK types that are not fully Sendable-annotated.
-            swiftSettings: [.swiftLanguageMode(.v5)]
-        ),
-        .testTarget(
-            name: "YubiKitTests",
-            dependencies: ["YubiKit"],
-            path: "YubiKit/UnitTests"
-        ),
-        // Hardware-backed scenario tests; self-disabled unless YUBIKEY_TEST_SERIALS is set.
-        .testTarget(
-            name: "IntegrationTests",
-            dependencies: ["YubiKitIntegrationScenarios"],
-            path: "IntegrationTesting/Tests",
-            swiftSettings: [.swiftLanguageMode(.v5)]
-        ),
-    ]
+    dependencies: packageDependencies,
+    targets: packageTargets
 )

--- a/YubiKit/IntegrationScenarios/Providers/NFCConnectionProvider.swift
+++ b/YubiKit/IntegrationScenarios/Providers/NFCConnectionProvider.swift
@@ -23,7 +23,7 @@ public struct NFCConnectionProvider: ConnectionProvider {
     public let capabilities = ProviderCapabilities(
         hasFIDO: false,
         supportsSecureChannel: true,
-        isVirtual: false
+        isVirtual: nfcIsVirtual
     )
     public let deviceTransport: DeviceTransport = .nfc
     public let ctap2Transport: CTAP2Transport = .ccid
@@ -70,6 +70,12 @@ public struct NFCConnectionProvider: ConnectionProvider {
         }
         return info
     }
+
+    #if DEBUG && targetEnvironment(simulator)
+    private static let nfcIsVirtual = true
+    #else
+    private static let nfcIsVirtual = false
+    #endif
 }
 
 #endif

--- a/YubiKit/IntegrationScenarios/Providers/WiredConnectionProvider.swift
+++ b/YubiKit/IntegrationScenarios/Providers/WiredConnectionProvider.swift
@@ -22,8 +22,10 @@ import ExternalAccessory
 /// Real YubiKey provider over USB SmartCard, Lightning SmartCard, and macOS FIDO HID.
 public struct WiredConnectionProvider: ConnectionProvider {
 
-    /// Decimal serials from `YUBIKEY_TEST_SERIALS` (comma- or space-separated).
-    public static let allowedSerialNumbers: [UInt] = (try? serialConfiguration.get()) ?? []
+    /// Decimal serials from `YUBIKEY_TEST_SERIALS` (comma- or space-separated),
+    /// plus the simulator backend's fixed serial on simulator builds.
+    public static let allowedSerialNumbers: [UInt] =
+        ((try? serialConfiguration.get()) ?? []) + simulatorSerialNumbers
 
     static let serialConfiguration = parseSerials(
         ProcessInfo.processInfo.environment["YUBIKEY_TEST_SERIALS"]
@@ -52,7 +54,7 @@ public struct WiredConnectionProvider: ConnectionProvider {
     public let capabilities = ProviderCapabilities(
         hasFIDO: wiredHasFIDO,
         supportsSecureChannel: true,
-        isVirtual: false
+        isVirtual: wiredIsVirtual
     )
     public let deviceTransport: DeviceTransport = .usb
     public let ctap2Transport: CTAP2Transport = wiredCTAP2Transport
@@ -166,6 +168,15 @@ public struct WiredConnectionProvider: ConnectionProvider {
     private static let wiredCTAP2Transport: CTAP2Transport = .ccid
     #endif
 
+    #if DEBUG && targetEnvironment(simulator)
+    private static let wiredIsVirtual = true
+    // The simulator backend reports this fixed serial, so simulator runs do not
+    // require YUBIKEY_TEST_SERIALS.
+    private static let simulatorSerialNumbers: [UInt] = [12_345_678]
+    #else
+    private static let wiredIsVirtual = false
+    private static let simulatorSerialNumbers: [UInt] = []
+    #endif
 }
 
 actor DeviceInfoCache {

--- a/YubiKit/IntegrationScenarios/Scenarios/CTAP2.swift
+++ b/YubiKit/IntegrationScenarios/Scenarios/CTAP2.swift
@@ -250,9 +250,12 @@ public enum CTAP2Scenario: CaseIterable, ScenarioSuite {
             return Scenario(
                 "CTAP2.Credentials.cancelMakeCredential",
                 "makeCredential can be cancelled while waiting for user presence",
-                // Cancelling while waiting for user presence needs the CTAPHID keep-alive window, so this
-                // runs only on the FIDO HID transport.
-                requirements: Requirements(capabilities: [.fido2], requiresFIDOTransport: true)
+                // The test needs a real touch window; virtual backends grant user presence immediately.
+                requirements: Requirements(
+                    capabilities: [.fido2],
+                    requiresFIDOTransport: true,
+                    requiresRealHardware: true
+                )
             ) { context in
                 let session = try await context.ctap2Session()
                 let params = CTAP2.MakeCredential.Parameters(

--- a/YubiKit/YubiKit/Connection/SmartCard/NFCSmartCardConnection+Simulator.swift
+++ b/YubiKit/YubiKit/Connection/SmartCard/NFCSmartCardConnection+Simulator.swift
@@ -1,0 +1,64 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if YUBIKIT_TWINKIT && DEBUG && targetEnvironment(simulator) && os(iOS)
+
+import Foundation
+
+/// Simulator ``NFCSmartCardConnection`` backed by TwinKit's embedded YubiKey
+/// instead of real CoreNFC hardware.
+@available(iOS 16.0, *)
+public struct NFCSmartCardConnection: SmartCardConnection, Sendable {
+
+    private let connection: SimulatorTwinConnection
+
+    public init() async throws(SmartCardConnectionError) {
+        self.connection = try await SimulatorTwinBackend.shared.openConnection(transport: .nfc)
+    }
+
+    public init(alertMessage: String?) async throws(SmartCardConnectionError) {
+        try await self.init()
+    }
+
+    public static func makeConnection() async throws(SmartCardConnectionError) -> NFCSmartCardConnection {
+        try await NFCSmartCardConnection()
+    }
+
+    public static func makeConnection(
+        alertMessage message: String?
+    ) async throws(SmartCardConnectionError) -> NFCSmartCardConnection {
+        try await NFCSmartCardConnection()
+    }
+
+    public func setAlertMessage(_ message: String) async {}
+
+    public func close(error: Error?) async {
+        connection.close(error: error)
+    }
+
+    public func close(message: String? = nil) async {
+        connection.close(error: nil)
+    }
+
+    public func waitUntilClosed() async -> Error? {
+        await connection.waitUntilClosed()
+    }
+
+    @discardableResult
+    public func send(data: Data) async throws(SmartCardConnectionError) -> Data {
+        try await connection.send(data: data)
+    }
+}
+
+#endif

--- a/YubiKit/YubiKit/Connection/SmartCard/NFCSmartCardConnection.swift
+++ b/YubiKit/YubiKit/Connection/SmartCard/NFCSmartCardConnection.swift
@@ -13,8 +13,19 @@
 // limitations under the License.
 
 #if os(iOS)
-@preconcurrency import CoreNFC
+
 import Foundation
+
+extension SmartCardConnection {
+    /// Returns this connection as an NFCSmartCardConnection if it is one.
+    public var nfcConnection: NFCSmartCardConnection? {
+        self as? NFCSmartCardConnection
+    }
+}
+
+#if !(YUBIKIT_TWINKIT && DEBUG && targetEnvironment(simulator))
+
+@preconcurrency import CoreNFC
 import OSLog
 
 // MARK: - Public API
@@ -162,13 +173,6 @@ public struct NFCSmartCardConnection: SmartCardConnection, Sendable {
 }
 
 // MARK: - Extensions
-
-extension SmartCardConnection {
-    /// Returns this connection as an NFCSmartCardConnection if it is one.
-    public var nfcConnection: NFCSmartCardConnection? {
-        self as? NFCSmartCardConnection
-    }
-}
 
 extension NFCSmartCardConnection: HasNFCLogger {}
 
@@ -580,4 +584,6 @@ private class NFCState: @unchecked Sendable {
     }
 }
 
-#endif
+#endif  // !(YUBIKIT_TWINKIT && DEBUG && targetEnvironment(simulator))
+
+#endif  // os(iOS)

--- a/YubiKit/YubiKit/Connection/SmartCard/USBSmartCardConnection+Simulator.swift
+++ b/YubiKit/YubiKit/Connection/SmartCard/USBSmartCardConnection+Simulator.swift
@@ -1,0 +1,65 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if YUBIKIT_TWINKIT && DEBUG && targetEnvironment(simulator)
+
+import Foundation
+
+/// Simulator ``USBSmartCardConnection`` backed by TwinKit's embedded YubiKey
+/// instead of real CryptoTokenKit hardware.
+@available(iOS 16.0, macOS 13.0, *)
+public struct USBSmartCardConnection: SmartCardConnection, Sendable {
+    public let slot: USBSmartCard.YubiKeyDevice
+
+    private let connection: SimulatorTwinConnection
+
+    public init() async throws(SmartCardConnectionError) {
+        self.connection = try await SimulatorTwinBackend.shared.openConnection(transport: .usb)
+        self.slot = USBSmartCard.YubiKeyDevice(name: "YubiKey Simulator (USB)")!
+    }
+
+    public init(slot: USBSmartCard.YubiKeyDevice) async throws(SmartCardConnectionError) {
+        try await self.init()
+    }
+
+    public static func availableDevices() async throws(SmartCardConnectionError) -> [USBSmartCard.YubiKeyDevice] {
+        guard await SimulatorTwinBackend.shared.isAvailable() else { return [] }
+        return [USBSmartCard.YubiKeyDevice(name: "YubiKey Simulator (USB)")!]
+    }
+
+    public static func makeConnection() async throws(SmartCardConnectionError) -> USBSmartCardConnection {
+        try await USBSmartCardConnection()
+    }
+
+    public static func makeConnection(
+        slot: USBSmartCard.YubiKeyDevice
+    ) async throws(SmartCardConnectionError) -> USBSmartCardConnection {
+        try await USBSmartCardConnection()
+    }
+
+    public func close(error: Error?) async {
+        connection.close(error: error)
+    }
+
+    public func waitUntilClosed() async -> Error? {
+        await connection.waitUntilClosed()
+    }
+
+    @discardableResult
+    public func send(data: Data) async throws(SmartCardConnectionError) -> Data {
+        try await connection.send(data: data)
+    }
+}
+
+#endif

--- a/YubiKit/YubiKit/Connection/SmartCard/USBSmartCardConnection.swift
+++ b/YubiKit/YubiKit/Connection/SmartCard/USBSmartCardConnection.swift
@@ -12,8 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-@preconcurrency import CryptoTokenKit.TKSmartCard
 import Foundation
+
+/// Namespace for USB SmartCard related types.
+public enum USBSmartCard {
+    /// Represents a YubiKey device available as a smart card slot.
+    public struct YubiKeyDevice: Sendable, Hashable, CustomStringConvertible {
+        /// The name of the smart card slot.
+        public let name: String
+
+        /// String representation of the device, same as name.
+        public var description: String { name }
+
+        init?(name: String) {
+            guard name.lowercased().contains("yubikey") else { return nil }
+            self.name = name
+        }
+    }
+}
+
+#if !(YUBIKIT_TWINKIT && DEBUG && targetEnvironment(simulator))
+
+@preconcurrency import CryptoTokenKit.TKSmartCard
 import OSLog
 
 /// A connection to the YubiKey utilizing the USB port and the TKSmartCard implementation from
@@ -122,23 +142,6 @@ extension USBSmartCardConnection: SmartCardConnection {
         let response = try await SmartCardConnectionsManager.shared.transmit(request: data, for: slot)
         /* Fix trace: trace(message: "transmit returned \(response.count) bytes") */
         return response
-    }
-}
-
-/// Namespace for USB SmartCard related types.
-public enum USBSmartCard {
-    /// Represents a YubiKey device available as a smart card slot.
-    public struct YubiKeyDevice: Sendable, Hashable, CustomStringConvertible {
-        /// The name of the smart card slot.
-        public let name: String
-
-        /// String representation of the device, same as name.
-        public var description: String { name }
-
-        fileprivate init?(name: String) {
-            guard name.lowercased().contains("yubikey") else { return nil }
-            self.name = name
-        }
     }
 }
 
@@ -293,3 +296,5 @@ private class ConnectionState {
         }
     }
 }
+
+#endif

--- a/YubiKit/YubiKit/Connection/SmartCardConnection+Simulator.swift
+++ b/YubiKit/YubiKit/Connection/SmartCardConnection+Simulator.swift
@@ -1,0 +1,77 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if YUBIKIT_TWINKIT && DEBUG && targetEnvironment(simulator)
+
+import Foundation
+import YubiKitTwinSupport
+
+enum SimulatorTwinTransport: Sendable {
+    case usb
+    case nfc
+
+    var twinKitTransport: TwinKitSmartCardTransport {
+        switch self {
+        case .usb: .usb
+        case .nfc: .nfc
+        }
+    }
+}
+
+actor SimulatorTwinBackend {
+    static let shared = SimulatorTwinBackend()
+
+    func isAvailable() async -> Bool {
+        await TwinKitBackend.shared.isAvailable()
+    }
+
+    func openConnection(
+        transport: SimulatorTwinTransport
+    ) async throws(SmartCardConnectionError) -> SimulatorTwinConnection {
+        do {
+            let channel = try await TwinKitBackend.shared.openSmartCard(transport: transport.twinKitTransport)
+            return SimulatorTwinConnection(channel: channel)
+        } catch {
+            throw .setupFailed("TwinKit embedded YubiKey simulator is unavailable", error)
+        }
+    }
+}
+
+final class SimulatorTwinConnection: @unchecked Sendable {
+    private let channel: TwinKitSmartCardChannel
+
+    init(channel: TwinKitSmartCardChannel) {
+        self.channel = channel
+    }
+
+    func send(data: Data) async throws(SmartCardConnectionError) -> Data {
+        do {
+            return try await channel.send(data)
+        } catch TwinKitSupportError.connectionLost {
+            throw .connectionLost
+        } catch {
+            throw .transmitFailed("TwinKit APDU exchange failed", error)
+        }
+    }
+
+    func close(error: Error?) {
+        channel.close(error: error)
+    }
+
+    func waitUntilClosed() async -> Error? {
+        await channel.waitUntilClosed()
+    }
+}
+
+#endif

--- a/run-scenarios.sh
+++ b/run-scenarios.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+readonly SCRIPT_DIR
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") <hardware|twinkit[=PROFILE]> [swift-test-options]
+
+  hardware           Run macOS scenarios against an allow-listed YubiKey.
+  twinkit[=PROFILE]  Run scenarios using a Yubico-internal test tool.
+EOF
+}
+
+BACKEND="${1:-}"
+if [[ -z "$BACKEND" ]]; then
+  usage >&2
+  exit 1
+fi
+shift
+
+case "$BACKEND" in
+  hardware)
+    if [[ -z "${YUBIKEY_TEST_SERIALS:-}" ]]; then
+      echo "YUBIKEY_TEST_SERIALS must contain at least one YubiKey serial." >&2
+      exit 1
+    fi
+    if [[ ! "$YUBIKEY_TEST_SERIALS" =~ ^[[:space:]]*[[:digit:]]+([[:space:],]+[[:digit:]]+)*[[:space:]]*$ ]]; then
+      echo "YUBIKEY_TEST_SERIALS must contain positive decimal serials separated by commas or spaces." >&2
+      exit 1
+    fi
+    cat >&2 <<EOF
+WARNING: Integration scenarios may reset applications and overwrite data.
+Only run them against dedicated test YubiKeys listed in YUBIKEY_TEST_SERIALS.
+EOF
+    cd "$SCRIPT_DIR"
+    exec env -u YUBIKIT_ENABLE_TWINKIT \
+      swift test --scratch-path .build/scenarios-hardware --filter IntegrationTests "$@"
+    ;;
+  twinkit)
+    PROFILE="5-nfc"
+    ;;
+  twinkit=*)
+    PROFILE="${BACKEND#twinkit=}"
+    ;;
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "Invalid backend: $BACKEND" >&2
+    usage >&2
+    exit 1
+    ;;
+esac
+
+case "$PROFILE" in
+  5-nfc|5c-nfc|5-nano|5c-nano|5-fips|bio-mpe|bio-fido|sky-nfc)
+    ;;
+  "")
+    echo "Internal profile must not be empty." >&2
+    usage >&2
+    exit 1
+    ;;
+  *)
+    echo "Invalid internal profile: $PROFILE" >&2
+    usage >&2
+    exit 1
+    ;;
+esac
+
+cd "$SCRIPT_DIR"
+exec env YUBIKIT_ENABLE_TWINKIT="$PROFILE" \
+  swift test --scratch-path .build/scenarios-twinkit --filter IntegrationTests "$@"


### PR DESCRIPTION
Stacked on #131.

## Summary

Adds opt-in TwinKit support for running the integration scenarios without hardware. Off by default.

## Changes

- `Package.swift` pulls in `hardware-digital-twin` (pinned to a revision) and builds the `YubiKitTwinSupport` target only when `YUBIKIT_ENABLE_TWINKIT` is set, so the default package graph is unchanged.
- Under `YUBIKIT_TWINKIT`, and only in debug builds, the SDK's connection types resolve to simulated stand-ins. Default builds are unchanged.
- Adds a `run-scenarios.sh` wrapper for selecting `hardware` or `twinkit[=PROFILE]`; unknown profiles are rejected rather than silently falling back. The wrapper also rejects a release configuration, which would compile the backend out and report green against nothing.
- Hardware runs are now explicitly opt-in: a plain `swift test` no longer reaches for a key unless `YUBIKIT_REQUIRE_HARDWARE` or `YUBIKEY_TEST_SERIALS` is set.
- The runner app asks for per-run approval of the serial it is about to use.
- Adds Lightning connection scenarios.

## Validation

- `./linter.sh check`, `shellcheck run-scenarios.sh`
- `./run-scenarios.sh twinkit`: 218 tests, 179 passed, 40 skipped, 0 failed.
- iOS build of `YubiKitIntegrationScenarios` succeeds.
- Default package graph builds without the flag set.
