### PR TITLE
SDK cleanups: Management operations, session versions, dead helpers

### DIFF
--- a/YubiKit/YubiKit/Errors/Connection/FIDOConnectionError.swift
+++ b/YubiKit/YubiKit/Errors/Connection/FIDOConnectionError.swift
@@ -38,21 +38,3 @@ public enum FIDOConnectionError: Error, Sendable {
     /// Failed to receive data.
     case receiveFailed(String?, Error? = nil)
 }
-
-// MARK: - Internal methods to flatten the error
-extension FIDOConnectionError {
-    static func setupFailed(_ message: String? = nil, flatten error: Error?) -> Self {
-        if let connectionError = error as? FIDOConnectionError { return connectionError }
-        return .setupFailed(message, error)
-    }
-
-    static func transmitFailed(_ message: String? = nil, flatten error: Error?) -> Self {
-        if let connectionError = error as? FIDOConnectionError { return connectionError }
-        return .transmitFailed(message, error)
-    }
-
-    static func receiveFailed(_ message: String? = nil, flatten error: Error?) -> Self {
-        if let connectionError = error as? FIDOConnectionError { return connectionError }
-        return .receiveFailed(message, error)
-    }
-}

--- a/YubiKit/YubiKit/FIDO/Interfaces/CBORInterface.swift
+++ b/YubiKit/YubiKit/FIDO/Interfaces/CBORInterface.swift
@@ -31,8 +31,6 @@ protocol CBORInterface: Actor {
     /// The error type thrown by this interface.
     associatedtype Error: SessionError
 
-    var version: Version { get async }
-
     /// Maximum message size supported by the authenticator.
     /// Defaults to 1024 bytes until getInfo() returns the actual limit.
     var maxMsgSize: Int { get async }

--- a/YubiKit/YubiKit/FIDO/Session/CTAPSession+Interface.swift
+++ b/YubiKit/YubiKit/FIDO/Session/CTAPSession+Interface.swift
@@ -43,17 +43,6 @@ extension CTAP2.Session {
 extension CTAP2.Session.Interface: CBORInterface {
     typealias Error = CTAP2.SessionError
 
-    var version: Version {
-        get async {
-            switch kind {
-            case let .ccid(i):
-                return await i.version
-            case let .hid(i):
-                return await i.version
-            }
-        }
-    }
-
     var maxMsgSize: Int {
         get async {
             switch kind {

--- a/YubiKit/YubiKit/FIDO/Session/CTAPSession.swift
+++ b/YubiKit/YubiKit/FIDO/Session/CTAPSession.swift
@@ -25,8 +25,15 @@ extension CTAP2 {
     /// Read more about FIDO2/WebAuthn on the
     /// [FIDO Alliance website](https://fidoalliance.org/fido2/).
     public actor Session {
-        /// The firmware version of the YubiKey.
-        public let version: Version
+        // NEXTMAJOR: Remove.
+        /// Unavailable over the FIDO application; always `0.0.0`.
+        @available(
+            *,
+            deprecated,
+            message:
+                "Always 0.0.0. Use Management.Session for the firmware version, or getInfo().versions for the CTAP versions the authenticator supports."
+        )
+        public let version: Version = Version(withData: Data([0, 0, 0]))!
 
         /// Get authenticator information.
         ///
@@ -87,7 +94,6 @@ extension CTAP2 {
 
         internal init(interface: Interface) async {
             self.interface = interface
-            self.version = await interface.version
         }
 
         // MARK: - Private

--- a/YubiKit/YubiKit/Management/ManagementInterface.swift
+++ b/YubiKit/YubiKit/Management/ManagementInterface.swift
@@ -14,10 +14,17 @@
 
 import Foundation
 
+// NEXTMAJOR: Remove this protocol.
+
 /// Protocol for interfaces that can perform YubiKey management operations.
 ///
-/// This protocol abstracts the communication layer for management operations,
-/// allowing them to work over different transports (SmartCard via APDUs or FIDO via CTAP).
+/// No type in the SDK conforms to this protocol. Management operations run through
+/// ``Management/Session``, which selects the Management application before issuing them.
+@available(
+    *,
+    deprecated,
+    message: "No SDK type conforms to this protocol. Use Management.Session for management operations."
+)
 public protocol ManagementInterface: Actor {
 
     /// The error type thrown by this interface.
@@ -43,91 +50,4 @@ public protocol ManagementInterface: Actor {
     ///
     /// - Throws: An error if the reset operation fails or is not supported.
     func resetDevice() async throws
-}
-
-// MARK: - ManagementInterface Conformance
-extension FIDOInterface: ManagementInterface {
-
-    /// Read a configuration page from the YubiKey using vendor-specific CTAP commands.
-    ///
-    /// Uses the CTAP `readConfig` command (0x42) to read device configuration pages.
-    ///
-    /// - Parameter page: The page number to read (0-based).
-    /// - Returns: The raw TLV-encoded configuration data for the requested page.
-    public func readConfig(page: UInt8) async throws -> Data {
-        let payload = Data([page])
-        return try await sendAndReceive(cmd: Self.hidCommand(.readConfig), payload: payload)
-    }
-
-    /// Write configuration data to the YubiKey using vendor-specific CTAP commands.
-    ///
-    /// Uses the CTAP `writeConfig` command (0x43) to write device configuration.
-    ///
-    /// - Parameter data: The configuration data to write.
-    public func writeConfig(data: Data) async throws {
-        _ = try await sendAndReceive(cmd: Self.hidCommand(.writeConfig), payload: data)
-    }
-
-    /// Device reset is not supported over FIDO/CTAP transport.
-    ///
-    /// Device reset is only available over SmartCard (CCID) connections.
-    public func resetDevice() async throws {
-        throw Error.featureNotSupported(source: .here())
-    }
-}
-
-// MARK: - ManagementInterface Conformance
-extension SmartCardInterface: ManagementInterface {
-
-    /// Read a configuration page from the YubiKey using SmartCard APDUs.
-    ///
-    /// - Parameter page: The page number to read (0-based).
-    /// - Returns: The raw TLV-encoded configuration data for the requested page.
-    public func readConfig(page: UInt8) async throws -> Data {
-        let apdu = APDU(cla: 0, ins: 0x1d, p1: page, p2: 0)
-        return try await send(apdu: apdu)
-    }
-
-    /// Write configuration data to the YubiKey using SmartCard APDUs.
-    ///
-    /// - Parameter data: The configuration data to write.
-    public func writeConfig(data: Data) async throws {
-        let apdu = APDU(cla: 0, ins: 0x1c, p1: 0, p2: 0, command: data)
-        let _: Data = try await send(apdu: apdu)
-    }
-
-    /// Perform a device-wide reset using SmartCard APDUs.
-    public func resetDevice() async throws {
-        let apdu = APDU(cla: 0, ins: 0x1f, p1: 0, p2: 0)
-        let _: Data = try await send(apdu: apdu)
-    }
-
-    /// The firmware version of the YubiKey, parsed from the select response.
-    public var version: Version {
-        get async {
-            guard let version = Version(withManagementResult: selectResponse) else {
-                return Version(withData: Data([0, 0, 0]))!
-            }
-            return version
-        }
-    }
-}
-
-// MARK: - Private helpers
-
-extension Version {
-    fileprivate init?(withManagementResult data: Data) {
-        guard let resultString = String(bytes: data.bytes, encoding: .ascii) else { return nil }
-        guard let versions = resultString.components(separatedBy: " ").last?.components(separatedBy: "."),
-            versions.count == 3
-        else {
-            return nil
-        }
-        guard let major = UInt8(versions[0]), let minor = UInt8(versions[1]), let micro = UInt8(versions[2]) else {
-            return nil
-        }
-        self.major = major
-        self.minor = minor
-        self.micro = micro
-    }
 }

--- a/YubiKit/YubiKit/Management/ManagementSession.swift
+++ b/YubiKit/YubiKit/Management/ManagementSession.swift
@@ -216,41 +216,50 @@ extension Management.Session {
             self.kind = .fido(interface)
         }
 
+        /// The firmware version of the YubiKey, parsed from the Management select response over
+        /// SmartCard and reported by CTAPHID INIT over FIDO.
         var version: Version {
             get async {
                 switch kind {
                 case let .smartCard(i):
-                    return await i.version
+                    return Version(withManagementResult: i.selectResponse) ?? Version(withData: Data([0, 0, 0]))!
                 case let .fido(i):
                     return await i.version
                 }
             }
         }
 
-        func readConfig(page: UInt8) async throws -> Data {
+        func readConfig(page: UInt8) async throws(ManagementSessionError) -> Data {
             switch kind {
             case let .smartCard(i):
-                return try await i.readConfig(page: page)
+                return try await i.send(apdu: APDU(cla: 0, ins: 0x1d, p1: page, p2: 0))
             case let .fido(i):
-                return try await i.readConfig(page: page)
+                return try await i.sendAndReceive(
+                    cmd: FIDOInterface<ManagementSessionError>.hidCommand(.readConfig),
+                    payload: Data([page])
+                )
             }
         }
 
-        func writeConfig(data: Data) async throws {
+        func writeConfig(data: Data) async throws(ManagementSessionError) {
             switch kind {
             case let .smartCard(i):
-                try await i.writeConfig(data: data)
+                let _: Data = try await i.send(apdu: APDU(cla: 0, ins: 0x1c, p1: 0, p2: 0, command: data))
             case let .fido(i):
-                try await i.writeConfig(data: data)
+                _ = try await i.sendAndReceive(
+                    cmd: FIDOInterface<ManagementSessionError>.hidCommand(.writeConfig),
+                    payload: data
+                )
             }
         }
 
-        func resetDevice() async throws {
+        /// Device reset is only available over SmartCard (CCID) connections.
+        func resetDevice() async throws(ManagementSessionError) {
             switch kind {
             case let .smartCard(i):
-                try await i.resetDevice()
-            case let .fido(i):
-                try await i.resetDevice()
+                let _: Data = try await i.send(apdu: APDU(cla: 0, ins: 0x1f, p1: 0, p2: 0))
+            case .fido:
+                throw .featureNotSupported(source: .here())
             }
         }
 
@@ -271,5 +280,24 @@ extension Management.Session {
                 return nil
             }
         }
+    }
+}
+
+// MARK: - Private helpers
+
+extension Version {
+    fileprivate init?(withManagementResult data: Data) {
+        guard let resultString = String(bytes: data.bytes, encoding: .ascii) else { return nil }
+        guard let versions = resultString.components(separatedBy: " ").last?.components(separatedBy: "."),
+            versions.count == 3
+        else {
+            return nil
+        }
+        guard let major = UInt8(versions[0]), let minor = UInt8(versions[1]), let micro = UInt8(versions[2]) else {
+            return nil
+        }
+        self.major = major
+        self.minor = minor
+        self.micro = micro
     }
 }

--- a/YubiKit/YubiKit/Management/ManagementSession.swift
+++ b/YubiKit/YubiKit/Management/ManagementSession.swift
@@ -148,7 +148,7 @@ public enum Management {
                 application: .management,
                 keyParams: scpKeyParams
             )
-            return await .init(interface: Interface(interface: smartCardInterface))
+            return try await .init(interface: Interface(interface: smartCardInterface))
         }
 
         /// Creates a new Management session with the provided FIDO connection.
@@ -160,12 +160,12 @@ public enum Management {
             connection: FIDOConnection
         ) async throws(ManagementSessionError) -> Self {
             let fidoInterface = try await FIDOInterface<Error>(connection: connection)
-            return await .init(interface: Interface(interface: fidoInterface))
+            return try await .init(interface: Interface(interface: fidoInterface))
         }
 
-        private init(interface: Interface) async {
+        private init(interface: Interface) async throws(ManagementSessionError) {
             self.interface = interface
-            self.version = await interface.version
+            self.version = try await interface.version
             self.scpState = await interface.scpState
             self.smartCardConnection = await interface.smartCardConnection
         }
@@ -219,10 +219,16 @@ extension Management.Session {
         /// The firmware version of the YubiKey, parsed from the Management select response over
         /// SmartCard and reported by CTAPHID INIT over FIDO.
         var version: Version {
-            get async {
+            get async throws(ManagementSessionError) {
                 switch kind {
                 case let .smartCard(i):
-                    return Version(withManagementResult: i.selectResponse) ?? Version(withData: Data([0, 0, 0]))!
+                    guard let version = Version(withManagementResult: i.selectResponse) else {
+                        throw .responseParseError(
+                            "Failed to parse the firmware version from the Management select response",
+                            source: .here()
+                        )
+                    }
+                    return version
                 case let .fido(i):
                     return await i.version
                 }


### PR DESCRIPTION
Four SDK cleanups, no scenario changes.

**Management operations.** `ManagementInterface` was conformed unconditionally by `FIDOInterface` and `SmartCardInterface`, putting `readConfig`, `writeConfig`, `resetDevice` and `version` on every application's interface — they only work once the Management application is selected. The implementations move into `Management.Session.Interface`, which already abstracted both transports. Nothing conforms to the protocol now, so it is deprecated rather than deleted (public since v1.1.0).

**`CTAP2.Session.version`.** `CBORInterface` required a `version`, silently satisfied by the conformance above; against the FIDO SELECT response that parse fails and yields 0.0.0. The requirement is dropped and the property deprecated as a hardcoded 0.0.0 — it has had no reader since ef6a004dc4 removed the `version >= 5.0.0` gate on `getInfo()`. This gives up the real firmware version on HID; `Management.Session` reads it over both transports.

**Unparseable Management version.** The SmartCard path fell back to 0.0.0 when the Management SELECT response would not parse, which fails every feature gate and reports `featureNotSupported` for features the key supports. `makeSession` now throws `responseParseError` instead, matching yubikit-android, where `Version.parse` throws on no match. **Behaviour change:** session creation fails where it previously returned a session that could not do anything.

**Dead code.** Unused `FIDOConnectionError` flatten helpers.

No downstream break from the removals: `SmartCardInterface.init` / `FIDOInterface.init` are internal, and every `interface` property vending one is internal or private, so no external code can hold an instance to have called the removed members.
