### PR TITLE
Report authenticator attachment in the credential JSON envelope

### DIFF
--- a/YubiKit/UnitTests/FIDO/WebAuthn/SerializationTests+JSON.swift
+++ b/YubiKit/UnitTests/FIDO/WebAuthn/SerializationTests+JSON.swift
@@ -400,6 +400,7 @@ extension SerializationTests {
                 publicKey: authData.attestedCredentialData!.credentialPublicKey,
                 aaguid: authData.attestedCredentialData!.aaguid,
                 signCount: authData.signCount,
+                authenticatorAttachment: .crossPlatform,
                 authenticatorData: authData,
                 clientDataJSON: Data("clientdata".utf8)
             )
@@ -432,6 +433,7 @@ extension SerializationTests {
                 user: WebAuthn.User(id: Data("user".utf8)),
                 clientExtensionResults: .init(),
                 signCount: authData.signCount,
+                authenticatorAttachment: .crossPlatform,
                 authenticatorData: authData,
                 clientDataJSON: Data("clientdata".utf8)
             )
@@ -463,6 +465,7 @@ extension SerializationTests {
                 user: nil,
                 clientExtensionResults: .init(),
                 signCount: authData.signCount,
+                authenticatorAttachment: .crossPlatform,
                 authenticatorData: authData,
                 clientDataJSON: Data("clientdata".utf8)
             )
@@ -472,6 +475,28 @@ extension SerializationTests {
 
             let inner = try #require(json["response"] as? [String: Any])
             #expect(inner["userHandle"] == nil)
+        }
+
+        @Test("Platform attachment is reported in the credential envelope")
+        func testPlatformAttachmentJSON() throws {
+            let authData = makeMinimalAuthData()
+
+            let response = WebAuthn.Authentication.Response(
+                credentialId: Data("credential_id".utf8),
+                rawAuthenticatorData: authData.rawData,
+                signature: Data("sig".utf8),
+                user: nil,
+                clientExtensionResults: .init(),
+                signCount: authData.signCount,
+                authenticatorAttachment: .platform,
+                authenticatorData: authData,
+                clientDataJSON: Data("clientdata".utf8)
+            )
+
+            let encoded = try response.toJSON()
+            let json = try JSONSerialization.jsonObject(with: encoded) as! [String: Any]
+
+            #expect(json["authenticatorAttachment"] as? String == "platform")
         }
     }
 

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Client/Authentication/AuthenticationResponse.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Client/Authentication/AuthenticationResponse.swift
@@ -45,6 +45,10 @@ extension WebAuthn.Authentication {
         /// Signature counter value.
         public let signCount: UInt32
 
+        /// Attachment modality of the authenticator that produced this assertion:
+        /// `.platform` for a device-bound authenticator, `.crossPlatform` for a roaming key.
+        public let authenticatorAttachment: WebAuthn.AuthenticatorAttachment
+
         /// Parsed authenticator data for internal extension processing.
         internal let authenticatorData: WebAuthn.AuthenticatorData
 
@@ -61,6 +65,7 @@ extension WebAuthn.Authentication {
             user: WebAuthn.User?,
             clientExtensionResults: WebAuthn.Extension.AuthenticationOutputs,
             signCount: UInt32,
+            authenticatorAttachment: WebAuthn.AuthenticatorAttachment,
             authenticatorData: WebAuthn.AuthenticatorData,
             clientDataJSON: Data?
         ) {
@@ -70,6 +75,7 @@ extension WebAuthn.Authentication {
             self.user = user
             self.clientExtensionResults = clientExtensionResults
             self.signCount = signCount
+            self.authenticatorAttachment = authenticatorAttachment
             self.authenticatorData = authenticatorData
             self.clientDataJSON = clientDataJSON
         }

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Client/Authentication/Client+GetAssertion.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Client/Authentication/Client+GetAssertion.swift
@@ -247,6 +247,7 @@ extension WebAuthn.Client {
                         user: ctapResponse.user,
                         clientExtensionResults: extensionOutputs,
                         signCount: authData.signCount,
+                        authenticatorAttachment: .crossPlatform,
                         authenticatorData: authData,
                         clientDataJSON: clientData.clientDataJSON
                     )

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Client/Registration/Client+MakeCredential.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Client/Registration/Client+MakeCredential.swift
@@ -226,6 +226,7 @@ extension WebAuthn.Client {
                 publicKey: attestedCredentialData.credentialPublicKey,
                 aaguid: attestedCredentialData.aaguid,
                 signCount: authenticatorData.signCount,
+                authenticatorAttachment: .crossPlatform,
                 authenticatorData: authenticatorData,
                 clientDataJSON: clientData.clientDataJSON
             )

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Client/Registration/RegistrationResponse.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Client/Registration/RegistrationResponse.swift
@@ -51,6 +51,10 @@ extension WebAuthn.Registration {
         /// Signature counter value.
         public let signCount: UInt32
 
+        /// Attachment modality of the authenticator that created this credential:
+        /// `.platform` for a device-bound authenticator, `.crossPlatform` for a roaming key.
+        public let authenticatorAttachment: WebAuthn.AuthenticatorAttachment
+
         /// Parsed authenticator data for internal extension processing.
         internal let authenticatorData: WebAuthn.AuthenticatorData
 
@@ -70,6 +74,7 @@ extension WebAuthn.Registration {
             publicKey: COSE.Key,
             aaguid: WebAuthn.AAGUID,
             signCount: UInt32,
+            authenticatorAttachment: WebAuthn.AuthenticatorAttachment,
             authenticatorData: WebAuthn.AuthenticatorData,
             clientDataJSON: Data?
         ) {
@@ -82,6 +87,7 @@ extension WebAuthn.Registration {
             self.publicKey = publicKey
             self.aaguid = aaguid
             self.signCount = signCount
+            self.authenticatorAttachment = authenticatorAttachment
             self.authenticatorData = authenticatorData
             self.clientDataJSON = clientDataJSON
         }

--- a/YubiKit/YubiKit/FIDO/WebAuthn/WebAuthn+JSON.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/WebAuthn+JSON.swift
@@ -58,12 +58,13 @@ extension WebAuthn {
 
     static func encodeCredentialEnvelope(
         to container: inout KeyedEncodingContainer<CredentialCodingKeys>,
-        credentialId: Data
+        credentialId: Data,
+        authenticatorAttachment: WebAuthn.AuthenticatorAttachment
     ) throws {
         try container.encodeBase64URL(credentialId, forKey: .id)
         try container.encodeBase64URL(credentialId, forKey: .rawId)
         try container.encode("public-key", forKey: .type)
-        try container.encode("cross-platform", forKey: .authenticatorAttachment)
+        try container.encode(authenticatorAttachment.rawValue, forKey: .authenticatorAttachment)
     }
 }
 
@@ -247,7 +248,11 @@ extension WebAuthn.Registration.Response: Encodable {
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: WebAuthn.CredentialCodingKeys.self)
-        try WebAuthn.encodeCredentialEnvelope(to: &container, credentialId: credentialId)
+        try WebAuthn.encodeCredentialEnvelope(
+            to: &container,
+            credentialId: credentialId,
+            authenticatorAttachment: authenticatorAttachment
+        )
 
         var inner = container.nestedContainer(keyedBy: RegistrationResponseKeys.self, forKey: .response)
         try inner.encodeBase64URL(rawAttestationObject, forKey: .attestationObject)
@@ -310,7 +315,11 @@ extension WebAuthn.Authentication.Response: Encodable {
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: WebAuthn.CredentialCodingKeys.self)
-        try WebAuthn.encodeCredentialEnvelope(to: &container, credentialId: credentialId)
+        try WebAuthn.encodeCredentialEnvelope(
+            to: &container,
+            credentialId: credentialId,
+            authenticatorAttachment: authenticatorAttachment
+        )
 
         var inner = container.nestedContainer(keyedBy: AuthenticationResponseKeys.self, forKey: .response)
         try inner.encodeBase64URL(rawAuthenticatorData, forKey: .authenticatorData)

--- a/YubiKit/YubiKit/FIDO/WebAuthn/WebAuthn.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/WebAuthn.swift
@@ -199,6 +199,16 @@ public enum WebAuthn {
         }
     }
 
+    /// The [authenticator attachment modality](https://www.w3.org/TR/webauthn-3/#enum-attachment)
+    /// a credential reports — whether the authenticator is bound to one device or roams between them.
+    public enum AuthenticatorAttachment: String, Sendable {
+        /// A platform authenticator bound to a single device (for example a Secure Enclave credential).
+        case platform
+
+        /// A roaming authenticator that moves between devices (for example a YubiKey).
+        case crossPlatform = "cross-platform"
+    }
+
     /// Public key credential descriptor identifying a specific credential.
     ///
     /// Used in `allowList` and `excludeList` parameters to identify credentials


### PR DESCRIPTION
The credential JSON envelope hardcoded `"authenticatorAttachment": "cross-platform"` in the encoder. Adds `WebAuthn.AuthenticatorAttachment` and carries it on `Registration.Response` / `Authentication.Response`, so the value is set by whoever constructs the response instead of being fixed in the serializer.

CTAP ceremonies pass `.crossPlatform` explicitly, so the encoded JSON is unchanged.