### PR TITLE
Add @_spi(YubiInternal) construction seam for WebAuthn result types

### DIFF
--- a/YubiKit/UnitTests/CBORTests.swift
+++ b/YubiKit/UnitTests/CBORTests.swift
@@ -15,7 +15,7 @@
 import Foundation
 import Testing
 
-@testable import YubiKit
+@_spi(YubiInternal) @testable import YubiKit
 
 /// Unit tests for CBOR functionality, ported from the Java SDK CborTest.java
 @Suite("CBOR Encoding and Decoding Tests")

--- a/YubiKit/UnitTests/COSE/COSEKeyTests.swift
+++ b/YubiKit/UnitTests/COSE/COSEKeyTests.swift
@@ -15,7 +15,7 @@
 import Foundation
 import Testing
 
-@testable import YubiKit
+@_spi(YubiInternal) @testable import YubiKit
 
 /// COSE key vectors from https://github.com/cose-wg/Examples;
 /// X25519 from RFC 7748 §6.1 (cose-wg has no X25519 example).

--- a/YubiKit/UnitTests/FIDO/CTAP/MakeCredentialSerializationTests.swift
+++ b/YubiKit/UnitTests/FIDO/CTAP/MakeCredentialSerializationTests.swift
@@ -15,7 +15,7 @@
 import Foundation
 import Testing
 
-@testable import YubiKit
+@_spi(YubiInternal) @testable import YubiKit
 
 /// Test CBOR encoding and decoding of CTAP2 MakeCredential request/response types.
 ///

--- a/YubiKit/UnitTests/FIDO/WebAuthn/CeremonyTests.swift
+++ b/YubiKit/UnitTests/FIDO/WebAuthn/CeremonyTests.swift
@@ -15,7 +15,7 @@
 import Foundation
 import Testing
 
-@testable import YubiKit
+@_spi(YubiInternal) @testable import YubiKit
 
 /// SDK-surface ceremony tests for `WebAuthn.Client`, driven through
 /// `MockWebAuthnBackend`. These exercise the Swift client (status stream,

--- a/YubiKit/UnitTests/FIDO/WebAuthn/ExtensionAllowlistTests.swift
+++ b/YubiKit/UnitTests/FIDO/WebAuthn/ExtensionAllowlistTests.swift
@@ -15,7 +15,7 @@
 import Foundation
 import Testing
 
-@testable import YubiKit
+@_spi(YubiInternal) @testable import YubiKit
 
 @Suite("Extension Allowlist Tests")
 struct ExtensionAllowlistTests {

--- a/YubiKit/UnitTests/FIDO/WebAuthn/MockWebAuthnBackend.swift
+++ b/YubiKit/UnitTests/FIDO/WebAuthn/MockWebAuthnBackend.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-@testable import YubiKit
+@_spi(YubiInternal) @testable import YubiKit
 
 // MARK: - MockWebAuthnBackend
 

--- a/YubiKit/UnitTests/FIDO/WebAuthn/ResponseParsingTests.swift
+++ b/YubiKit/UnitTests/FIDO/WebAuthn/ResponseParsingTests.swift
@@ -15,7 +15,7 @@
 import Foundation
 import Testing
 
-@testable import YubiKit
+@_spi(YubiInternal) @testable import YubiKit
 
 /// Test parsing of CTAP2 response structures: AuthenticatorData and AttestationStatement.
 /// Uses test data from yubikit-android's SerializationTest.

--- a/YubiKit/UnitTests/FIDO/WebAuthn/SerializationTests+JSON.swift
+++ b/YubiKit/UnitTests/FIDO/WebAuthn/SerializationTests+JSON.swift
@@ -15,7 +15,7 @@
 import Foundation
 import Testing
 
-@testable import YubiKit
+@_spi(YubiInternal) @testable import YubiKit
 
 // MARK: - Test Helpers
 

--- a/YubiKit/UnitTests/FIDO/WebAuthn/SerializationTests.swift
+++ b/YubiKit/UnitTests/FIDO/WebAuthn/SerializationTests.swift
@@ -15,7 +15,7 @@
 import Foundation
 import Testing
 
-@testable import YubiKit
+@_spi(YubiInternal) @testable import YubiKit
 
 /// Tests for CBOR and JSON serialization of WebAuthn types.
 /// Modeled after yubikit-android's SerializationTest.

--- a/YubiKit/UnitTests/FIDO/WebAuthn/StatusStreamTests.swift
+++ b/YubiKit/UnitTests/FIDO/WebAuthn/StatusStreamTests.swift
@@ -15,7 +15,7 @@
 import Foundation
 import Testing
 
-@testable import YubiKit
+@_spi(YubiInternal) @testable import YubiKit
 
 @Suite("WebAuthn StatusStream Tests")
 struct StatusStreamTests {

--- a/YubiKit/UnitTests/FIDO/WebAuthn/UVFallbackToPINTests.swift
+++ b/YubiKit/UnitTests/FIDO/WebAuthn/UVFallbackToPINTests.swift
@@ -15,7 +15,7 @@
 import Foundation
 import Testing
 
-@testable import YubiKit
+@_spi(YubiInternal) @testable import YubiKit
 
 @Suite("WebAuthn UV → PIN Mid-Flight Downgrade", .serialized)
 struct UVFallbackToPINTests {

--- a/YubiKit/YubiKit/FIDO/CBOR/CBORValue.swift
+++ b/YubiKit/YubiKit/FIDO/CBOR/CBORValue.swift
@@ -16,7 +16,7 @@ import Foundation
 
 extension CBOR {
     // CBOR value representation for CTAP2/FIDO2
-    indirect enum Value: Sendable {
+    @_spi(YubiInternal) public indirect enum Value: Sendable {
         case unsignedInt(UInt64)  // CBOR major type 0
         case negativeInt(UInt64)  // CBOR major type 1, one's complement
         case byteString(Data)  // CBOR major type 2
@@ -180,14 +180,14 @@ extension CBOR.Value {
 // MARK: - Hashable & Equatable
 
 extension CBOR.Value: Hashable {
-    func hash(into hasher: inout Hasher) {
+    @_spi(YubiInternal) public func hash(into hasher: inout Hasher) {
         // Use the canonical CBOR encoding for hashing
         hasher.combine(self.encode())
     }
 }
 
 extension CBOR.Value: Equatable {
-    static func == (lhs: CBOR.Value, rhs: CBOR.Value) -> Bool {
+    @_spi(YubiInternal) public static func == (lhs: CBOR.Value, rhs: CBOR.Value) -> Bool {
         // Two CBOR values are equal if their canonical encodings are equal
         lhs.encode() == rhs.encode()
     }
@@ -196,31 +196,31 @@ extension CBOR.Value: Equatable {
 // MARK: - ExpressibleBy Literal Conformances
 
 extension CBOR.Value: ExpressibleByIntegerLiteral {
-    init(integerLiteral value: Int) {
+    @_spi(YubiInternal) public init(integerLiteral value: Int) {
         self.init(Int64(value))
     }
 }
 
 extension CBOR.Value: ExpressibleByStringLiteral {
-    init(stringLiteral value: String) {
+    @_spi(YubiInternal) public init(stringLiteral value: String) {
         self.init(value)
     }
 }
 
 extension CBOR.Value: ExpressibleByBooleanLiteral {
-    init(booleanLiteral value: Bool) {
+    @_spi(YubiInternal) public init(booleanLiteral value: Bool) {
         self.init(value)
     }
 }
 
 extension CBOR.Value: ExpressibleByArrayLiteral {
-    init(arrayLiteral elements: CBOR.Value...) {
+    @_spi(YubiInternal) public init(arrayLiteral elements: CBOR.Value...) {
         self = .array(elements)
     }
 }
 
 extension CBOR.Value: ExpressibleByDictionaryLiteral {
-    init(dictionaryLiteral elements: (CBOR.Value, CBOR.Value)...) {
+    @_spi(YubiInternal) public init(dictionaryLiteral elements: (CBOR.Value, CBOR.Value)...) {
         var dict: [CBOR.Value: CBOR.Value] = [:]
         for (key, value) in elements {
             dict[key] = value
@@ -230,7 +230,7 @@ extension CBOR.Value: ExpressibleByDictionaryLiteral {
 }
 
 extension CBOR.Value: ExpressibleByNilLiteral {
-    init(nilLiteral: ()) {
+    @_spi(YubiInternal) public init(nilLiteral: ()) {
         self = .null
     }
 }
@@ -238,7 +238,7 @@ extension CBOR.Value: ExpressibleByNilLiteral {
 // MARK: - CustomStringConvertible
 
 extension CBOR.Value: CustomStringConvertible {
-    var description: String {
+    @_spi(YubiInternal) public var description: String {
         switch self {
         case .unsignedInt(let n):
             return "\(n)"

--- a/YubiKit/YubiKit/FIDO/Session/CTAPSession.swift
+++ b/YubiKit/YubiKit/FIDO/Session/CTAPSession.swift
@@ -127,8 +127,8 @@ extension CTAP2 {
     }
 }
 
-extension CTAP2.Status: StreamStatus {
-    var finishedResponse: Response? {
+@_spi(YubiInternal) extension CTAP2.Status: StreamStatus {
+    @_spi(YubiInternal) public var finishedResponse: Response? {
         if case .finished(let response) = self { return response }
         return nil
     }

--- a/YubiKit/YubiKit/FIDO/StatusStream.swift
+++ b/YubiKit/YubiKit/FIDO/StatusStream.swift
@@ -15,38 +15,42 @@
 import Foundation
 
 /// Protocol for status types that can signal completion.
-protocol StreamStatus<Response>: Sendable {
+///
+/// The conformances on `WebAuthn.Status` and `CTAP2.Status` must carry `@_spi(YubiInternal)` too —
+/// an ungated conformance on a public type would force this protocol into the public API.
+@_spi(YubiInternal) public protocol StreamStatus<Response>: Sendable {
     associatedtype Response: Sendable
     /// Returns the response if this is a terminal status, nil otherwise.
     var finishedResponse: Response? { get }
 }
 
 /// Async sequence that yields status updates with typed errors.
-struct StatusStreamBase<Status: StreamStatus, Failure: Error & Sendable>: AsyncSequence,
+@_spi(YubiInternal)
+public struct StatusStreamBase<Status: StreamStatus, Failure: Error & Sendable>: AsyncSequence,
     @unchecked Sendable
 {
-    typealias Element = Status
+    @_spi(YubiInternal) public typealias Element = Status
 
     private let stream: AsyncStream<Result<Status, Failure>>
 
-    init(_ build: @escaping (Continuation) -> Void) {
+    @_spi(YubiInternal) public init(_ build: @escaping (Continuation) -> Void) {
         self.stream = AsyncStream { continuation in
             build(Continuation(continuation))
         }
     }
 
-    func makeAsyncIterator() -> Iterator {
+    @_spi(YubiInternal) public func makeAsyncIterator() -> Iterator {
         Iterator(stream.makeAsyncIterator())
     }
 
-    struct Iterator: AsyncIteratorProtocol {
+    @_spi(YubiInternal) public struct Iterator: AsyncIteratorProtocol {
         private var iterator: AsyncStream<Result<Status, Failure>>.AsyncIterator
 
         fileprivate init(_ iterator: AsyncStream<Result<Status, Failure>>.AsyncIterator) {
             self.iterator = iterator
         }
 
-        mutating func next() async throws(Failure) -> Status? {
+        @_spi(YubiInternal) public mutating func next() async throws(Failure) -> Status? {
             guard let result = await iterator.next() else { return nil }
             return try result.get()
         }
@@ -97,26 +101,26 @@ extension StatusStreamBase {
         }
     }
 
-    struct Continuation: Sendable {
+    @_spi(YubiInternal) public struct Continuation: Sendable {
         private let continuation: AsyncStream<Result<Status, Failure>>.Continuation
 
         fileprivate init(_ continuation: AsyncStream<Result<Status, Failure>>.Continuation) {
             self.continuation = continuation
         }
 
-        func yield(_ status: Status) {
+        @_spi(YubiInternal) public func yield(_ status: Status) {
             continuation.yield(.success(status))
             if status.finishedResponse != nil {
                 continuation.finish()
             }
         }
 
-        func yield(error: Failure) {
+        @_spi(YubiInternal) public func yield(error: Failure) {
             continuation.yield(.failure(error))
             continuation.finish()
         }
 
-        func finish() {
+        @_spi(YubiInternal) public func finish() {
             continuation.finish()
         }
     }

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Attestation/AttestationObject.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Attestation/AttestationObject.swift
@@ -39,7 +39,8 @@ extension WebAuthn {
         public let authenticatorData: AuthenticatorData
 
         /// Creates an attestation object from its components.
-        internal init(format: String, statementCBOR: CBOR.Value, authenticatorData: AuthenticatorData) {
+        @_spi(YubiInternal) public init(format: String, statementCBOR: CBOR.Value, authenticatorData: AuthenticatorData)
+        {
             self.format = format
             self.statement = .init(format: format, statementCBOR: statementCBOR)
             self.authenticatorData = authenticatorData

--- a/YubiKit/YubiKit/FIDO/WebAuthn/AuthenticatorData.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/AuthenticatorData.swift
@@ -78,7 +78,7 @@ extension WebAuthn.AuthenticatorData {
     ///
     /// - Parameter data: The raw authenticator data bytes.
     /// - Returns: Parsed authenticator data, or nil if parsing fails.
-    init?(data: Data) {
+    @_spi(YubiInternal) public init?(data: Data) {
         // Minimum size: rpIdHash (32) + flags (1) + signCount (4) = 37 bytes
         guard data.count >= 37 else {
             return nil

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Client/Authentication/AuthenticationResponse.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Client/Authentication/AuthenticationResponse.swift
@@ -52,5 +52,26 @@ extension WebAuthn.Authentication {
         ///
         /// This is `nil` for credential provider flows where only the hash was provided.
         internal let clientDataJSON: Data?
+
+        /// Memberwise initializer, written out only to carry the SPI annotation.
+        @_spi(YubiInternal) public init(
+            credentialId: Data,
+            rawAuthenticatorData: Data,
+            signature: Data,
+            user: WebAuthn.User?,
+            clientExtensionResults: WebAuthn.Extension.AuthenticationOutputs,
+            signCount: UInt32,
+            authenticatorData: WebAuthn.AuthenticatorData,
+            clientDataJSON: Data?
+        ) {
+            self.credentialId = credentialId
+            self.rawAuthenticatorData = rawAuthenticatorData
+            self.signature = signature
+            self.user = user
+            self.clientExtensionResults = clientExtensionResults
+            self.signCount = signCount
+            self.authenticatorData = authenticatorData
+            self.clientDataJSON = clientDataJSON
+        }
     }
 }

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Client/ClientData.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Client/ClientData.swift
@@ -26,16 +26,16 @@ extension WebAuthn {
         // MARK: - Internal Implementation
 
         // This is `nil` for credential provider flows where only the hash is provided.
-        internal let clientDataJSON: Data?
+        @_spi(YubiInternal) public let clientDataJSON: Data?
 
         // SHA-256 hash of the client data.
-        internal let clientDataHash: Data
+        @_spi(YubiInternal) public let clientDataHash: Data
 
         // The origin for this request.
-        internal let origin: Origin
+        @_spi(YubiInternal) public let origin: Origin
 
         // The effective RP ID for this request.
-        internal let rpId: String
+        @_spi(YubiInternal) public let rpId: String
     }
 }
 

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Client/Registration/RegistrationResponse.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Client/Registration/RegistrationResponse.swift
@@ -58,5 +58,32 @@ extension WebAuthn.Registration {
         ///
         /// This is `nil` for credential provider flows where only the hash was provided.
         internal let clientDataJSON: Data?
+
+        /// Memberwise initializer, written out only to carry the SPI annotation.
+        @_spi(YubiInternal) public init(
+            credentialId: Data,
+            rawAttestationObject: Data,
+            rawAuthenticatorData: Data,
+            attestationStatement: WebAuthn.AttestationStatement,
+            transports: [WebAuthn.Transport],
+            clientExtensionResults: WebAuthn.Extension.RegistrationOutputs,
+            publicKey: COSE.Key,
+            aaguid: WebAuthn.AAGUID,
+            signCount: UInt32,
+            authenticatorData: WebAuthn.AuthenticatorData,
+            clientDataJSON: Data?
+        ) {
+            self.credentialId = credentialId
+            self.rawAttestationObject = rawAttestationObject
+            self.rawAuthenticatorData = rawAuthenticatorData
+            self.attestationStatement = attestationStatement
+            self.transports = transports
+            self.clientExtensionResults = clientExtensionResults
+            self.publicKey = publicKey
+            self.aaguid = aaguid
+            self.signCount = signCount
+            self.authenticatorData = authenticatorData
+            self.clientDataJSON = clientDataJSON
+        }
     }
 }

--- a/YubiKit/YubiKit/FIDO/WebAuthn/WebAuthn.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/WebAuthn.swift
@@ -94,12 +94,13 @@ public enum WebAuthn {
     public struct StatusStream<R: Sendable>: AsyncSequence, @unchecked Sendable {
         public typealias Element = Status<R>
 
-        typealias Base = StatusStreamBase<Status<R>, ClientError>
-        typealias Continuation = Base.Continuation
+        @_spi(YubiInternal) public typealias Base = StatusStreamBase<Status<R>, ClientError>
+        @_spi(YubiInternal) public typealias Continuation = Base.Continuation
 
         private let base: Base
 
-        init(_ build: @escaping (Continuation) -> Void) {
+        /// Builds a stream from a closure that drives a ``Continuation``.
+        @_spi(YubiInternal) public init(_ build: @escaping (Continuation) -> Void) {
             self.base = Base(build)
         }
 
@@ -111,7 +112,8 @@ public enum WebAuthn {
             Self(Base.error(error))
         }
 
-        func withTimeout(_ duration: Duration?) -> Self {
+        /// Wraps this stream with the request timeout. A `nil` duration returns the stream unchanged.
+        @_spi(YubiInternal) public func withTimeout(_ duration: Duration?) -> Self {
             guard let duration else { return self }
             return Self(base.timeout(duration, error: .timeout(source: .here())))
         }
@@ -265,8 +267,8 @@ public enum WebAuthn {
 
 // MARK: - StreamStatus Conformance
 
-extension WebAuthn.Status: StreamStatus {
-    var finishedResponse: Response? {
+@_spi(YubiInternal) extension WebAuthn.Status: StreamStatus {
+    @_spi(YubiInternal) public var finishedResponse: Response? {
         if case .finished(let response) = self { return response }
         return nil
     }


### PR DESCRIPTION
Opens a `@_spi(YubiInternal)` seam so dependent packages can construct YubiKit's own WebAuthn result types instead of maintaining parallel ones.

Exposed through the seam:

- `Registration.Response` / `Authentication.Response` — memberwise initializers, written out only to carry the annotation.
- `WebAuthn.StatusStream` — `init(_:)` and `withTimeout(_:)`, plus `StatusStreamBase`, its `Continuation`, and the `StreamStatus` protocol with its `WebAuthn.Status` / `CTAP2.Status` conformances.
- `ClientData` stored properties, `AttestationObject.init(format:statementCBOR:authenticatorData:)`, `AuthenticatorData.init?(data:)`, and `CBOR.Value`.

No public API changes and no behaviour changes — every annotated declaration was previously `internal`.

The unit tests switch to `@_spi(YubiInternal) @testable import YubiKit`. `@testable` widens `internal` only, so it no longer reaches these declarations on its own.