### PR TITLE
Verify previewSign signatures against an ARKG-derived public key

### DIFF
--- a/YubiKit/IntegrationScenarios/Scenarios/CTAP2.swift
+++ b/YubiKit/IntegrationScenarios/Scenarios/CTAP2.swift
@@ -70,7 +70,6 @@ enum CTAP2Scenario: CaseIterable, ScenarioSuite {
     case enterpriseAttestationPlatform
     case previewSignUnsupportedAlgorithm
     case previewSignInvalidFlags
-    case previewSignMissingParameter
     case previewSignUpRequired
     case previewSignUvRequired
     case previewSignGenerateAndSign
@@ -1741,96 +1740,6 @@ enum CTAP2Scenario: CaseIterable, ScenarioSuite {
                     ) {
                         _ = try await session.makeCredential(parameters: params, token: token).value
                     }
-                }
-            }
-        case .previewSignMissingParameter:
-            return Scenario(
-                "CTAP2.PreviewSign.missingParameter",
-                "previewSign getAssertion rejects a missing keyHandle or TBS with INVALID_OPTION",
-                requirements: Requirements(capabilities: [.fido2])
-            ) { context in
-                let session = try await sessionWithPin(context)
-                guard try await CTAP2.Extension.PreviewSign.isSupported(by: session) else {
-                    try context.skip("previewSign not supported")
-                }
-                let previewSign = try await CTAP2.Extension.PreviewSign(session: session)
-
-                let mcToken = try await session.getPinUVToken(
-                    using: .pin(defaultTestPin),
-                    permissions: [.makeCredential]
-                )
-                let mcParams = CTAP2.MakeCredential.Parameters(
-                    clientDataHash: defaultClientDataHash,
-                    rp: WebAuthn.RelyingParty(id: "example.com", name: "PS Missing"),
-                    user: WebAuthn.User(
-                        id: randomBytes(count: 32),
-                        name: "psmissing@example.com",
-                        displayName: "PS Missing"
-                    ),
-                    pubKeyCredParams: [.es256],
-                    extensions: [previewSign.makeCredential.input(algorithms: [.esp256, .es256], flags: 0)],
-                    rk: false
-                )
-                context.touch("Touch the key to generate a previewSign key")
-                let mcResponse = try await session.makeCredential(parameters: mcParams, token: mcToken).value
-                let generatedKey = try context.require(
-                    previewSign.makeCredential.output(from: mcResponse),
-                    "previewSign should return a generated key"
-                )
-                let credentialId = try context.require(
-                    mcResponse.authenticatorData.attestedCredentialData?.credentialId,
-                    "makeCredential must return a credential id"
-                )
-
-                let tbs = randomBytes(count: 32)
-
-                // Missing keyHandle: pass empty data as keyHandle.
-                let gaTokenKH = try await session.getPinUVToken(
-                    using: .pin(defaultTestPin),
-                    permissions: [.getAssertion],
-                    rpId: "example.com"
-                )
-                let missingKH = CTAP2.GetAssertion.Parameters(
-                    rpId: "example.com",
-                    clientDataHash: defaultClientDataHash,
-                    allowList: [.init(id: credentialId)],
-                    extensions: [
-                        previewSign.getAssertion.input(keyHandle: Data(), tbs: tbs)
-                    ],
-                    up: false
-                )
-                await context.expectCTAPError(
-                    .invalidOption,
-                    .invalidCredential,
-                    during: "getAssertion with empty previewSign keyHandle"
-                ) {
-                    _ = try await session.getAssertion(parameters: missingKH, token: gaTokenKH).value
-                }
-
-                // Missing TBS: pass empty data as TBS.
-                let gaTokenTBS = try await session.getPinUVToken(
-                    using: .pin(defaultTestPin),
-                    permissions: [.getAssertion],
-                    rpId: "example.com"
-                )
-                let missingTBS = CTAP2.GetAssertion.Parameters(
-                    rpId: "example.com",
-                    clientDataHash: defaultClientDataHash,
-                    allowList: [.init(id: credentialId)],
-                    extensions: [
-                        previewSign.getAssertion.input(
-                            keyHandle: generatedKey.keyHandle,
-                            tbs: Data()
-                        )
-                    ],
-                    up: false
-                )
-                await context.expectCTAPError(
-                    .invalidOption,
-                    .invalidCredential,
-                    during: "getAssertion with empty previewSign TBS"
-                ) {
-                    _ = try await session.getAssertion(parameters: missingTBS, token: gaTokenTBS).value
                 }
             }
         case .previewSignUpRequired:

--- a/YubiKit/IntegrationScenarios/Scenarios/CTAP2.swift
+++ b/YubiKit/IntegrationScenarios/Scenarios/CTAP2.swift
@@ -1855,11 +1855,6 @@ enum CTAP2Scenario: CaseIterable, ScenarioSuite {
                     "makeCredential must return a credential id"
                 )
 
-                let gaToken = try await session.getPinUVToken(
-                    using: .pin(defaultTestPin),
-                    permissions: [.getAssertion],
-                    rpId: "example.com"
-                )
                 let gaParams = CTAP2.GetAssertion.Parameters(
                     rpId: "example.com",
                     clientDataHash: defaultClientDataHash,
@@ -1873,11 +1868,13 @@ enum CTAP2Scenario: CaseIterable, ScenarioSuite {
                     ],
                     up: true
                 )
+                // Unauthenticated: a pinUvAuthToken would satisfy UV and the key's UV
+                // requirement would never be exercised.
                 await context.expectCTAPError(
                     .puatRequired,
                     during: "getAssertion without UV on a UV-required previewSign key"
                 ) {
-                    _ = try await session.getAssertion(parameters: gaParams, token: gaToken).value
+                    _ = try await session.getAssertion(parameters: gaParams).value
                 }
             }
         // MARK: - previewSign (generate and sign round-trip)

--- a/YubiKit/IntegrationScenarios/Scenarios/CTAP2.swift
+++ b/YubiKit/IntegrationScenarios/Scenarios/CTAP2.swift
@@ -1727,7 +1727,7 @@ enum CTAP2Scenario: CaseIterable, ScenarioSuite {
                         pubKeyCredParams: [.es256],
                         extensions: [
                             previewSign.makeCredential.input(
-                                algorithms: [.esp256, .es256],
+                                algorithms: [.esp256SplitARKGPlaceholder],
                                 flags: flags
                             )
                         ],
@@ -1767,7 +1767,12 @@ enum CTAP2Scenario: CaseIterable, ScenarioSuite {
                         displayName: "PS UP"
                     ),
                     pubKeyCredParams: [.es256],
-                    extensions: [previewSign.makeCredential.input(algorithms: [.esp256, .es256], flags: 0b001)],
+                    extensions: [
+                        previewSign.makeCredential.input(
+                            algorithms: [.esp256SplitARKGPlaceholder],
+                            flags: 0b001
+                        )
+                    ],
                     rk: false
                 )
                 context.touch("Touch the key to create a UP-required previewSign key")
@@ -1793,7 +1798,8 @@ enum CTAP2Scenario: CaseIterable, ScenarioSuite {
                     extensions: [
                         previewSign.getAssertion.input(
                             keyHandle: generatedKey.keyHandle,
-                            tbs: randomBytes(count: 32)
+                            tbs: randomBytes(count: 32),
+                            additionalArgs: try ifARKG(generatedKey).additionalArgs
                         )
                     ],
                     up: false
@@ -1830,7 +1836,12 @@ enum CTAP2Scenario: CaseIterable, ScenarioSuite {
                         displayName: "PS UV"
                     ),
                     pubKeyCredParams: [.es256],
-                    extensions: [previewSign.makeCredential.input(algorithms: [.esp256, .es256], flags: 0b101)],
+                    extensions: [
+                        previewSign.makeCredential.input(
+                            algorithms: [.esp256SplitARKGPlaceholder],
+                            flags: 0b101
+                        )
+                    ],
                     rk: false
                 )
                 context.touch("Touch the key to create a UV-required previewSign key")
@@ -1856,7 +1867,8 @@ enum CTAP2Scenario: CaseIterable, ScenarioSuite {
                     extensions: [
                         previewSign.getAssertion.input(
                             keyHandle: generatedKey.keyHandle,
-                            tbs: randomBytes(count: 32)
+                            tbs: randomBytes(count: 32),
+                            additionalArgs: try ifARKG(generatedKey).additionalArgs
                         )
                     ],
                     up: true
@@ -1872,7 +1884,7 @@ enum CTAP2Scenario: CaseIterable, ScenarioSuite {
         case .previewSignGenerateAndSign:
             return Scenario(
                 "CTAP2.PreviewSign.generateAndSign",
-                "previewSign generates a key and produces a non-empty signature",
+                "previewSign generates a key and its signature verifies against the ARKG-derived public key",
                 requirements: Requirements(capabilities: [.fido2])
             ) { context in
                 let session = try await sessionWithPin(context)
@@ -1894,7 +1906,12 @@ enum CTAP2Scenario: CaseIterable, ScenarioSuite {
                         displayName: "PS Sign"
                     ),
                     pubKeyCredParams: [.es256],
-                    extensions: [previewSign.makeCredential.input(algorithms: [.esp256, .es256], flags: 0)],
+                    extensions: [
+                        previewSign.makeCredential.input(
+                            algorithms: [.esp256SplitARKGPlaceholder],
+                            flags: 0
+                        )
+                    ],
                     rk: false
                 )
                 context.touch("Touch the key to generate a previewSign key")
@@ -1912,7 +1929,11 @@ enum CTAP2Scenario: CaseIterable, ScenarioSuite {
                     "makeCredential must return a credential id"
                 )
 
-                let tbs = randomBytes(count: 32)
+                // The authenticator signs tbs as a prehashed SHA-256 digest, so verification
+                // has to run over the message that produced it.
+                let message = randomBytes(count: 64)
+                let tbs = Data(SHA256.hash(data: message))
+                let derived = try ifARKG(generatedKey)
                 let gaToken = try await session.getPinUVToken(
                     using: .pin(defaultTestPin),
                     permissions: [.getAssertion],
@@ -1925,7 +1946,8 @@ enum CTAP2Scenario: CaseIterable, ScenarioSuite {
                     extensions: [
                         previewSign.getAssertion.input(
                             keyHandle: generatedKey.keyHandle,
-                            tbs: tbs
+                            tbs: tbs,
+                            additionalArgs: derived.additionalArgs
                         )
                     ],
                     up: false
@@ -1936,6 +1958,14 @@ enum CTAP2Scenario: CaseIterable, ScenarioSuite {
                     "getAssertion should return a previewSign signature"
                 )
                 context.expect(!signature.isEmpty, "signature should not be empty")
+                context.expect(
+                    ARKG.verifySignature(
+                        publicKey: derived.publicKey,
+                        message: message,
+                        derSignature: signature
+                    ),
+                    "signature should verify against the derived public key"
+                )
             }
         }
     }
@@ -2402,6 +2432,28 @@ extension Scenario.Context {
             body
         )
     }
+}
+
+// MARK: - previewSign ARKG
+
+/// The delegated party's half of a split-ARKG sign, mirroring python-fido2's `if_arkg`:
+/// derive a public key from the authenticator's seed, plus the COSE_Sign_Args it needs to
+/// re-derive the matching private key.
+private func ifARKG(
+    _ key: CTAP2.Extension.PreviewSign.GeneratedKey,
+    context: Data = Data("YubiKitIntegrationScenarios".utf8)
+) throws -> (publicKey: Data, additionalArgs: Data) {
+    guard key.algorithm == .esp256SplitARKGPlaceholder else {
+        throw ARKGError.unexpectedAlgorithm(key.algorithm.rawValue)
+    }
+    guard let seed = ARKG.seedPoints(fromCOSE: key.publicKey) else { throw ARKGError.notAnARKGSeed }
+    let derived = try ARKG.derivePublicKey(
+        pkKem: seed.pkKem,
+        pkBl: seed.pkBl,
+        ikm: randomBytes(count: 32),
+        context: context
+    )
+    return (derived.publicKey, ARKG.buildAdditionalArgs(context: context, arkgKeyHandle: derived.arkgKeyHandle))
 }
 
 // MARK: - Shared constants

--- a/YubiKit/IntegrationScenarios/Support/ARKG/ARKG.swift
+++ b/YubiKit/IntegrationScenarios/Support/ARKG/ARKG.swift
@@ -1,0 +1,355 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import CryptoKit
+import Foundation
+
+// Warning: test scaffolding only. An unreviewed implementation of a draft spec
+// (draft-bradleylundberg-cfrg-arkg), here so the scenarios can verify an authenticator's ARKG
+// output instead of trusting it. Not constant-time, does not check that points are on the curve,
+// no known-answer coverage. Do not move it into the SDK.
+
+// MARK: - Error types
+
+enum ARKGError: Error, LocalizedError {
+    case unexpectedAlgorithm(Int)
+    case notAnARKGSeed
+    case contextTooLong
+    case expandMessageXmdInputTooLarge
+
+    var errorDescription: String? {
+        switch self {
+        case .unexpectedAlgorithm(let alg): return "Expected an ESP256-split-ARKG key, got algorithm \(alg)"
+        case .notAnARKGSeed: return "Generated public key is not an ARKG-P256 seed"
+        case .contextTooLong: return "Context must be at most 64 bytes"
+        case .expandMessageXmdInputTooLarge: return "expand_message_xmd: input size out of range"
+        }
+    }
+}
+
+// MARK: - ARKG
+
+enum ARKG {
+    // RFC 9380 domain separation
+    private static let dstExt = Data("ARKG-P256".utf8)
+    private static let kemDstExt = Data("ARKG-ECDH.ARKG-P256".utf8)
+    private static let hashToFieldL = 48  // bytes of XMD output per field element
+
+    // MARK: - Public API
+
+    static func derivePublicKey(
+        pkKem: Data,
+        pkBl: Data,
+        ikm: Data,
+        context: Data
+    ) throws -> (publicKey: Data, arkgKeyHandle: Data) {
+        guard context.count <= 64 else { throw ARKGError.contextTooLong }
+
+        let ctxPrime = Data([UInt8(context.count)]) + context
+        let ctxBl = Data("ARKG-Derive-Key-BL.".utf8) + ctxPrime
+        let ctxKem = Data("ARKG-Derive-Key-KEM.".utf8) + ctxPrime
+
+        let (ikmTau, c) = try kemEncaps(pkKem: pkKem, ikm: ikm, ctxKem: ctxKem)
+        let tau = try blPrf(ikmTau: ikmTau, ctxBl: ctxBl)
+        let tauG = try p256ScalarMulG(scalar: tau)
+        let pkPrime = try p256Add(pkBl, tauG)
+
+        return (pkPrime, c)
+    }
+
+    // The seed's blinding and key-encapsulation keys as uncompressed points, or nil if `cose` is
+    // not an ARKG-P256 seed. Its -1 and -2 members are themselves EC2 keys, so it is not a plain
+    // COSE key.
+    static func seedPoints(fromCOSE cose: Data) -> (pkBl: Data, pkKem: Data)? {
+        let arkgP256Algorithm = -65700
+        guard
+            let seed = decodeCBOR(cose)?.mapValue,
+            seed[3]?.intValue == arkgP256Algorithm
+        else { return nil }
+
+        func point(_ label: Int) -> Data? {
+            guard
+                let ec2 = seed[label]?.mapValue,
+                let x = ec2[-2]?.bytesValue, x.count == 32,
+                let y = ec2[-3]?.bytesValue, y.count == 32
+            else { return nil }
+            return Data([0x04]) + x + y
+        }
+        guard let pkBl = point(-1), let pkKem = point(-2) else { return nil }
+        return (pkBl, pkKem)
+    }
+
+    // COSE_Sign_Args for GetAssertion: { 3: -65539, -2: context, -1: arkgKeyHandle }.
+    static func buildAdditionalArgs(context: Data, arkgKeyHandle: Data) -> Data {
+        // Written out directly because YubiKit's CBOR encoder is internal to the SDK.
+        // Major type 1 encodes -1-n; major type 2 is a byte string.
+        func header(major: UInt8, _ n: Int) -> Data {
+            if n < 24 { return Data([major | UInt8(n)]) }
+            if n < 0x1_00 { return Data([major | 24, UInt8(n)]) }
+            if n < 0x1_0000 { return Data([major | 25, UInt8(n >> 8), UInt8(n & 0xFF)]) }
+            return Data([major | 26, UInt8(n >> 24), UInt8((n >> 16) & 0xFF), UInt8((n >> 8) & 0xFF), UInt8(n & 0xFF)])
+        }
+        func int(_ value: Int) -> Data {
+            value < 0 ? header(major: 0x20, -1 - value) : header(major: 0x00, value)
+        }
+        func bytes(_ data: Data) -> Data { header(major: 0x40, data.count) + data }
+
+        return Data([0xA3])  // map, 3 pairs — CTAP2 canonical order: 3, -1, -2
+            + int(3) + int(-65539)
+            + int(-1) + bytes(arkgKeyHandle)
+            + int(-2) + bytes(context)
+    }
+
+    // Pass the message, not its digest: CryptoKit applies SHA-256 internally, reproducing the
+    // digest the app sent as `tbs`.
+    static func verifySignature(publicKey: Data, message: Data, derSignature: Data) -> Bool {
+        guard let pubKey = try? P256.Signing.PublicKey(x963Representation: publicKey),
+            let sig = try? P256.Signing.ECDSASignature(derRepresentation: derSignature)
+        else { return false }
+        return pubKey.isValidSignature(sig, for: message)
+    }
+
+    // MARK: - KEM (ARKG-KEM-HMAC)
+
+    private static func kemEncaps(
+        pkKem: Data,
+        ikm: Data,
+        ctxKem: Data
+    ) throws -> (ikmTau: Data, c: Data) {
+        // The spec's ctx_sub is not derived here: the ECDH sub-KEM ignores its context, so it
+        // would never reach a hash.
+        let (kPrime, cPrime) = try subKemEncaps(pkKem: pkKem, ikm: ikm)
+
+        let mk = hkdfSha256(
+            ikm: kPrime,
+            info: Data("ARKG-KEM-HMAC-mac.".utf8) + kemDstExt + ctxKem,
+            length: 32
+        )
+        let fullMac = hmacSha256(key: mk, message: cPrime)
+        let tau = Data(fullMac.prefix(16))
+
+        let k = hkdfSha256(
+            ikm: kPrime,
+            info: Data("ARKG-KEM-HMAC-shared.".utf8) + kemDstExt + ctxKem,
+            length: kPrime.count
+        )
+        return (k, tau + cPrime)  // keyHandle = truncatedMAC || ephemeralPubKey
+    }
+
+    private static func subKemEncaps(
+        pkKem: Data,
+        ikm: Data
+    ) throws -> (k: Data, cPrime: Data) {
+        let (pkPrime, skPrime) = try subKemDeriveKeyPair(ikm: ikm)
+        let k = try p256ECDH(privateScalar: skPrime, publicPoint: pkKem)
+        return (k, pkPrime)
+    }
+
+    private static func subKemDeriveKeyPair(ikm: Data) throws -> (pk: Data, sk: Data) {
+        let dst = Data("ARKG-KEM-ECDH-KG.".utf8) + kemDstExt
+        let sk = try hashToField(msg: ikm, count: 1, dst: dst)[0]
+        let pk = try p256ScalarMulG(scalar: sk)
+        return (pk, sk)
+    }
+
+    // MARK: - Blinding PRF
+
+    private static func blPrf(ikmTau: Data, ctxBl: Data) throws -> Data {
+        let dst = Data("ARKG-BL-EC.".utf8) + dstExt + ctxBl
+        return try hashToField(msg: ikmTau, count: 1, dst: dst)[0]
+    }
+
+    // MARK: - Hash to field (RFC 9380)
+
+    // `count` 32-byte scalars, each an element of Z/nZ.
+    private static func hashToField(msg: Data, count: Int, dst: Data) throws -> [Data] {
+        let expanded = try expandMessageXmd(msg: msg, lenInBytes: count * hashToFieldL, dst: dst)
+        return (0..<count).map { i in
+            let slice = expanded[(i * hashToFieldL)..<((i + 1) * hashToFieldL)]
+            return p256ModN48(Data(slice))
+        }
+    }
+
+    // RFC 9380 §5.4.1 expand_message_xmd with SHA-256.
+    private static func expandMessageXmd(msg: Data, lenInBytes: Int, dst: Data) throws -> Data {
+        let bInBytes = 32  // SHA-256 output
+        let sInBytes = 64  // SHA-256 block size
+        let ell = (lenInBytes + bInBytes - 1) / bInBytes
+        guard ell <= 255, lenInBytes <= 65535, dst.count <= 255 else {
+            throw ARKGError.expandMessageXmdInputTooLarge
+        }
+
+        let dstPrime = dst + Data([UInt8(dst.count)])
+        let zPad = Data(repeating: 0, count: sInBytes)
+        let lIBStr = Data([UInt8((lenInBytes >> 8) & 0xFF), UInt8(lenInBytes & 0xFF)])
+        let msgPrime = zPad + msg + lIBStr + Data([0x00]) + dstPrime
+
+        let b0 = Data(SHA256.hash(data: msgPrime))
+        var bXor = b0  // i=1 hashes b0; later rounds hash b0 XOR b_(i-1)
+        var uniformBytes = Data()
+
+        for i in 1...ell {
+            let input = bXor + Data([UInt8(i)]) + dstPrime
+            let bi = Data(SHA256.hash(data: input))
+            uniformBytes += bi
+            bXor = xorBytes(b0, bi)
+        }
+
+        return Data(uniformBytes.prefix(lenInBytes))
+    }
+
+    // MARK: - Symmetric crypto
+
+    // Null salt, i.e. 32 zero bytes per RFC 5869 §2.2.
+    private static func hkdfSha256(ikm: Data, info: Data, length: Int) -> Data {
+        let salt = Data(repeating: 0, count: 32)
+        let key = HKDF<SHA256>.deriveKey(
+            inputKeyMaterial: SymmetricKey(data: ikm),
+            salt: salt,
+            info: info,
+            outputByteCount: length
+        )
+        return key.withUnsafeBytes { Data($0) }
+    }
+
+    private static func hmacSha256(key: Data, message: Data) -> Data {
+        Data(HMAC<SHA256>.authenticationCode(for: message, using: SymmetricKey(data: key)))
+    }
+
+    // MARK: - EC primitives (backed by CryptoKit + P256Arithmetic)
+
+    private static func p256ScalarMulG(scalar: Data) throws -> Data {
+        let priv = try P256.KeyAgreement.PrivateKey(rawRepresentation: scalar)
+        return priv.publicKey.x963Representation
+    }
+
+    // x-coordinate of privateScalar × publicPoint, 32 bytes big-endian.
+    private static func p256ECDH(privateScalar: Data, publicPoint: Data) throws -> Data {
+        let priv = try P256.KeyAgreement.PrivateKey(rawRepresentation: privateScalar)
+        let pub = try P256.KeyAgreement.PublicKey(x963Representation: publicPoint)
+        return try priv.sharedSecretFromKeyAgreement(with: pub).withUnsafeBytes { Data($0) }
+    }
+
+    // MARK: - CBOR (only enough to read a COSE key)
+
+    // Definite-length major types 0-5 only: tags and floats never appear in a COSE key, and an
+    // indefinite length would mean non-canonical CBOR, which is itself a failure. Non-integer map
+    // keys are parsed to advance the cursor, then discarded.
+    private indirect enum CBORValue {
+        case int(Int)
+        case bytes(Data)
+        case text(String)
+        case array([CBORValue])
+        case map([Int: CBORValue])
+
+        var intValue: Int? {
+            if case .int(let value) = self { return value }
+            return nil
+        }
+
+        var bytesValue: Data? {
+            if case .bytes(let data) = self { return data }
+            return nil
+        }
+
+        var mapValue: [Int: CBORValue]? {
+            if case .map(let map) = self { return map }
+            return nil
+        }
+    }
+
+    // One item, required to consume `data` exactly.
+    private static func decodeCBOR(_ data: Data) -> CBORValue? {
+        var cursor = data.startIndex
+        guard let value = decodeCBORItem(data, &cursor), cursor == data.endIndex else { return nil }
+        return value
+    }
+
+    private static func decodeCBORItem(_ data: Data, _ cursor: inout Int) -> CBORValue? {
+        guard cursor < data.endIndex else { return nil }
+        let initial = data[cursor]
+        cursor += 1
+        guard let argument = decodeCBORArgument(data, &cursor, info: initial & 0x1F) else { return nil }
+
+        switch initial >> 5 {
+        case 0:
+            return Int(exactly: argument).map { .int($0) }
+        case 1:
+            return Int(exactly: argument).map { .int(-1 - $0) }
+        case 2:
+            guard let end = cborOffset(data, cursor, by: argument) else { return nil }
+            let bytes = Data(data[cursor..<end])
+            cursor = end
+            return .bytes(bytes)
+        case 3:
+            guard let end = cborOffset(data, cursor, by: argument),
+                let text = String(data: Data(data[cursor..<end]), encoding: .utf8)
+            else { return nil }
+            cursor = end
+            return .text(text)
+        case 4:
+            // Each element needs at least one byte, so the remaining length bounds the count.
+            guard argument <= UInt64(data.endIndex - cursor) else { return nil }
+            var items: [CBORValue] = []
+            for _ in 0..<argument {
+                guard let item = decodeCBORItem(data, &cursor) else { return nil }
+                items.append(item)
+            }
+            return .array(items)
+        case 5:
+            guard argument <= UInt64(data.endIndex - cursor) else { return nil }
+            var map: [Int: CBORValue] = [:]
+            for _ in 0..<argument {
+                guard let key = decodeCBORItem(data, &cursor), let value = decodeCBORItem(data, &cursor)
+                else { return nil }
+                if let key = key.intValue { map[key] = value }
+            }
+            return .map(map)
+        default:
+            return nil
+        }
+    }
+
+    // Inlined in the initial byte, or the 1/2/4/8 bytes that follow it.
+    private static func decodeCBORArgument(_ data: Data, _ cursor: inout Int, info: UInt8) -> UInt64? {
+        switch info {
+        case 0...23: return UInt64(info)
+        case 24: return readBigEndian(data, &cursor, count: 1)
+        case 25: return readBigEndian(data, &cursor, count: 2)
+        case 26: return readBigEndian(data, &cursor, count: 4)
+        case 27: return readBigEndian(data, &cursor, count: 8)
+        default: return nil
+        }
+    }
+
+    private static func readBigEndian(_ data: Data, _ cursor: inout Int, count: Int) -> UInt64? {
+        guard let end = cborOffset(data, cursor, by: UInt64(count)) else { return nil }
+        var value: UInt64 = 0
+        for byte in data[cursor..<end] { value = value << 8 | UInt64(byte) }
+        cursor = end
+        return value
+    }
+
+    private static func cborOffset(_ data: Data, _ cursor: Int, by count: UInt64) -> Int? {
+        guard count <= UInt64(data.endIndex - cursor) else { return nil }
+        return cursor + Int(count)
+    }
+}
+
+// MARK: - Helpers
+
+private func xorBytes(_ a: Data, _ b: Data) -> Data {
+    precondition(a.count == b.count)
+    return Data(zip(a, b).map { $0 ^ $1 })
+}

--- a/YubiKit/IntegrationScenarios/Support/ARKG/P256Arithmetic.swift
+++ b/YubiKit/IntegrationScenarios/Support/ARKG/P256Arithmetic.swift
@@ -1,0 +1,269 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+// Warning: test scaffolding only — see ARKG.swift. Everything here branches on its inputs, so it
+// leaks through timing. It exists because CryptoKit has no EC point addition, and is only ever
+// fed public ARKG values.
+
+// MARK: - 256-bit Integer (4 × UInt64, little-endian limbs)
+
+private struct UInt256: Equatable {
+    var v0, v1, v2, v3: UInt64
+
+    // init(bigEndian:) suppresses the memberwise init.
+    init(v0: UInt64, v1: UInt64, v2: UInt64, v3: UInt64) {
+        self.v0 = v0
+        self.v1 = v1
+        self.v2 = v2
+        self.v3 = v3
+    }
+
+    static let zero = UInt256(v0: 0, v1: 0, v2: 0, v3: 0)
+    static let one = UInt256(v0: 1, v1: 0, v2: 0, v3: 0)
+
+    // p = 2^256 - 2^224 + 2^192 + 2^96 - 1
+    static let p256p = UInt256(
+        v0: 0xFFFF_FFFF_FFFF_FFFF,
+        v1: 0x0000_0000_FFFF_FFFF,
+        v2: 0x0000_0000_0000_0000,
+        v3: 0xFFFF_FFFF_0000_0001
+    )
+
+    static let p256n = UInt256(
+        v0: 0xF3B9_CAC2_FC63_2551,
+        v1: 0xBCE6_FAAD_A717_9E84,
+        v2: 0xFFFF_FFFF_FFFF_FFFF,
+        v3: 0xFFFF_FFFF_0000_0000
+    )
+
+    init(bigEndian data: Data) {
+        precondition(data.count == 32)
+        let bytes = [UInt8](data)
+        func load(_ i: Int) -> UInt64 {
+            let off = i * 8
+            return UInt64(bytes[off]) << 56 | UInt64(bytes[off + 1]) << 48
+                | UInt64(bytes[off + 2]) << 40 | UInt64(bytes[off + 3]) << 32
+                | UInt64(bytes[off + 4]) << 24 | UInt64(bytes[off + 5]) << 16
+                | UInt64(bytes[off + 6]) << 8 | UInt64(bytes[off + 7])
+        }
+        v3 = load(0)
+        v2 = load(1)
+        v1 = load(2)
+        v0 = load(3)
+    }
+
+    var bigEndian: Data {
+        func store(_ x: UInt64) -> [UInt8] {
+            let b7 = UInt8((x >> 56) & 0xFF)
+            let b6 = UInt8((x >> 48) & 0xFF)
+            let b5 = UInt8((x >> 40) & 0xFF)
+            let b4 = UInt8((x >> 32) & 0xFF)
+            let b3 = UInt8((x >> 24) & 0xFF)
+            let b2 = UInt8((x >> 16) & 0xFF)
+            let b1 = UInt8((x >> 8) & 0xFF)
+            let b0 = UInt8(x & 0xFF)
+            return [b7, b6, b5, b4, b3, b2, b1, b0]
+        }
+        return Data(store(v3) + store(v2) + store(v1) + store(v0))
+    }
+
+    func isLessThan(_ other: UInt256) -> Bool {
+        if v3 != other.v3 { return v3 < other.v3 }
+        if v2 != other.v2 { return v2 < other.v2 }
+        if v1 != other.v1 { return v1 < other.v1 }
+        return v0 < other.v0
+    }
+
+    var isZero: Bool { v0 == 0 && v1 == 0 && v2 == 0 && v3 == 0 }
+}
+
+// MARK: - Public helpers for ARKG
+
+// 48 big-endian bytes reduced mod n, returned as 32 big-endian bytes in [0, n-1].
+func p256ModN48(_ bytes48: Data) -> Data {
+    precondition(bytes48.count == 48)
+    let padded = Data(repeating: 0, count: 16) + bytes48  // 512 bits
+    var limbs = [UInt64](repeating: 0, count: 8)
+    for i in 0..<8 {
+        let off = (7 - i) * 8
+        limbs[i] =
+            UInt64(padded[off]) << 56 | UInt64(padded[off + 1]) << 48
+            | UInt64(padded[off + 2]) << 40 | UInt64(padded[off + 3]) << 32
+            | UInt64(padded[off + 4]) << 24 | UInt64(padded[off + 5]) << 16
+            | UInt64(padded[off + 6]) << 8 | UInt64(padded[off + 7])
+    }
+    return reduce512(limbs, mod: .p256n).bigEndian
+}
+
+// MARK: - Modular arithmetic mod p (P-256 field prime)
+
+// (a - b) mod m, inputs < m
+private func submod(_ a: UInt256, _ b: UInt256, mod m: UInt256) -> UInt256 {
+    if b.isLessThan(a) || a == b {
+        return sub256NoUnderflow(a, b)
+    }
+    // a + m can wrap past 2^256; the subtraction cancels it.
+    return sub256NoUnderflow(add256(a, m), b)
+}
+
+private func mulmod(_ a: UInt256, _ b: UInt256, mod m: UInt256) -> UInt256 {
+    reduce512(mul256(a, b), mod: m)
+}
+
+// a^exp mod m (binary exponentiation)
+private func powmod(_ base: UInt256, exp: UInt256, mod m: UInt256) -> UInt256 {
+    var result = UInt256.one
+    var b = base
+    var e = exp
+    while !e.isZero {
+        if e.v0 & 1 == 1 { result = mulmod(result, b, mod: m) }
+        b = mulmod(b, b, mod: m)
+        e = shr1(e)
+    }
+    return result
+}
+
+// Fermat's little theorem: a^(m-2) mod m, m prime
+private func modinv(_ a: UInt256, mod m: UInt256) -> UInt256 {
+    let exp = sub256NoUnderflow(m, UInt256(v0: 2, v1: 0, v2: 0, v3: 0))
+    return powmod(a, exp: exp, mod: m)
+}
+
+// MARK: - EC Point Addition on P-256 (affine coordinates)
+
+private enum P256ArithmeticError: Error {
+    case invalidPoint
+    case pointAtInfinity
+}
+
+// Add two P-256 points in uncompressed form (04 || x32 || y32).
+// Requires P1 ≠ P2 and P1 ≠ -P2 (no infinity handling needed for ARKG).
+func p256Add(_ p1: Data, _ p2: Data) throws -> Data {
+    guard p1.count == 65, p2.count == 65, p1.first == 0x04, p2.first == 0x04 else {
+        throw P256ArithmeticError.invalidPoint
+    }
+    let p = UInt256.p256p
+    let x1 = UInt256(bigEndian: p1[1...32])
+    let y1 = UInt256(bigEndian: p1[33...64])
+    let x2 = UInt256(bigEndian: p2[1...32])
+    let y2 = UInt256(bigEndian: p2[33...64])
+
+    // λ = (y2 - y1) / (x2 - x1) mod p
+    let dy = submod(y2, y1, mod: p)
+    let dx = submod(x2, x1, mod: p)
+    guard !dx.isZero else { throw P256ArithmeticError.pointAtInfinity }
+    let lambda = mulmod(dy, modinv(dx, mod: p), mod: p)
+
+    // x3 = λ² - x1 - x2 mod p
+    let lambda2 = mulmod(lambda, lambda, mod: p)
+    let x3 = submod(submod(lambda2, x1, mod: p), x2, mod: p)
+
+    // y3 = λ(x1 - x3) - y1 mod p
+    let y3 = submod(mulmod(lambda, submod(x1, x3, mod: p), mod: p), y1, mod: p)
+
+    return Data([0x04]) + x3.bigEndian + y3.bigEndian
+}
+
+// MARK: - 256-bit arithmetic primitives
+
+// Wraps modulo 2^256.
+private func add256(_ a: UInt256, _ b: UInt256) -> UInt256 {
+    let (v0, c0) = a.v0.addingReportingOverflow(b.v0)
+    let (v1a, c1a) = a.v1.addingReportingOverflow(b.v1)
+    let (v1, c1b) = v1a.addingReportingOverflow(c0 ? 1 : 0)
+    let (v2a, c2a) = a.v2.addingReportingOverflow(b.v2)
+    let (v2, c2b) = v2a.addingReportingOverflow(c1a || c1b ? 1 : 0)
+    let v3 = a.v3 &+ b.v3 &+ (c2a || c2b ? 1 : 0)
+    return UInt256(v0: v0, v1: v1, v2: v2, v3: v3)
+}
+
+// Caller ensures a >= b.
+private func sub256NoUnderflow(_ a: UInt256, _ b: UInt256) -> UInt256 {
+    let (v0, b0) = a.v0.subtractingReportingOverflow(b.v0)
+    let (v1a, b1a) = a.v1.subtractingReportingOverflow(b.v1)
+    let (v1, b1b) = v1a.subtractingReportingOverflow(b0 ? 1 : 0)
+    let borrow1 = b1a || b1b
+    let (v2a, b2a) = a.v2.subtractingReportingOverflow(b.v2)
+    let (v2, b2b) = v2a.subtractingReportingOverflow(borrow1 ? 1 : 0)
+    let borrow2 = b2a || b2b
+    let (v3a, _) = a.v3.subtractingReportingOverflow(b.v3)
+    let (v3, _) = v3a.subtractingReportingOverflow(borrow2 ? 1 : 0)
+    return UInt256(v0: v0, v1: v1, v2: v2, v3: v3)
+}
+
+private func shr1(_ a: UInt256) -> UInt256 {
+    UInt256(
+        v0: (a.v0 >> 1) | (a.v1 << 63),
+        v1: (a.v1 >> 1) | (a.v2 << 63),
+        v2: (a.v2 >> 1) | (a.v3 << 63),
+        v3: a.v3 >> 1
+    )
+}
+
+// 256×256 → 512-bit schoolbook multiply, returning 8 LE limbs.
+private func mul256(_ a: UInt256, _ b: UInt256) -> [UInt64] {
+    let aLimbs: [UInt64] = [a.v0, a.v1, a.v2, a.v3]
+    let bLimbs: [UInt64] = [b.v0, b.v1, b.v2, b.v3]
+    var result = [UInt64](repeating: 0, count: 8)
+    for i in 0..<4 {
+        var carry: UInt64 = 0
+        for j in 0..<4 {
+            let (hi, lo) = aLimbs[i].multipliedFullWidth(by: bLimbs[j])
+            let (r, c1) = result[i + j].addingReportingOverflow(lo)
+            let (r2, c2) = r.addingReportingOverflow(carry)
+            result[i + j] = r2
+            carry = hi &+ (c1 ? 1 : 0) &+ (c2 ? 1 : 0)
+        }
+        result[i + 4] = carry
+    }
+    return result
+}
+
+// Binary long division. Requires m > 2^255, true for both p and n.
+private func reduce512(_ limbs: [UInt64], mod m: UInt256) -> UInt256 {
+    let negM = sub256NoUnderflow(.zero, m)  // 2^256 - m
+    var r = UInt256.zero
+    for limb in stride(from: 7, through: 0, by: -1) {
+        for bit in stride(from: 63, through: 0, by: -1) {
+            // r := 2*r, keeping the bit shifted out as the 2^256 overflow.
+            let overflow = (r.v3 >> 63) == 1
+            r = UInt256(
+                v0: r.v0 << 1,
+                v1: (r.v1 << 1) | (r.v0 >> 63),
+                v2: (r.v2 << 1) | (r.v1 >> 63),
+                v3: (r.v3 << 1) | (r.v2 >> 63)
+            )
+            // Safe: r's LSB is 0 after the shift.
+            let inputBit = (limbs[limb] >> bit) & 1
+            if inputBit == 1 { r = add256(r, .one) }
+
+            // Previous r < m and m > 2^255, so the value is < 2m and one -m suffices.
+            if overflow { r = add256(r, negM) }
+            if !r.isLessThan(m) { r = sub256NoUnderflow(r, m) }
+        }
+    }
+    return r
+}
+
+// MARK: - Data subscript helpers
+
+extension Data {
+    // Offsets are relative to startIndex, so slices of a larger buffer work.
+    fileprivate subscript(range: ClosedRange<Int>) -> Data {
+        let lower = startIndex + range.lowerBound
+        return Data(self[lower..<(lower + range.count)])
+    }
+}


### PR DESCRIPTION
The previewSign round-trip only checked that a signature came back non-empty. It now derives the public key from the authenticator's ARKG-P256 seed and verifies the signature against it, so a wrong signature is actually caught.

- Requests `esp256-split-ARKG` alone rather than a mixed algorithm list, so the prehash and verification assumptions hold by construction.
- Adds offline ARKG-P256 derivation under `IntegrationScenarios/Support/ARKG`, mirroring python-fido2's `if_arkg`.
- Drops the missing-parameter scenario, which the split algorithm made unrepresentable in its old form.
- Exercises the UV requirement without a pinUvAuthToken, which would otherwise satisfy UV and never test the key's own requirement.

The ARKG code is test scaffolding only: unreviewed draft-spec crypto, not constant-time, with no known-answer vectors committed. It carries a warning saying so and should not move into the SDK. The derivation and the P-256 arithmetic under it were cross-checked byte-exact against python-fido2's `fido2.arkg` over 709 generated vectors.

`./run-scenarios.sh twinkit=5-nfc-58`: 263 scenarios, 237 passed, 0 failed, 26 skipped.
