### PR TITLE
Keep the integration scenarios out of the public API diff

### DIFF
--- a/.github/workflows/public-api-diff.yml
+++ b/.github/workflows/public-api-diff.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main", "release/**" ]
     paths:
       - 'YubiKit/**/*.swift'
+      - '!YubiKit/IntegrationScenarios/**'
       - 'Package.swift'
       - '.github/workflows/public-api-diff.yml'
   workflow_dispatch:

--- a/YubiKit/IntegrationScenarios/Scenarios/CTAP2.swift
+++ b/YubiKit/IntegrationScenarios/Scenarios/CTAP2.swift
@@ -17,7 +17,7 @@ import Foundation
 import YubiKit
 
 /// CTAP2 application scenarios.
-public enum CTAP2Scenario: CaseIterable, ScenarioSuite {
+enum CTAP2Scenario: CaseIterable, ScenarioSuite {
 
     case cleanState
     case getInfo
@@ -75,7 +75,7 @@ public enum CTAP2Scenario: CaseIterable, ScenarioSuite {
     case previewSignUvRequired
     case previewSignGenerateAndSign
 
-    public var scenario: Scenario {
+    var scenario: Scenario {
         switch self {
         // MARK: - Setup
         case .cleanState:

--- a/YubiKit/IntegrationScenarios/Scenarios/CTAPHID.swift
+++ b/YubiKit/IntegrationScenarios/Scenarios/CTAPHID.swift
@@ -19,7 +19,7 @@ import Foundation
 #endif
 
 /// CTAPHID transport-layer scenarios.
-public enum CTAPHIDScenario: CaseIterable, ScenarioSuite {
+enum CTAPHIDScenario: CaseIterable, ScenarioSuite {
 
     case initialize
     case getInfo
@@ -28,7 +28,7 @@ public enum CTAPHIDScenario: CaseIterable, ScenarioSuite {
     case echo
     case invalidCommand
 
-    public var scenario: Scenario {
+    var scenario: Scenario {
         switch self {
         // MARK: - Interface
         case .initialize:

--- a/YubiKit/IntegrationScenarios/Scenarios/Connection.swift
+++ b/YubiKit/IntegrationScenarios/Scenarios/Connection.swift
@@ -17,7 +17,7 @@ import Foundation
 import YubiKit
 
 /// Connection scenarios.
-public enum ConnectionScenario: CaseIterable, ScenarioSuite {
+enum ConnectionScenario: CaseIterable, ScenarioSuite {
 
     case open
     case closeNotifies
@@ -29,7 +29,7 @@ public enum ConnectionScenario: CaseIterable, ScenarioSuite {
     case alertMessage
     case closingErrorMessage
 
-    public var scenario: Scenario {
+    var scenario: Scenario {
         switch self {
         // MARK: - SmartCard (connection lifecycle)
         case .open:

--- a/YubiKit/IntegrationScenarios/Scenarios/Management.swift
+++ b/YubiKit/IntegrationScenarios/Scenarios/Management.swift
@@ -16,7 +16,7 @@ import Foundation
 import YubiKit
 
 /// Management application scenarios.
-public enum ManagementScenario: CaseIterable, ScenarioSuite {
+enum ManagementScenario: CaseIterable, ScenarioSuite {
 
     case timeouts
     case chaining
@@ -28,7 +28,7 @@ public enum ManagementScenario: CaseIterable, ScenarioSuite {
     /// The Management application answers over SmartCard and over FIDO HID, and the SDK ships a
     /// `makeSession` for each. These read-only families run over both, so neither backend can rot
     /// unnoticed — before this, only SmartCard was ever exercised.
-    public static var parameterizedScenarios: [Scenario] {
+    static var parameterizedScenarios: [Scenario] {
         Scenario.parameterized(
             "Management.Info.version",
             over: ManagementTransport.allCases
@@ -48,7 +48,7 @@ public enum ManagementScenario: CaseIterable, ScenarioSuite {
             }
     }
 
-    public var scenario: Scenario {
+    var scenario: Scenario {
         switch self {
         // MARK: - Configuration
         case .timeouts:

--- a/YubiKit/IntegrationScenarios/Scenarios/OATH.swift
+++ b/YubiKit/IntegrationScenarios/Scenarios/OATH.swift
@@ -16,7 +16,7 @@ import Foundation
 import YubiKit
 
 /// OATH application scenarios.
-public enum OATHScenario: CaseIterable, ScenarioSuite {
+enum OATHScenario: CaseIterable, ScenarioSuite {
 
     case credentials
     case allCodes
@@ -43,7 +43,7 @@ public enum OATHScenario: CaseIterable, ScenarioSuite {
     case maxCredentials
     case unicodeName
 
-    public var scenario: Scenario { definition }
+    var scenario: Scenario { definition }
 
     private var definition: Scenario {
         switch self {

--- a/YubiKit/IntegrationScenarios/Scenarios/PIV.swift
+++ b/YubiKit/IntegrationScenarios/Scenarios/PIV.swift
@@ -18,7 +18,7 @@ import Security
 import YubiKit
 
 /// PIV application scenarios.
-public enum PIVScenario: CaseIterable, ScenarioSuite {
+enum PIVScenario: CaseIterable, ScenarioSuite {
 
     case eccp256Message
     case eccp256Digest
@@ -88,7 +88,7 @@ public enum PIVScenario: CaseIterable, ScenarioSuite {
     case putCertificateRequiresAuth
     case putKeyRequiresAuth
 
-    public var scenario: Scenario { definition }
+    var scenario: Scenario { definition }
 
     private var definition: Scenario {
         switch self {

--- a/YubiKit/IntegrationScenarios/Scenarios/SCP.swift
+++ b/YubiKit/IntegrationScenarios/Scenarios/SCP.swift
@@ -18,7 +18,7 @@ import Foundation
 import YubiKit
 
 /// Secure Channel Protocol scenarios.
-public enum SCPScenario: CaseIterable, ScenarioSuite {
+enum SCPScenario: CaseIterable, ScenarioSuite {
 
     case defaultKeys
     case importKeySCP03
@@ -38,7 +38,7 @@ public enum SCPScenario: CaseIterable, ScenarioSuite {
     case cardRecognitionData
     case resetRestoresDefaultKeys
 
-    public var scenario: Scenario { definition }
+    var scenario: Scenario { definition }
 
     private var definition: Scenario {
         switch self {

--- a/YubiKit/IntegrationScenarios/Scenarios/WebAuthn.swift
+++ b/YubiKit/IntegrationScenarios/Scenarios/WebAuthn.swift
@@ -16,7 +16,7 @@ import Foundation
 import YubiKit
 
 /// WebAuthn `Client` scenarios.
-public enum WebAuthnScenario: CaseIterable, ScenarioSuite {
+enum WebAuthnScenario: CaseIterable, ScenarioSuite {
 
     case makeCredentialGetAssertion
     case allowCredentials
@@ -45,7 +45,7 @@ public enum WebAuthnScenario: CaseIterable, ScenarioSuite {
     case echoedFalse
     case echoedTrue
 
-    public var scenario: Scenario {
+    var scenario: Scenario {
         switch self {
         // MARK: - Ceremonies (make / get via Client)
         case .makeCredentialGetAssertion:


### PR DESCRIPTION
The API diff analyzes every library product, so `YubiKitIntegrationScenarios` is reported alongside `YubiKit` — #137 removing one `CTAP2Scenario` case drew a "1 Removal" comment. The Adyen action has no target filter.

The eight suite enums become internal; nothing outside the module names them. `Engine/`, `Providers/` and `Scenario.Catalog` stay public — `IntegrationTesting/App` imports them plainly and cannot use `@testable`.

`public-api-diff.yml` also stops running for scenario-only PRs. This one triggers it anyway, since it edits the workflow.