### PR TITLE
Trim WebAuthn construction SPI exposure

### DIFF
--- a/YubiKit/YubiKit/FIDO/CBOR/CBORValue.swift
+++ b/YubiKit/YubiKit/FIDO/CBOR/CBORValue.swift
@@ -16,7 +16,7 @@ import Foundation
 
 extension CBOR {
     // CBOR value representation for CTAP2/FIDO2
-    @_spi(YubiInternal) public indirect enum Value: Sendable {
+    indirect enum Value: Sendable {
         case unsignedInt(UInt64)  // CBOR major type 0
         case negativeInt(UInt64)  // CBOR major type 1, one's complement
         case byteString(Data)  // CBOR major type 2
@@ -180,14 +180,14 @@ extension CBOR.Value {
 // MARK: - Hashable & Equatable
 
 extension CBOR.Value: Hashable {
-    @_spi(YubiInternal) public func hash(into hasher: inout Hasher) {
+    func hash(into hasher: inout Hasher) {
         // Use the canonical CBOR encoding for hashing
         hasher.combine(self.encode())
     }
 }
 
 extension CBOR.Value: Equatable {
-    @_spi(YubiInternal) public static func == (lhs: CBOR.Value, rhs: CBOR.Value) -> Bool {
+    static func == (lhs: CBOR.Value, rhs: CBOR.Value) -> Bool {
         // Two CBOR values are equal if their canonical encodings are equal
         lhs.encode() == rhs.encode()
     }
@@ -196,31 +196,31 @@ extension CBOR.Value: Equatable {
 // MARK: - ExpressibleBy Literal Conformances
 
 extension CBOR.Value: ExpressibleByIntegerLiteral {
-    @_spi(YubiInternal) public init(integerLiteral value: Int) {
+    init(integerLiteral value: Int) {
         self.init(Int64(value))
     }
 }
 
 extension CBOR.Value: ExpressibleByStringLiteral {
-    @_spi(YubiInternal) public init(stringLiteral value: String) {
+    init(stringLiteral value: String) {
         self.init(value)
     }
 }
 
 extension CBOR.Value: ExpressibleByBooleanLiteral {
-    @_spi(YubiInternal) public init(booleanLiteral value: Bool) {
+    init(booleanLiteral value: Bool) {
         self.init(value)
     }
 }
 
 extension CBOR.Value: ExpressibleByArrayLiteral {
-    @_spi(YubiInternal) public init(arrayLiteral elements: CBOR.Value...) {
+    init(arrayLiteral elements: CBOR.Value...) {
         self = .array(elements)
     }
 }
 
 extension CBOR.Value: ExpressibleByDictionaryLiteral {
-    @_spi(YubiInternal) public init(dictionaryLiteral elements: (CBOR.Value, CBOR.Value)...) {
+    init(dictionaryLiteral elements: (CBOR.Value, CBOR.Value)...) {
         var dict: [CBOR.Value: CBOR.Value] = [:]
         for (key, value) in elements {
             dict[key] = value
@@ -230,7 +230,7 @@ extension CBOR.Value: ExpressibleByDictionaryLiteral {
 }
 
 extension CBOR.Value: ExpressibleByNilLiteral {
-    @_spi(YubiInternal) public init(nilLiteral: ()) {
+    init(nilLiteral: ()) {
         self = .null
     }
 }
@@ -238,7 +238,7 @@ extension CBOR.Value: ExpressibleByNilLiteral {
 // MARK: - CustomStringConvertible
 
 extension CBOR.Value: CustomStringConvertible {
-    @_spi(YubiInternal) public var description: String {
+    var description: String {
         switch self {
         case .unsignedInt(let n):
             return "\(n)"

--- a/YubiKit/YubiKit/FIDO/Session/CTAPSession.swift
+++ b/YubiKit/YubiKit/FIDO/Session/CTAPSession.swift
@@ -127,8 +127,8 @@ extension CTAP2 {
     }
 }
 
-@_spi(YubiInternal) extension CTAP2.Status: StreamStatus {
-    @_spi(YubiInternal) public var finishedResponse: Response? {
+extension CTAP2.Status: StreamStatus {
+    var finishedResponse: Response? {
         if case .finished(let response) = self { return response }
         return nil
     }

--- a/YubiKit/YubiKit/FIDO/StatusStream.swift
+++ b/YubiKit/YubiKit/FIDO/StatusStream.swift
@@ -15,42 +15,38 @@
 import Foundation
 
 /// Protocol for status types that can signal completion.
-///
-/// The conformances on `WebAuthn.Status` and `CTAP2.Status` must carry `@_spi(YubiInternal)` too —
-/// an ungated conformance on a public type would force this protocol into the public API.
-@_spi(YubiInternal) public protocol StreamStatus<Response>: Sendable {
+protocol StreamStatus<Response>: Sendable {
     associatedtype Response: Sendable
     /// Returns the response if this is a terminal status, nil otherwise.
     var finishedResponse: Response? { get }
 }
 
 /// Async sequence that yields status updates with typed errors.
-@_spi(YubiInternal)
-public struct StatusStreamBase<Status: StreamStatus, Failure: Error & Sendable>: AsyncSequence,
+struct StatusStreamBase<Status: StreamStatus, Failure: Error & Sendable>: AsyncSequence,
     @unchecked Sendable
 {
-    @_spi(YubiInternal) public typealias Element = Status
+    typealias Element = Status
 
     private let stream: AsyncStream<Result<Status, Failure>>
 
-    @_spi(YubiInternal) public init(_ build: @escaping (Continuation) -> Void) {
+    init(_ build: @escaping (Continuation) -> Void) {
         self.stream = AsyncStream { continuation in
             build(Continuation(continuation))
         }
     }
 
-    @_spi(YubiInternal) public func makeAsyncIterator() -> Iterator {
+    func makeAsyncIterator() -> Iterator {
         Iterator(stream.makeAsyncIterator())
     }
 
-    @_spi(YubiInternal) public struct Iterator: AsyncIteratorProtocol {
+    struct Iterator: AsyncIteratorProtocol {
         private var iterator: AsyncStream<Result<Status, Failure>>.AsyncIterator
 
         fileprivate init(_ iterator: AsyncStream<Result<Status, Failure>>.AsyncIterator) {
             self.iterator = iterator
         }
 
-        @_spi(YubiInternal) public mutating func next() async throws(Failure) -> Status? {
+        mutating func next() async throws(Failure) -> Status? {
             guard let result = await iterator.next() else { return nil }
             return try result.get()
         }
@@ -101,26 +97,26 @@ extension StatusStreamBase {
         }
     }
 
-    @_spi(YubiInternal) public struct Continuation: Sendable {
+    struct Continuation: Sendable {
         private let continuation: AsyncStream<Result<Status, Failure>>.Continuation
 
         fileprivate init(_ continuation: AsyncStream<Result<Status, Failure>>.Continuation) {
             self.continuation = continuation
         }
 
-        @_spi(YubiInternal) public func yield(_ status: Status) {
+        func yield(_ status: Status) {
             continuation.yield(.success(status))
             if status.finishedResponse != nil {
                 continuation.finish()
             }
         }
 
-        @_spi(YubiInternal) public func yield(error: Failure) {
+        func yield(error: Failure) {
             continuation.yield(.failure(error))
             continuation.finish()
         }
 
-        @_spi(YubiInternal) public func finish() {
+        func finish() {
             continuation.finish()
         }
     }

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Attestation/AttestationObject.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Attestation/AttestationObject.swift
@@ -39,8 +39,7 @@ extension WebAuthn {
         public let authenticatorData: AuthenticatorData
 
         /// Creates an attestation object from its components.
-        @_spi(YubiInternal) public init(format: String, statementCBOR: CBOR.Value, authenticatorData: AuthenticatorData)
-        {
+        init(format: String, statementCBOR: CBOR.Value, authenticatorData: AuthenticatorData) {
             self.format = format
             self.statement = .init(format: format, statementCBOR: statementCBOR)
             self.authenticatorData = authenticatorData

--- a/YubiKit/YubiKit/FIDO/WebAuthn/AuthenticatorData.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/AuthenticatorData.swift
@@ -78,7 +78,7 @@ extension WebAuthn.AuthenticatorData {
     ///
     /// - Parameter data: The raw authenticator data bytes.
     /// - Returns: Parsed authenticator data, or nil if parsing fails.
-    @_spi(YubiInternal) public init?(data: Data) {
+    init?(data: Data) {
         // Minimum size: rpIdHash (32) + flags (1) + signCount (4) = 37 bytes
         guard data.count >= 37 else {
             return nil

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Client/Authentication/AuthenticationResponse.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Client/Authentication/AuthenticationResponse.swift
@@ -57,8 +57,7 @@ extension WebAuthn.Authentication {
         /// This is `nil` for credential provider flows where only the hash was provided.
         internal let clientDataJSON: Data?
 
-        /// Memberwise initializer, written out only to carry the SPI annotation.
-        @_spi(YubiInternal) public init(
+        init(
             credentialId: Data,
             rawAuthenticatorData: Data,
             signature: Data,

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Client/ClientData.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Client/ClientData.swift
@@ -26,16 +26,16 @@ extension WebAuthn {
         // MARK: - Internal Implementation
 
         // This is `nil` for credential provider flows where only the hash is provided.
-        @_spi(YubiInternal) public let clientDataJSON: Data?
+        internal let clientDataJSON: Data?
 
         // SHA-256 hash of the client data.
-        @_spi(YubiInternal) public let clientDataHash: Data
+        internal let clientDataHash: Data
 
         // The origin for this request.
-        @_spi(YubiInternal) public let origin: Origin
+        internal let origin: Origin
 
         // The effective RP ID for this request.
-        @_spi(YubiInternal) public let rpId: String
+        internal let rpId: String
     }
 }
 

--- a/YubiKit/YubiKit/FIDO/WebAuthn/Client/Registration/RegistrationResponse.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/Client/Registration/RegistrationResponse.swift
@@ -63,8 +63,7 @@ extension WebAuthn.Registration {
         /// This is `nil` for credential provider flows where only the hash was provided.
         internal let clientDataJSON: Data?
 
-        /// Memberwise initializer, written out only to carry the SPI annotation.
-        @_spi(YubiInternal) public init(
+        init(
             credentialId: Data,
             rawAttestationObject: Data,
             rawAuthenticatorData: Data,

--- a/YubiKit/YubiKit/FIDO/WebAuthn/WebAuthn.swift
+++ b/YubiKit/YubiKit/FIDO/WebAuthn/WebAuthn.swift
@@ -94,13 +94,13 @@ public enum WebAuthn {
     public struct StatusStream<R: Sendable>: AsyncSequence, @unchecked Sendable {
         public typealias Element = Status<R>
 
-        @_spi(YubiInternal) public typealias Base = StatusStreamBase<Status<R>, ClientError>
-        @_spi(YubiInternal) public typealias Continuation = Base.Continuation
+        typealias Base = StatusStreamBase<Status<R>, ClientError>
+        typealias Continuation = Base.Continuation
 
         private let base: Base
 
         /// Builds a stream from a closure that drives a ``Continuation``.
-        @_spi(YubiInternal) public init(_ build: @escaping (Continuation) -> Void) {
+        init(_ build: @escaping (Continuation) -> Void) {
             self.base = Base(build)
         }
 
@@ -113,7 +113,7 @@ public enum WebAuthn {
         }
 
         /// Wraps this stream with the request timeout. A `nil` duration returns the stream unchanged.
-        @_spi(YubiInternal) public func withTimeout(_ duration: Duration?) -> Self {
+        func withTimeout(_ duration: Duration?) -> Self {
             guard let duration else { return self }
             return Self(base.timeout(duration, error: .timeout(source: .here())))
         }
@@ -277,8 +277,8 @@ public enum WebAuthn {
 
 // MARK: - StreamStatus Conformance
 
-@_spi(YubiInternal) extension WebAuthn.Status: StreamStatus {
-    @_spi(YubiInternal) public var finishedResponse: Response? {
+extension WebAuthn.Status: StreamStatus {
+    var finishedResponse: Response? {
         if case .finished(let response) = self { return response }
         return nil
     }


### PR DESCRIPTION
## Summary
- Remove `@_spi(YubiInternal)` from WebAuthn construction helpers that do not need to be integration surface.
- Keep the existing internals usable from YubiKit tests through `@testable` import.
- Leave the delegated authenticator SPI to its own PR.

## Rationale
This is a focused rollback of the production access-level surface added in `f0614bd905`, not a full revert of that commit. The broad construction SPI was useful while shaping tests and integration, but the stable boundary should stay narrower: external code should not manually assemble WebAuthn responses or depend on client-data internals.

## Testing
- `swift test --filter WebAuthn`