### PR TITLE
Run build, test, and API diff on release branch pull requests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3,7 +3,7 @@ name: Build and Test
 on:
   workflow_dispatch:
   pull_request:
-    branches: ["main"]
+    branches: ["main", "release/**"]
 
 jobs:
   build:

--- a/.github/workflows/public-api-diff.yml
+++ b/.github/workflows/public-api-diff.yml
@@ -2,7 +2,7 @@ name: Detect public API changes
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ "main", "release/**" ]
     paths:
       - 'YubiKit/**/*.swift'
       - 'Package.swift'


### PR DESCRIPTION
`build_and_test.yml` and `public-api-diff.yml` only trigger on PRs to `main`, so a PR targeting a
release branch runs neither — #136 merged into `release/1.4.0` with only the DocC preview green.

Both filters now match what `docc_preview.yml` already does:

```yaml
    branches: ["main", "release/**"]
```

`pull_request` filters on the PR's base branch, so this has to land on the release branch to take
effect there; it reaches `main` when 1.4.0 merges back. This PR triggers its own new filter.
